### PR TITLE
fix(activity): send anonymous follows to login

### DIFF
--- a/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
@@ -8,6 +8,7 @@ import {
   getActivityFeedHref,
   getActivityFeedSelection,
   loadActivityFeed,
+  requiresActivityFeedLogin,
 } from "./loadActivityFeed";
 
 type Options = Parameters<typeof loadActivityFeed>[0];
@@ -64,6 +65,18 @@ test("keeps signed-in activity links on the activity page", () => {
   expect(getActivityFeedHref({ feed: "following", isLoggedIn: true })).toBe(
     "/activity?feed=following",
   );
+});
+
+test("requires login only for anonymous Following visitors", () => {
+  expect(
+    requiresActivityFeedLogin({ feed: "following", isLoggedIn: false }),
+  ).toBe(true);
+  expect(
+    requiresActivityFeedLogin({ feed: "following", isLoggedIn: true }),
+  ).toBe(false);
+  expect(
+    requiresActivityFeedLogin({ feed: "everyone", isLoggedIn: false }),
+  ).toBe(false);
 });
 
 test("keeps Following empty when followed people have no activity", async () => {

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
@@ -4,7 +4,11 @@ import {
   mockFriendships,
 } from "@peated/server/orpc/mock/fixtures";
 import { beforeEach, expect, test, vi } from "vitest";
-import { getActivityFeedSelection, loadActivityFeed } from "./loadActivityFeed";
+import {
+  getActivityFeedHref,
+  getActivityFeedSelection,
+  loadActivityFeed,
+} from "./loadActivityFeed";
 
 type Options = Parameters<typeof loadActivityFeed>[0];
 const publicClient = {
@@ -45,6 +49,21 @@ test("defaults the activity feed selection to Everyone", () => {
   expect(getActivityFeedSelection("everyone")).toBe("everyone");
   expect(getActivityFeedSelection("unknown")).toBe("everyone");
   expect(getActivityFeedSelection("following")).toBe("following");
+});
+
+test("sends anonymous Following visitors to login", () => {
+  expect(getActivityFeedHref({ feed: "following", isLoggedIn: false })).toBe(
+    "/login?redirectTo=%2Factivity%3Ffeed%3Dfollowing",
+  );
+  expect(getActivityFeedHref({ feed: "everyone", isLoggedIn: false })).toBe(
+    "/activity?feed=everyone",
+  );
+});
+
+test("keeps signed-in activity links on the activity page", () => {
+  expect(getActivityFeedHref({ feed: "following", isLoggedIn: true })).toBe(
+    "/activity?feed=following",
+  );
 });
 
 test("keeps Following empty when followed people have no activity", async () => {

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.ts
@@ -10,6 +10,16 @@ export function getActivityFeedSelection(feed?: string) {
   return feed === "following" ? "following" : "everyone";
 }
 
+export function requiresActivityFeedLogin({
+  feed,
+  isLoggedIn,
+}: {
+  feed: "everyone" | "following";
+  isLoggedIn: boolean;
+}) {
+  return feed === "following" && !isLoggedIn;
+}
+
 export function getActivityFeedHref({
   feed,
   isLoggedIn,

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.ts
@@ -1,5 +1,6 @@
 import type { RouterClient } from "@orpc/server";
 import type { Router } from "@peated/server/orpc/router";
+import { getAuthRedirect } from "@peated/web/lib/auth";
 import { getCommunityFeedItems } from "@peated/web/lib/communityFeed";
 
 type Client = RouterClient<Router>;
@@ -7,6 +8,23 @@ type ActivityClient = { activity: Pick<Client["activity"], "list"> };
 
 export function getActivityFeedSelection(feed?: string) {
   return feed === "following" ? "following" : "everyone";
+}
+
+export function getActivityFeedHref({
+  feed,
+  isLoggedIn,
+}: {
+  feed: "everyone" | "following";
+  isLoggedIn: boolean;
+}) {
+  const href = `/activity?feed=${feed}`;
+
+  return feed === "following" && !isLoggedIn
+    ? getAuthRedirect({
+        pathname: "/activity",
+        searchParams: new URLSearchParams({ feed }),
+      })
+    : href;
 }
 
 /** Falls back to public activity only when there are no accepted follows. */

--- a/apps/web/src/app/(app)/activity/page.tsx
+++ b/apps/web/src/app/(app)/activity/page.tsx
@@ -8,7 +8,11 @@ import {
   getServerClient,
 } from "@peated/web/lib/orpc/client.server";
 import type { Metadata } from "next";
-import { getActivityFeedSelection, loadActivityFeed } from "./loadActivityFeed";
+import {
+  getActivityFeedHref,
+  getActivityFeedSelection,
+  loadActivityFeed,
+} from "./loadActivityFeed";
 
 export const metadata: Metadata = {
   title: "Activity",
@@ -77,8 +81,20 @@ export default async function Activity({
           ariaLabel="Activity feeds"
           currentHref={`/activity?feed=${selectedFeed}`}
           items={[
-            { href: "/activity?feed=following", label: "Following" },
-            { href: "/activity?feed=everyone", label: "Everyone" },
+            {
+              href: getActivityFeedHref({
+                feed: "following",
+                isLoggedIn: Boolean(user),
+              }),
+              label: "Following",
+            },
+            {
+              href: getActivityFeedHref({
+                feed: "everyone",
+                isLoggedIn: Boolean(user),
+              }),
+              label: "Everyone",
+            },
           ]}
         />
       }

--- a/apps/web/src/app/(app)/activity/page.tsx
+++ b/apps/web/src/app/(app)/activity/page.tsx
@@ -1,5 +1,6 @@
 import { CursorPager, PageTabs } from "@peated/web/components";
 import { ActivityPage } from "@peated/web/components/pages/activityPage.stylex";
+import { redirectToAuth } from "@peated/web/lib/auth";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
@@ -12,6 +13,7 @@ import {
   getActivityFeedHref,
   getActivityFeedSelection,
   loadActivityFeed,
+  requiresActivityFeedLogin,
 } from "./loadActivityFeed";
 
 export const metadata: Metadata = {
@@ -34,6 +36,18 @@ export default async function Activity({
   const page = getPageNumber(getFirstValue(resolvedSearchParams.page));
   const selectedFeed = getActivityFeedSelection(feed);
   const following = selectedFeed === "following";
+  if (
+    requiresActivityFeedLogin({
+      feed: selectedFeed,
+      isLoggedIn: Boolean(user),
+    })
+  ) {
+    redirectToAuth({
+      pathname: "/activity",
+      searchParams: new URLSearchParams({ feed: selectedFeed }),
+    });
+  }
+
   const { client: publicClient } = await getAnonymousServerClient();
   const memberClient = user ? (await getServerClient()).client : undefined;
   const [{ items, note, rel }, library] = await Promise.all([


### PR DESCRIPTION
Anonymous visitors now go directly to sign in whether they select Following on the activity feed or open `/activity?feed=following` directly. The redirect preserves Following as the post-login destination, while signed-in users and the Everyone feed keep their existing behavior; the route guard also prevents an anonymous Following page from rendering without an active tab.
