### PR TITLE
perf(web): cache homepage locations for one hour

### DIFF
--- a/apps/web/src/app/(app)/homeLocations.server.ts
+++ b/apps/web/src/app/(app)/homeLocations.server.ts
@@ -1,0 +1,47 @@
+"server only";
+
+import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import type { ORPCQueryUtils } from "@peated/web/lib/orpc/context";
+import {
+  homeLocationCriteria,
+  publicHomeQueries,
+} from "@peated/web/lib/orpc/homeQueries";
+import type { QueryClient } from "@tanstack/react-query";
+import { unstable_cache } from "next/cache";
+
+const ONE_HOUR_IN_SECONDS = 60 * 60;
+
+// Web caching rule: shared homepage data always uses an anonymous client.
+const loadPublicHomeCountries = unstable_cache(
+  async () => {
+    const { client } = await createAnonymousServerClient();
+    return client.countries.list(homeLocationCriteria.countries);
+  },
+  ["public-home-countries"],
+  { revalidate: ONE_HOUR_IN_SECONDS },
+);
+
+const loadPublicHomeRegions = unstable_cache(
+  async () => {
+    const { client } = await createAnonymousServerClient();
+    return client.regions.list(homeLocationCriteria.regions);
+  },
+  ["public-home-regions"],
+  { revalidate: ONE_HOUR_IN_SECONDS },
+);
+
+export async function loadPublicHomeLocations(
+  queryClient: QueryClient,
+  orpc: ORPCQueryUtils,
+) {
+  await Promise.all([
+    queryClient.prefetchQuery({
+      ...publicHomeQueries.countries(orpc),
+      queryFn: loadPublicHomeCountries,
+    }),
+    queryClient.prefetchQuery({
+      ...publicHomeQueries.regions(orpc),
+      queryFn: loadPublicHomeRegions,
+    }),
+  ]);
+}

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -14,6 +14,7 @@ import { homeMetadata } from "@peated/web/lib/seoMetadata";
 import { getSession } from "@peated/web/lib/session.server";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
+import { loadPublicHomeLocations } from "./homeLocations.server";
 import { HomePageClient } from "./homePageClient";
 
 export const metadata = homeMetadata;
@@ -39,6 +40,7 @@ export default async function Page() {
     queryClient.prefetchQuery(publicHomeQueries.memberActivity(orpc)),
     queryClient.prefetchQuery(publicHomeQueries.recentReviews(orpc)),
     queryClient.prefetchQuery(publicHomeQueries.releases(orpc)),
+    loadPublicHomeLocations(queryClient, orpc),
     ...(session.user
       ? [queryClient.prefetchQuery(memberHomeQueries.followedReleases(orpc))]
       : []),

--- a/apps/web/src/lib/orpc/homeQueries.ts
+++ b/apps/web/src/lib/orpc/homeQueries.ts
@@ -1,5 +1,5 @@
 import { StatsSchema } from "@peated/server/orpc/contracts/stats";
-import type { Outputs } from "@peated/server/orpc/router";
+import type { Inputs, Outputs } from "@peated/server/orpc/router";
 import {
   infiniteQueryOptions,
   type InfiniteData,
@@ -10,6 +10,22 @@ import type { ORPCQueryUtils } from "./context";
 
 type ActivityFilter = "friends" | "global" | "local";
 type ActivityList = Outputs["activity"]["list"];
+
+const ONE_HOUR_IN_MILLISECONDS = 60 * 60 * 1000;
+
+export const homeLocationCriteria = {
+  countries: {
+    hasBottles: true,
+    limit: 100,
+    sort: "-bottles",
+  } satisfies Inputs["countries"]["list"],
+  regions: {
+    country: "scotland",
+    hasBottles: true,
+    limit: 6,
+    sort: "-bottles",
+  } satisfies Inputs["regions"]["list"],
+};
 
 export const publicHomeQueries = {
   stats: (orpc: ORPCQueryUtils) =>
@@ -40,16 +56,13 @@ export const publicHomeQueries = {
     }),
   countries: (orpc: ORPCQueryUtils) =>
     orpc.countries.list.queryOptions({
-      input: { hasBottles: true, limit: 100, sort: "-bottles" },
+      input: homeLocationCriteria.countries,
+      staleTime: ONE_HOUR_IN_MILLISECONDS,
     }),
   regions: (orpc: ORPCQueryUtils) =>
     orpc.regions.list.queryOptions({
-      input: {
-        country: "scotland",
-        hasBottles: true,
-        limit: 6,
-        sort: "-bottles",
-      },
+      input: homeLocationCriteria.regions,
+      staleTime: ONE_HOUR_IN_MILLISECONDS,
     }),
   distilleries: (orpc: ORPCQueryUtils) =>
     orpc.distilleries.list.queryOptions({

--- a/docs/architecture/web-caching.md
+++ b/docs/architecture/web-caching.md
@@ -23,6 +23,8 @@ headers prove it.
 - `publicStats.server.ts` caches anonymous counts for one hour. Server reads use
   `getPublicStats`; browser reads use `/api/stats`, backed by the same cache.
   The endpoint sends `no-store` to avoid an extra HTTP cache lifetime.
+- `homeLocations.server.ts` caches the homepage country and region lists
+  for one hour. Visitors and members use the same public data.
 - `publicCatalog.server.ts` caches anonymous entity summaries and first-page
   entity/series bottle lists for five minutes. Keys include entity, series,
   distillery view, sort, and limit. Members, searches, extra filters, later


### PR DESCRIPTION
The homepage now loads its country and region lists from shared one-hour caches for both visitors and members. The browser uses the same one-hour freshness window, while personalized homepage data remains uncached.

Countries and regions keep separate cache entries so either list can still load if the other request fails. The web caching guide records the new behavior.
