### PR TITLE
feat(companies): show complete whisky portfolios

### DIFF
--- a/apps/server/src/lib/companyPortfolio.ts
+++ b/apps/server/src/lib/companyPortfolio.ts
@@ -1,0 +1,77 @@
+import { db } from "@peated/server/db";
+import { entities } from "@peated/server/db/schema";
+import { sql, type SQL } from "drizzle-orm";
+
+type OwnershipPathRow = {
+  descendantId: string;
+  path: string[];
+};
+
+function companyDescendantsCte(companyId: number): SQL {
+  return sql`
+    WITH RECURSIVE company_descendants(descendant_id, path) AS (
+      SELECT
+        ${entities.id},
+        ARRAY[${companyId}::bigint, ${entities.id}]::bigint[]
+      FROM ${entities}
+      WHERE ${entities.ownerId} = ${companyId}
+        AND ${entities.id} <> ${companyId}
+
+      UNION ALL
+
+      SELECT
+        child.id,
+        parent.path || child.id
+      FROM ${entities} AS child
+      INNER JOIN company_descendants AS parent
+        ON child.owner_id = parent.descendant_id
+      WHERE NOT child.id = ANY(parent.path)
+    )
+  `;
+}
+
+/** Returns every recorded descendant once, even if corrupt data contains a loop. */
+export function companyDescendantIds(companyId: number): SQL {
+  return sql`
+    ${companyDescendantsCte(companyId)}
+    SELECT DISTINCT descendant_id
+    FROM company_descendants
+  `;
+}
+
+/** Includes the Company itself plus every descendant that a Bottle may use. */
+export function companyBottleEntityIds(companyId: number): SQL {
+  return sql`
+    ${companyDescendantsCte(companyId)}
+    SELECT ${companyId}::bigint AS entity_id
+    UNION
+    SELECT DISTINCT descendant_id AS entity_id
+    FROM company_descendants
+  `;
+}
+
+export async function getCompanyOwnershipPaths(
+  companyId: number,
+  descendantIds: number[],
+): Promise<Map<number, number[]>> {
+  if (!descendantIds.length) return new Map();
+
+  const result = await db.execute<OwnershipPathRow>(sql`
+    ${companyDescendantsCte(companyId)}
+    SELECT DISTINCT ON (descendant_id)
+      descendant_id AS "descendantId",
+      path
+    FROM company_descendants
+    WHERE descendant_id IN (
+      ${sql.join(
+        descendantIds.map((descendantId) => sql`${descendantId}`),
+        sql`, `,
+      )}
+    )
+    ORDER BY descendant_id, cardinality(path), path
+  `);
+
+  return new Map(
+    result.rows.map((row) => [Number(row.descendantId), row.path.map(Number)]),
+  );
+}

--- a/apps/server/src/orpc/contracts/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/bottles/list.ts
@@ -24,6 +24,14 @@ export const BottleListInputSchema = z.object({
   brand: z.coerce.number().nullish(),
   distiller: z.coerce.number().nullish(),
   bottler: z.coerce.number().nullish(),
+  company: z.coerce
+    .number()
+    .int()
+    .positive()
+    .nullish()
+    .describe(
+      "Filter by a Company and the brands, distilleries, or bottlers below it",
+    ),
   entity: z.coerce.number().nullish(),
   country: z.coerce
     .string()

--- a/apps/server/src/orpc/contracts/entities/portfolio.ts
+++ b/apps/server/src/orpc/contracts/entities/portfolio.ts
@@ -1,0 +1,68 @@
+import { EntitySchema, listResponse } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export const CompanyPortfolioKindSchema = z.enum([
+  "brand",
+  "distillery",
+  "bottler",
+]);
+
+const OwnershipPathEntitySchema = EntitySchema.pick({
+  id: true,
+  peatedId: true,
+  name: true,
+  kind: true,
+});
+
+const PortfolioEntitySchema = EntitySchema.extend({
+  ownershipPath: z
+    .array(OwnershipPathEntitySchema)
+    .readonly()
+    .describe(
+      "Recorded owner path from the requested Company through the immediate owner",
+    ),
+});
+
+export const CompanyPortfolioInputSchema = z.object({
+  company: z.coerce.number().int().positive(),
+  kinds: z.array(CompanyPortfolioKindSchema).min(1).max(3).optional(),
+  cursor: z.coerce.number().int().gte(1).default(1),
+  limit: z.coerce.number().int().gte(1).lte(100).default(25),
+  sort: z
+    .enum(["name", "-name", "bottles", "-bottles", "tastings", "-tastings"])
+    .default("-bottles"),
+});
+
+export const CompanyPortfolioOutputSchema = listResponse(
+  PortfolioEntitySchema,
+).extend({
+  total: z.number().int().nonnegative(),
+  totals: z.object({
+    all: z.number().int().nonnegative(),
+    brands: z.number().int().nonnegative(),
+    distilleries: z.number().int().nonnegative(),
+    bottlers: z.number().int().nonnegative(),
+  }),
+  groupCompanies: z.object({
+    results: z.array(EntitySchema),
+    total: z.number().int().nonnegative(),
+  }),
+  previews: z.object({
+    brands: z.array(EntitySchema),
+    distilleries: z.array(EntitySchema),
+    bottlers: z.array(EntitySchema),
+  }),
+});
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/entities/{company}/portfolio",
+    summary: "List a company portfolio",
+    description:
+      "List brands, distilleries, and bottlers below a Company in the recorded current-owner chain.",
+    operationId: "listCompanyPortfolio",
+  })
+  .input(CompanyPortfolioInputSchema)
+  .output(CompanyPortfolioOutputSchema);

--- a/apps/server/src/orpc/mock/contract.ts
+++ b/apps/server/src/orpc/mock/contract.ts
@@ -30,6 +30,7 @@ import entityDetails from "@peated/server/orpc/contracts/entities/details";
 import entityEventList from "@peated/server/orpc/contracts/entities/events/list";
 import entityFlavorProfile from "@peated/server/orpc/contracts/entities/flavor-profile";
 import entityList from "@peated/server/orpc/contracts/entities/list";
+import entityPortfolio from "@peated/server/orpc/contracts/entities/portfolio";
 import entityResolve from "@peated/server/orpc/contracts/entities/resolve";
 import eventList from "@peated/server/orpc/contracts/events/list";
 import externalReviewList from "@peated/server/orpc/contracts/externalReviews/list";
@@ -125,6 +126,7 @@ export const mockContract = {
       list: entityEventList,
     },
     list: entityList,
+    portfolio: entityPortfolio,
     resolve: entityResolve,
   },
   events: {

--- a/apps/server/src/orpc/mock/fixtures/entities.ts
+++ b/apps/server/src/orpc/mock/fixtures/entities.ts
@@ -115,6 +115,16 @@ export const mockSuntoryGlobalSpiritsEntity = {
     "A spirits company based in New York. Its Scotch whisky distilleries include Laphroaig and Bowmore.",
 } satisfies Entity;
 
+export const mockSparseCompanyEntity = {
+  ...entityDefaults,
+  id: 9224,
+  peatedId: "E9224",
+  name: "Example Holdings",
+  kind: "company",
+  country: mockCountries[2],
+  description: "A company with no recorded whisky portfolio.",
+} satisfies Entity;
+
 export const mockEntity = {
   ...entityDefaults,
   id: 9201,
@@ -472,6 +482,7 @@ export const mockEntities: Entity[] = [
     totalBottles: 1,
     totalTastings: 56,
   },
+  mockSparseCompanyEntity,
 ];
 
 const followedEntityIds = new Set([9201, 9207, 9208]);

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -32,10 +32,13 @@ import {
   mockJohnnieWalkerEntity,
   mockLaphroaigEntity,
   mockNotifications,
+  mockPernodRicardEntity,
   mockPublicUserDetails,
   mockRegion,
   mockRegions,
+  mockSparseCompanyEntity,
   mockStats,
+  mockSuntoryGlobalSpiritsEntity,
   mockTaliskerEntity,
   mockTasting,
   mockUser,
@@ -126,6 +129,61 @@ describe("mock oRPC router", () => {
       mockEntity,
       mockJohnnieWalkerEntity,
     ]);
+    const nestedPortfolio = await anonymousClient.entities.portfolio({
+      company: mockPernodRicardEntity.id,
+      sort: "name",
+    });
+    expect(nestedPortfolio.results.map(({ name }) => name)).toEqual([
+      "Midleton",
+      "Redbreast",
+    ]);
+    expect(nestedPortfolio.groupCompanies.results).toEqual([
+      mockIrishDistillersEntity,
+    ]);
+    expect(
+      nestedPortfolio.results[0]?.ownershipPath.map(({ name }) => name),
+    ).toEqual(["Pernod Ricard", "Irish Distillers"]);
+    await expect(
+      anonymousClient.entities.portfolio({
+        company: mockSuntoryGlobalSpiritsEntity.id,
+      }),
+    ).resolves.toMatchObject({
+      results: [expect.objectContaining({ name: "Laphroaig" })],
+      total: 1,
+      totals: { all: 1, distilleries: 1 },
+    });
+    const companyBottles = await anonymousClient.bottles.list({
+      company: mockSuntoryGlobalSpiritsEntity.id,
+      sort: "-release",
+    });
+    expect(companyBottles.results.map(({ brand }) => brand.name)).toEqual([
+      "Laphroaig",
+      "Laphroaig",
+    ]);
+    const nestedCompanyBottles = await anonymousClient.bottles.list({
+      company: mockPernodRicardEntity.id,
+    });
+    expect(nestedCompanyBottles.results.map(({ brand }) => brand.name)).toEqual(
+      ["Redbreast"],
+    );
+    await expect(
+      anonymousClient.bottles.list({
+        company: mockPernodRicardEntity.id,
+        entity: mockLaphroaigEntity.id,
+      }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Choose either a Company or an Entity.",
+    });
+    await expect(
+      anonymousClient.entities.portfolio({
+        company: mockSparseCompanyEntity.id,
+      }),
+    ).resolves.toMatchObject({
+      results: [],
+      total: 0,
+      totals: { all: 0 },
+    });
     const laphroaigReleases = await anonymousClient.bottles.list({
       entity: mockLaphroaigEntity.id,
       sort: "-release",

--- a/apps/server/src/orpc/mock/router.ts
+++ b/apps/server/src/orpc/mock/router.ts
@@ -30,6 +30,7 @@ import entityDetails from "./routes/entities/details";
 import entityEventList from "./routes/entities/events/list";
 import entityFlavorProfile from "./routes/entities/flavor-profile";
 import entityList from "./routes/entities/list";
+import entityPortfolio from "./routes/entities/portfolio";
 import entityResolve from "./routes/entities/resolve";
 import eventList from "./routes/events/list";
 import externalReviewList from "./routes/externalReviews/list";
@@ -125,6 +126,7 @@ export const mockRouter = mockOS.router({
       list: entityEventList,
     },
     list: entityList,
+    portfolio: entityPortfolio,
     resolve: entityResolve,
   },
   events: {

--- a/apps/server/src/orpc/mock/routes/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/list.ts
@@ -3,6 +3,7 @@ import {
   includesQuery,
   mockBottleFor,
   mockBottles,
+  mockEntities,
   mockFlightBottleIds,
   mockPage,
 } from "@peated/server/orpc/mock/fixtures";
@@ -10,6 +11,18 @@ import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 type MockBottle = (typeof mockBottles)[number];
 type BottleAgeBand = (typeof BOTTLE_AGE_BAND_LIST)[number];
+
+function isInCompanyBottleScope(entityId: number, companyId: number) {
+  let entity = mockEntities.find(({ id }) => id === entityId);
+
+  const visited = new Set<number>();
+  while (entity && !visited.has(entity.id)) {
+    if (entity.id === companyId) return true;
+    visited.add(entity.id);
+    entity = mockEntities.find(({ id }) => id === entity?.ownerId);
+  }
+  return false;
+}
 
 function matchesDistilleryView(
   bottle: MockBottle,
@@ -60,6 +73,17 @@ export default mockOS.bottles.list.handler(
     if (input.filter === "following" && !context.user) {
       throw errors.UNAUTHORIZED();
     }
+    if (input.company != null && input.entity != null) {
+      throw errors.BAD_REQUEST({
+        message: "Choose either a Company or an Entity.",
+      });
+    }
+    if (
+      input.company != null &&
+      mockEntities.find(({ id }) => id === input.company)?.kind !== "company"
+    ) {
+      throw errors.BAD_REQUEST({ message: "Choose a Company." });
+    }
 
     const flightBottleIds = input.flight
       ? mockFlightBottleIds.get(input.flight)
@@ -75,6 +99,13 @@ export default mockOS.bottles.list.handler(
       (input.distiller == null ||
         bottle.distillers.some((entity) => entity.id === input.distiller)) &&
       (input.bottler == null || bottle.bottler?.id === input.bottler) &&
+      (input.company == null ||
+        isInCompanyBottleScope(bottle.brand.id, input.company) ||
+        (bottle.bottler !== null &&
+          isInCompanyBottleScope(bottle.bottler.id, input.company)) ||
+        bottle.distillers.some((entity) =>
+          isInCompanyBottleScope(entity.id, input.company!),
+        )) &&
       (input.entity == null ||
         (input.distilleryView
           ? matchesDistilleryView(bottle, input.entity, input.distilleryView)

--- a/apps/server/src/orpc/mock/routes/entities/portfolio.ts
+++ b/apps/server/src/orpc/mock/routes/entities/portfolio.ts
@@ -1,0 +1,132 @@
+import {
+  mockEntities,
+  mockEntityFor,
+  mockPage,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+function isPortfolioKind(
+  kind: (typeof mockEntities)[number]["kind"],
+): kind is "brand" | "bottler" | "distillery" {
+  return kind === "brand" || kind === "bottler" || kind === "distillery";
+}
+
+export default mockOS.entities.portfolio.handler(
+  ({ input, context, errors }) => {
+    const company = mockEntities.find(({ id }) => id === input.company);
+    if (!company) {
+      throw errors.NOT_FOUND({ message: "Company not found." });
+    }
+    if (company.kind !== "company") {
+      throw errors.BAD_REQUEST({ message: "Choose a Company." });
+    }
+
+    const pathById = new Map<number, number[]>();
+    const queue = mockEntities
+      .filter(({ ownerId }) => ownerId === company.id)
+      .map((entity) => ({ entity, path: [company.id, entity.id] }));
+
+    while (queue.length) {
+      const next = queue.shift();
+      if (!next || pathById.has(next.entity.id)) continue;
+      pathById.set(next.entity.id, next.path);
+
+      for (const child of mockEntities.filter(
+        ({ ownerId }) => ownerId === next.entity.id,
+      )) {
+        if (!next.path.includes(child.id)) {
+          queue.push({ entity: child, path: [...next.path, child.id] });
+        }
+      }
+    }
+
+    const portfolioKinds = ["brand", "distillery", "bottler"] as const;
+    const allPortfolio = mockEntities.filter(
+      (entity) => pathById.has(entity.id) && isPortfolioKind(entity.kind),
+    );
+    const requestedKinds = input.kinds ?? portfolioKinds;
+    const direction = input.sort.startsWith("-") ? -1 : 1;
+    const sort = input.sort.replace(/^-/, "");
+    const portfolio = allPortfolio
+      .filter(
+        (entity) =>
+          isPortfolioKind(entity.kind) && requestedKinds.includes(entity.kind),
+      )
+      .toSorted((left, right) => {
+        let result = 0;
+        switch (sort) {
+          case "name":
+            result = left.name.localeCompare(right.name);
+            break;
+          case "tastings":
+            result = left.totalTastings - right.totalTastings;
+            break;
+          case "bottles":
+          default:
+            result = left.totalBottles - right.totalBottles;
+        }
+        return direction * result || left.id - right.id;
+      });
+    const page = mockPage(portfolio, input.cursor, input.limit);
+    const signedIn = Boolean(context.user);
+    const previews = (kind: (typeof portfolioKinds)[number]) =>
+      allPortfolio
+        .filter((entity) => entity.kind === kind)
+        .toSorted(
+          (left, right) =>
+            right.totalBottles - left.totalBottles || left.id - right.id,
+        )
+        .slice(0, 4)
+        .map((entity) => mockEntityFor(signedIn, entity));
+
+    return {
+      ...page,
+      results: page.results.map((entity) => ({
+        ...mockEntityFor(signedIn, entity),
+        ownershipPath: (pathById.get(entity.id) ?? [])
+          .slice(0, -1)
+          .flatMap((entityId) => {
+            const pathEntity = mockEntities.find(({ id }) => id === entityId);
+            return pathEntity
+              ? [
+                  {
+                    id: pathEntity.id,
+                    peatedId: pathEntity.peatedId,
+                    name: pathEntity.name,
+                    kind: pathEntity.kind,
+                  },
+                ]
+              : [];
+          }),
+      })),
+      total: portfolio.length,
+      totals: {
+        all: allPortfolio.length,
+        brands: allPortfolio.filter(({ kind }) => kind === "brand").length,
+        distilleries: allPortfolio.filter(({ kind }) => kind === "distillery")
+          .length,
+        bottlers: allPortfolio.filter(({ kind }) => kind === "bottler").length,
+      },
+      groupCompanies: {
+        results: mockEntities
+          .filter(
+            ({ kind, ownerId }) => kind === "company" && ownerId === company.id,
+          )
+          .toSorted(
+            (left, right) =>
+              right.totalBottles - left.totalBottles || left.id - right.id,
+          )
+          .slice(0, 4)
+          .map((entity) => mockEntityFor(signedIn, entity)),
+        total: mockEntities.filter(
+          ({ kind, ownerId }) => kind === "company" && ownerId === company.id,
+        ).length,
+      },
+      previews: {
+        brands: previews("brand"),
+        distilleries: previews("distillery"),
+        bottlers: previews("bottler"),
+      },
+    };
+  },
+);

--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -290,6 +290,142 @@ describe("GET /bottles", () => {
     expect(results[0].id).toBe(bottle1.id);
   });
 
+  test("lists each active Bottle once through a complete Company portfolio", async ({
+    fixtures,
+  }) => {
+    const company = await fixtures.Entity({
+      kind: "company",
+      name: "Complete Portfolio Company",
+    });
+    const group = await fixtures.Entity({
+      kind: "company",
+      name: "Nested Portfolio Company",
+      ownerId: company.id,
+    });
+    const brand = await fixtures.Entity({
+      kind: "brand",
+      name: "Nested Portfolio Brand",
+      ownerId: group.id,
+    });
+    const distillery = await fixtures.Entity({
+      kind: "distillery",
+      name: "Nested Portfolio Distillery",
+      ownerId: brand.id,
+    });
+    const bottler = await fixtures.Entity({
+      kind: "bottler",
+      name: "Nested Portfolio Bottler",
+      ownerId: group.id,
+    });
+    const outsideBrand = await fixtures.Entity({
+      kind: "brand",
+      name: "Outside Portfolio Brand",
+    });
+
+    const brandBottle = await fixtures.Bottle({
+      name: "Brand Match",
+      brandId: brand.id,
+    });
+    const distilleryBottle = await fixtures.Bottle({
+      name: "Distillery Match",
+      brandId: outsideBrand.id,
+      distillerIds: [distillery.id],
+    });
+    const bottlerBottle = await fixtures.Bottle({
+      name: "Bottler Match",
+      brandId: outsideBrand.id,
+      bottlerId: bottler.id,
+    });
+    const severalMatches = await fixtures.Bottle({
+      name: "Several Matches",
+      brandId: brand.id,
+      bottlerId: bottler.id,
+      distillerIds: [distillery.id],
+    });
+    const nestedCompanyBottle = await fixtures.Bottle({
+      name: "Nested Company Match",
+      brandId: group.id,
+    });
+    const directCompanyBottle = await fixtures.Bottle({
+      name: "Direct Company Match",
+      brandId: company.id,
+    });
+    const retiredBottle = await fixtures.Bottle({
+      name: "Retired Match",
+      brandId: brand.id,
+    });
+    const replacement = await fixtures.Bottle({
+      name: "Unrelated Replacement",
+      brandId: outsideBrand.id,
+    });
+    await db.insert(bottleTombstones).values({
+      bottleId: retiredBottle.id,
+      newBottleId: replacement.id,
+    });
+
+    const result = await routerClient.bottles.list({
+      company: company.id,
+      sort: "-tastings",
+      limit: 2,
+    });
+    const secondPage = await routerClient.bottles.list({
+      company: company.id,
+      sort: "-tastings",
+      cursor: 2,
+      limit: 2,
+    });
+    const thirdPage = await routerClient.bottles.list({
+      company: company.id,
+      sort: "-tastings",
+      cursor: 3,
+      limit: 2,
+    });
+
+    expect(result.total).toBe(6);
+    expect(result.results.map(({ id }) => id)).toEqual([
+      brandBottle.id,
+      distilleryBottle.id,
+    ]);
+    expect(result.rel.nextCursor).toBe(2);
+    expect(secondPage.results.map(({ id }) => id)).toEqual([
+      bottlerBottle.id,
+      severalMatches.id,
+    ]);
+    expect(thirdPage.results.map(({ id }) => id)).toEqual([
+      nestedCompanyBottle.id,
+      directCompanyBottle.id,
+    ]);
+    expect(
+      new Set(
+        [...result.results, ...secondPage.results, ...thirdPage.results].map(
+          ({ id }) => id,
+        ),
+      ),
+    ).toEqual(
+      new Set([
+        brandBottle.id,
+        distilleryBottle.id,
+        bottlerBottle.id,
+        severalMatches.id,
+        nestedCompanyBottle.id,
+        directCompanyBottle.id,
+      ]),
+    );
+  });
+
+  test("requires the Company filter to identify a Company", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ kind: "brand" });
+
+    await expect(
+      routerClient.bottles.list({ company: brand.id }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Choose a Company.",
+    });
+  });
+
   test("separates distillery releases from other bottlings", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -15,6 +15,7 @@ import {
   tastings,
 } from "@peated/server/db/schema";
 import { bottleProducedIn } from "@peated/server/lib/bottleProductionLocation";
+import { companyBottleEntityIds } from "@peated/server/lib/companyPortfolio";
 import { getReservedCollection } from "@peated/server/lib/db";
 import { bottlesForDistilleryView } from "@peated/server/lib/distilleryBottleView";
 import {
@@ -234,6 +235,34 @@ export default implement(bottleListContract).handler(async function ({
   if (rest.bottler) {
     where.push(eq(bottles.bottlerId, rest.bottler));
   }
+  if (rest.company) {
+    if (rest.entity) {
+      throw errors.BAD_REQUEST({
+        message: "Choose either a Company or an Entity.",
+      });
+    }
+    const [company] = await db
+      .select({ kind: entities.kind })
+      .from(entities)
+      .where(eq(entities.id, rest.company))
+      .limit(1);
+    if (company?.kind !== "company") {
+      throw errors.BAD_REQUEST({ message: "Choose a Company." });
+    }
+
+    const companyEntityIds = companyBottleEntityIds(rest.company);
+    where.push(
+      or(
+        sql`${bottles.brandId} IN (${companyEntityIds})`,
+        sql`${bottles.bottlerId} IN (${companyEntityIds})`,
+        sql`EXISTS(
+          SELECT FROM ${bottlesToDistillers}
+          WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
+            AND ${bottlesToDistillers.distillerId} IN (${companyEntityIds})
+        )`,
+      ),
+    );
+  }
   if (rest.distilleryView) {
     if (!rest.entity) {
       throw errors.BAD_REQUEST({
@@ -311,7 +340,7 @@ export default implement(bottleListContract).handler(async function ({
       }
       break;
     case "brand":
-      if (!rest.entity) {
+      if (!rest.entity && !rest.company) {
         throw errors.BAD_REQUEST({
           message: "Cannot sort by brand without entity filter.",
         });

--- a/apps/server/src/orpc/routes/entities/index.ts
+++ b/apps/server/src/orpc/routes/entities/index.ts
@@ -13,6 +13,7 @@ import follow from "./follow";
 import images from "./images";
 import list from "./list";
 import merge from "./merge";
+import portfolio from "./portfolio";
 import references from "./references";
 import resolve from "./resolve";
 import unfollow from "./unfollow";
@@ -27,6 +28,7 @@ export default base.tag("entities").router({
   update,
   delete: delete_,
   merge,
+  portfolio,
   aliases,
   references,
   resolve,

--- a/apps/server/src/orpc/routes/entities/portfolio.test.ts
+++ b/apps/server/src/orpc/routes/entities/portfolio.test.ts
@@ -1,0 +1,220 @@
+import { db } from "@peated/server/db";
+import { entities } from "@peated/server/db/schema";
+import { routerClient } from "@peated/server/orpc/router";
+import { eq } from "drizzle-orm";
+
+describe("GET /entities/{company}/portfolio", () => {
+  test("lists direct and nested whisky Entities with exact totals and paths", async ({
+    fixtures,
+  }) => {
+    const company = await fixtures.Entity({
+      kind: "company",
+      name: "Parent Company",
+    });
+    const group = await fixtures.Entity({
+      kind: "company",
+      name: "Portfolio Company",
+      ownerId: company.id,
+    });
+    const directBrand = await fixtures.Entity({
+      kind: "brand",
+      name: "Direct Brand",
+      ownerId: company.id,
+      totalBottles: 4,
+    });
+    const nestedDistillery = await fixtures.Entity({
+      kind: "distillery",
+      name: "Nested Distillery",
+      ownerId: group.id,
+      totalBottles: 8,
+    });
+    const nestedBottler = await fixtures.Entity({
+      kind: "bottler",
+      name: "Nested Bottler",
+      ownerId: nestedDistillery.id,
+      totalBottles: 2,
+    });
+
+    const result = await routerClient.entities.portfolio({
+      company: company.id,
+      sort: "-bottles",
+    });
+
+    expect(result.total).toBe(3);
+    expect(result.totals).toEqual({
+      all: 3,
+      brands: 1,
+      distilleries: 1,
+      bottlers: 1,
+    });
+    expect(result.results.map(({ id }) => id)).toEqual([
+      nestedDistillery.id,
+      directBrand.id,
+      nestedBottler.id,
+    ]);
+    expect(
+      result.results.find(({ id }) => id === nestedBottler.id)?.ownershipPath,
+    ).toEqual([
+      expect.objectContaining({ id: company.id, kind: "company" }),
+      expect.objectContaining({ id: group.id, kind: "company" }),
+      expect.objectContaining({
+        id: nestedDistillery.id,
+        kind: "distillery",
+      }),
+    ]);
+    expect(result.groupCompanies).toEqual({
+      results: [
+        expect.objectContaining({
+          id: group.id,
+          kind: "company",
+        }),
+      ],
+      total: 1,
+    });
+  });
+
+  test("filters by kind and keeps totals for the complete portfolio", async ({
+    fixtures,
+  }) => {
+    const company = await fixtures.Entity({ kind: "company" });
+    const brand = await fixtures.Entity({
+      kind: "brand",
+      ownerId: company.id,
+    });
+    await fixtures.Entity({ kind: "distillery", ownerId: company.id });
+
+    const result = await routerClient.entities.portfolio({
+      company: company.id,
+      kinds: ["brand"],
+    });
+
+    expect(result.results.map(({ id }) => id)).toEqual([brand.id]);
+    expect(result.total).toBe(1);
+    expect(result.totals.all).toBe(2);
+  });
+
+  test("paginates in stable Entity ID order when sort values match", async ({
+    fixtures,
+  }) => {
+    const company = await fixtures.Entity({ kind: "company" });
+    const first = await fixtures.Entity({
+      kind: "brand",
+      ownerId: company.id,
+      totalBottles: 5,
+    });
+    const second = await fixtures.Entity({
+      kind: "brand",
+      ownerId: company.id,
+      totalBottles: 5,
+    });
+
+    const pageOne = await routerClient.entities.portfolio({
+      company: company.id,
+      kinds: ["brand"],
+      limit: 1,
+    });
+    const pageTwo = await routerClient.entities.portfolio({
+      company: company.id,
+      kinds: ["brand"],
+      cursor: 2,
+      limit: 1,
+    });
+
+    expect(pageOne.results[0]?.id).toBe(first.id);
+    expect(pageOne.rel).toEqual({ nextCursor: 2, prevCursor: null });
+    expect(pageTwo.results[0]?.id).toBe(second.id);
+    expect(pageTwo.rel).toEqual({ nextCursor: null, prevCursor: 1 });
+  });
+
+  test("returns an empty portfolio without inventing relationships", async ({
+    fixtures,
+  }) => {
+    const company = await fixtures.Entity({ kind: "company" });
+
+    const result = await routerClient.entities.portfolio({
+      company: company.id,
+    });
+
+    expect(result.results).toEqual([]);
+    expect(result.total).toBe(0);
+    expect(result.totals.all).toBe(0);
+    expect(result.groupCompanies).toEqual({ results: [], total: 0 });
+  });
+
+  test("stops if corrupt ownership data loops back to the Company", async ({
+    fixtures,
+  }) => {
+    const company = await fixtures.Entity({ kind: "company" });
+    const brand = await fixtures.Entity({
+      kind: "brand",
+      ownerId: company.id,
+    });
+    await db
+      .update(entities)
+      .set({ ownerId: brand.id })
+      .where(eq(entities.id, company.id));
+
+    const result = await routerClient.entities.portfolio({
+      company: company.id,
+    });
+
+    expect(result.results.map(({ id }) => id)).toEqual([brand.id]);
+  });
+
+  test("rejects a non-Company root", async ({ fixtures }) => {
+    const brand = await fixtures.Entity({ kind: "brand" });
+
+    await expect(
+      routerClient.entities.portfolio({ company: brand.id }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Choose a Company.",
+    });
+  });
+
+  test("bounds a larger portfolio response while retaining exact totals", async ({
+    fixtures,
+  }) => {
+    const company = await fixtures.Entity({
+      countryId: null,
+      kind: "company",
+      name: "Large Portfolio Company",
+    });
+
+    const groups: (typeof company)[] = [];
+    for (let groupIndex = 0; groupIndex < 5; groupIndex += 1) {
+      const group = await fixtures.Entity({
+        countryId: null,
+        createdByActorId: company.createdByActorId,
+        kind: "company",
+        name: `Portfolio Group ${groupIndex}`,
+        ownerId: company.id,
+      });
+      groups.push(group);
+    }
+
+    await db.insert(entities).values(
+      groups.flatMap((group, groupIndex) =>
+        Array.from({ length: 12 }, (_, brandIndex) => ({
+          kind: "brand" as const,
+          name: `Portfolio Brand ${groupIndex}-${brandIndex}`,
+          ownerId: group.id,
+          totalBottles: brandIndex,
+          createdByActorId: company.createdByActorId,
+        })),
+      ),
+    );
+
+    const result = await routerClient.entities.portfolio({
+      company: company.id,
+      kinds: ["brand"],
+      limit: 25,
+    });
+
+    expect(result.results).toHaveLength(25);
+    expect(result.total).toBe(60);
+    expect(result.totals).toMatchObject({ all: 60, brands: 60 });
+    expect(result.rel.nextCursor).toBe(2);
+    expect(JSON.stringify(result).length).toBeLessThan(100_000);
+  });
+});

--- a/apps/server/src/orpc/routes/entities/portfolio.ts
+++ b/apps/server/src/orpc/routes/entities/portfolio.ts
@@ -1,0 +1,209 @@
+import { db } from "@peated/server/db";
+import { entities } from "@peated/server/db/schema";
+import {
+  companyDescendantIds,
+  getCompanyOwnershipPaths,
+} from "@peated/server/lib/companyPortfolio";
+import { formatPeatedId } from "@peated/server/lib/peatedId";
+import { implement } from "@peated/server/orpc";
+import contract from "@peated/server/orpc/contracts/entities/portfolio";
+import { serialize } from "@peated/server/serializers";
+import { EntitySerializer } from "@peated/server/serializers/entity";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  getTableColumns,
+  inArray,
+  sql,
+  type SQL,
+} from "drizzle-orm";
+
+const portfolioKinds = ["brand", "distillery", "bottler"] as const;
+
+export default implement(contract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const [company] = await db
+    .select({ id: entities.id, kind: entities.kind })
+    .from(entities)
+    .where(eq(entities.id, input.company))
+    .limit(1);
+
+  if (!company) {
+    throw errors.NOT_FOUND({ message: "Company not found." });
+  }
+  if (company.kind !== "company") {
+    throw errors.BAD_REQUEST({ message: "Choose a Company." });
+  }
+
+  const requestedKinds = input.kinds ?? [...portfolioKinds];
+  const descendants = sql`${entities.id} IN (${companyDescendantIds(company.id)})`;
+  const portfolioWhere = and(
+    descendants,
+    inArray(entities.kind, requestedKinds),
+  );
+  const offset = (input.cursor - 1) * input.limit;
+
+  let orderBy: SQL<unknown>;
+  switch (input.sort) {
+    case "name":
+      orderBy = asc(entities.name);
+      break;
+    case "-name":
+      orderBy = desc(entities.name);
+      break;
+    case "bottles":
+      orderBy = asc(entities.totalBottles);
+      break;
+    case "tastings":
+      orderBy = asc(entities.totalTastings);
+      break;
+    case "-tastings":
+      orderBy = desc(entities.totalTastings);
+      break;
+    case "-bottles":
+    default:
+      orderBy = desc(entities.totalBottles);
+  }
+
+  const [
+    portfolioRows,
+    [totalRow],
+    totalRows,
+    previewRowGroups,
+    groupCompanyRows,
+    [groupCompanyTotalRow],
+  ] = await Promise.all([
+    db
+      .select({ ...getTableColumns(entities) })
+      .from(entities)
+      .where(portfolioWhere)
+      .limit(input.limit + 1)
+      .offset(offset)
+      .orderBy(orderBy, asc(entities.id)),
+    db
+      .select({ count: sql<string>`COUNT(*)` })
+      .from(entities)
+      .where(portfolioWhere),
+    db
+      .select({
+        kind: entities.kind,
+        count: sql<string>`COUNT(*)`,
+      })
+      .from(entities)
+      .where(and(descendants, inArray(entities.kind, [...portfolioKinds])))
+      .groupBy(entities.kind),
+    Promise.all(
+      portfolioKinds.map((kind) =>
+        db
+          .select({ ...getTableColumns(entities) })
+          .from(entities)
+          .where(and(descendants, eq(entities.kind, kind)))
+          .limit(4)
+          .orderBy(desc(entities.totalBottles), asc(entities.id)),
+      ),
+    ),
+    db
+      .select({ ...getTableColumns(entities) })
+      .from(entities)
+      .where(
+        and(eq(entities.ownerId, company.id), eq(entities.kind, "company")),
+      )
+      .limit(4)
+      .orderBy(desc(entities.totalBottles), asc(entities.id)),
+    db
+      .select({ count: sql<string>`COUNT(*)` })
+      .from(entities)
+      .where(
+        and(eq(entities.ownerId, company.id), eq(entities.kind, "company")),
+      ),
+  ]);
+
+  const shownPortfolioRows = portfolioRows.slice(0, input.limit);
+  const ownershipPaths = await getCompanyOwnershipPaths(
+    company.id,
+    shownPortfolioRows.map(({ id }) => id),
+  );
+  const pathEntityIds = [
+    ...new Set(
+      [...ownershipPaths.values()].flatMap((path) => path.slice(0, -1)),
+    ),
+  ];
+  const pathEntities = pathEntityIds.length
+    ? await db
+        .select({
+          id: entities.id,
+          kind: entities.kind,
+          name: entities.name,
+        })
+        .from(entities)
+        .where(inArray(entities.id, pathEntityIds))
+    : [];
+  const pathEntitiesById = new Map(
+    pathEntities.map((entity) => [entity.id, entity]),
+  );
+  const serializedPortfolio = await serialize(
+    EntitySerializer,
+    shownPortfolioRows,
+    context.user,
+  );
+  const counts = new Map(
+    totalRows.map(({ kind, count }) => [kind, Number(count)]),
+  );
+  const totals = {
+    brands: counts.get("brand") ?? 0,
+    distilleries: counts.get("distillery") ?? 0,
+    bottlers: counts.get("bottler") ?? 0,
+  };
+  const [brandPreviews, distilleryPreviews, bottlerPreviews] =
+    await Promise.all(
+      previewRowGroups.map((rows) =>
+        serialize(EntitySerializer, rows, context.user),
+      ),
+    );
+
+  return {
+    results: serializedPortfolio.map((entity) => ({
+      ...entity,
+      ownershipPath: (ownershipPaths.get(entity.id) ?? [])
+        .slice(0, -1)
+        .flatMap((entityId) => {
+          const pathEntity = pathEntitiesById.get(entityId);
+          return pathEntity
+            ? [
+                {
+                  ...pathEntity,
+                  peatedId: formatPeatedId("entity", pathEntity.id),
+                },
+              ]
+            : [];
+        }),
+    })),
+    total: Number(totalRow?.count ?? 0),
+    totals: {
+      ...totals,
+      all: totals.brands + totals.distilleries + totals.bottlers,
+    },
+    groupCompanies: {
+      results: await serialize(
+        EntitySerializer,
+        groupCompanyRows,
+        context.user,
+      ),
+      total: Number(groupCompanyTotalRow?.count ?? 0),
+    },
+    previews: {
+      brands: brandPreviews ?? [],
+      distilleries: distilleryPreviews ?? [],
+      bottlers: bottlerPreviews ?? [],
+    },
+    rel: {
+      nextCursor: portfolioRows.length > input.limit ? input.cursor + 1 : null,
+      prevCursor: input.cursor > 1 ? input.cursor - 1 : null,
+    },
+  };
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/(overview)/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/(overview)/page.tsx
@@ -57,13 +57,7 @@ export default async function EntityPage(props: {
   if (entity.kind === "company") {
     prefetches.push(
       queryClient.prefetchQuery(
-        entityOverviewQueries.companyBrands(orpc, entity),
-      ),
-      queryClient.prefetchQuery(
-        entityOverviewQueries.companyDistilleries(orpc, entity),
-      ),
-      queryClient.prefetchQuery(
-        entityOverviewQueries.companyBottlersAndCompanies(orpc, entity),
+        entityOverviewQueries.companyPortfolio(orpc, entity),
       ),
     );
   }

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
@@ -67,6 +67,7 @@ export function EntityBottleListClient({
         "age",
         "brand",
         "bottler",
+        "company",
         "cursor",
         "distiller",
         "entity",
@@ -74,8 +75,9 @@ export function EntityBottleListClient({
         "series",
       ],
       overrides: {
+        company: entityKind === "company" ? entityId : undefined,
         distilleryView,
-        entity: entityId,
+        entity: entityKind === "company" ? undefined : entityId,
         limit: 25,
       },
     }),

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
@@ -25,7 +25,11 @@ export default async function EntityBottlesPage(props: {
   const { entityId } = await props.params;
   const searchParams = await props.searchParams;
   const entity = await getEntityPage(parseCatalogRouteId(entityId));
-  if (!entityHasBottleCatalog(entity) && entity.totalBottles === 0) {
+  if (
+    entity.kind !== "company" &&
+    !entityHasBottleCatalog(entity) &&
+    entity.totalBottles === 0
+  ) {
     redirect(getEntityUrl(entity));
   }
 
@@ -40,6 +44,7 @@ export default async function EntityBottlesPage(props: {
         "age",
         "brand",
         "bottler",
+        "company",
         "cursor",
         "distiller",
         "entity",
@@ -47,13 +52,17 @@ export default async function EntityBottlesPage(props: {
         "series",
       ],
       overrides: {
+        company: entity.kind === "company" ? entity.id : undefined,
         distilleryView,
-        entity: entity.id,
+        entity: entity.kind === "company" ? undefined : entity.id,
         limit: 25,
       },
     }),
   );
   let bottleList = await getPageBottleList(queryParams);
+  if (entity.kind === "company" && bottleList.total === 0) {
+    redirect(getEntityUrl(entity));
+  }
 
   if (
     entity.kind === "distillery" &&

--- a/apps/web/src/app/(app)/entities/[entityId]/companyOwnedList.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/companyOwnedList.test.tsx
@@ -17,17 +17,36 @@ const company = {
 } satisfies Entity;
 
 function render(
-  section: "brands" | "distilleries" | "operates",
+  section:
+    | "brands"
+    | "bottlers"
+    | "distilleries"
+    | "groupCompanies"
+    | "portfolio",
   items?: ListItems,
+  total?: number,
 ) {
+  const kind =
+    section === "brands"
+      ? "brand"
+      : section === "distilleries"
+        ? "distillery"
+        : section === "bottlers"
+          ? "bottler"
+          : undefined;
+
   return renderToStaticMarkup(
     <CompanyOwnedList
       company={company}
       error={false}
+      href={
+        kind ? `/companies/1-example-company/portfolio?kind=${kind}` : undefined
+      }
       items={items}
       pending={false}
       retry={() => undefined}
       section={section}
+      total={total}
     />,
   );
 }
@@ -49,11 +68,18 @@ describe("CompanyOwnedList", () => {
       "/distillers/2-lagavulin",
     ],
     [
-      "operates",
-      "Operates",
+      "bottlers",
+      "Bottlers",
       "bottler",
       "Elixir Distillers",
       "/bottlers/2-elixir-distillers",
+    ],
+    [
+      "groupCompanies",
+      "Companies in this group",
+      "company",
+      "Suntory Global Spirits",
+      "/companies/2-suntory-global-spirits",
     ],
   ] as const)(
     "shows the %s group with its own heading",
@@ -75,7 +101,7 @@ describe("CompanyOwnedList", () => {
   );
 
   test("keeps bottle counts out of owned entity rows", () => {
-    const html = render("operates", [
+    const html = render("bottlers", [
       {
         ...mockEntity,
         id: 2,
@@ -86,17 +112,55 @@ describe("CompanyOwnedList", () => {
       },
     ]);
 
-    expect(html).toContain("Operates");
+    expect(html).toContain("Bottlers");
     expect(html).toContain("The Scotch Malt Whisky Society");
     expect(html).toContain('href="/bottlers/2-the-scotch-malt-whisky-society"');
     expect(html).toContain("Bottler · Islay, Scotland");
     expect(html).not.toContain("3,499 bottles");
   });
 
-  test.each(["brands", "distilleries", "operates"] as const)(
-    "does not render an empty %s section",
-    (section) => {
-      expect(render(section, [])).toBe("");
-    },
-  );
+  test("links truncated previews to the complete filtered portfolio", () => {
+    const html = render(
+      "brands",
+      [
+        {
+          ...mockEntity,
+          id: 2,
+          kind: "brand",
+          name: "Portfolio Brand",
+        },
+      ],
+      12,
+    );
+
+    expect(html).toContain("View all 12");
+    expect(html).toContain(
+      'href="/companies/1-example-company/portfolio?kind=brand"',
+    );
+  });
+
+  test("keeps a failed portfolio request local to its section", () => {
+    const html = renderToStaticMarkup(
+      <CompanyOwnedList
+        company={company}
+        error
+        pending={false}
+        retry={() => undefined}
+        section="portfolio"
+      />,
+    );
+
+    expect(html).toContain("Could not load whisky portfolio");
+    expect(html).toContain("Try again");
+  });
+
+  test.each([
+    "brands",
+    "bottlers",
+    "distilleries",
+    "groupCompanies",
+    "portfolio",
+  ] as const)("does not render an empty %s section", (section) => {
+    expect(render(section, [])).toBe("");
+  });
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/companyOwnedList.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/companyOwnedList.tsx
@@ -7,13 +7,14 @@ import {
   LoadingList,
   RailList,
   SectionError,
+  TextLink,
 } from "@peated/web/components";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
 import { type Entity } from "./entityPageData";
 
-type ListItem = Outputs["entities"]["list"]["results"][number];
+type ListItem = Outputs["entities"]["portfolio"]["previews"]["brands"][number];
 
 const sectionCopy = {
   brands: {
@@ -26,10 +27,20 @@ const sectionCopy = {
     heading: "Distilleries",
     loadingLabel: "Loading distilleries",
   },
-  operates: {
-    errorHeading: "Could not load bottlers and companies",
-    heading: "Operates",
-    loadingLabel: "Loading bottlers and companies",
+  bottlers: {
+    errorHeading: "Could not load bottlers",
+    heading: "Bottlers",
+    loadingLabel: "Loading bottlers",
+  },
+  groupCompanies: {
+    errorHeading: "Could not load companies in this group",
+    heading: "Companies in this group",
+    loadingLabel: "Loading companies in this group",
+  },
+  portfolio: {
+    errorHeading: "Could not load whisky portfolio",
+    heading: "Whisky portfolio",
+    loadingLabel: "Loading whisky portfolio",
   },
 } as const;
 
@@ -38,17 +49,21 @@ type CompanySection = keyof typeof sectionCopy;
 export function CompanyOwnedList({
   company,
   error,
+  href,
   items,
   pending,
   retry,
   section,
+  total,
 }: {
   company: Entity;
   error: boolean;
+  href?: string;
   items?: ListItem[];
   pending: boolean;
   retry: () => void;
   section: CompanySection;
+  total?: number;
 }) {
   if (company.kind !== "company") return null;
 
@@ -76,7 +91,14 @@ export function CompanyOwnedList({
   if (!shownItems.length) return null;
 
   return (
-    <PageSection heading={heading}>
+    <PageSection
+      heading={heading}
+      intro={
+        href && total && total > shownItems.length ? (
+          <TextLink href={href}>View all {total.toLocaleString()}</TextLink>
+        ) : undefined
+      }
+    >
       <RailList ariaLabel={`${company.name} ${heading.toLowerCase()}`}>
         {shownItems.map((item) => (
           <ItemListItem key={item.id}>

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -8,6 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getEntityUrl } from "@peated/web/lib/urls";
 
 import { CompanyOwnedList } from "./companyOwnedList";
 import { EntityBottleOverview } from "./entityBottleOverview";
@@ -36,12 +37,8 @@ export function EntityOverviewClient() {
   const releaseListQuery = useQuery(
     entityOverviewQueries.releases(orpc, entity),
   );
-  const brandList = useQuery(entityOverviewQueries.companyBrands(orpc, entity));
-  const distilleryList = useQuery(
-    entityOverviewQueries.companyDistilleries(orpc, entity),
-  );
-  const bottlerAndCompanyList = useQuery(
-    entityOverviewQueries.companyBottlersAndCompanies(orpc, entity),
+  const companyPortfolioQuery = useQuery(
+    entityOverviewQueries.companyPortfolio(orpc, entity),
   );
   const siblingListQuery = useQuery(
     entityOverviewQueries.siblings(orpc, entity),
@@ -56,30 +53,48 @@ export function EntityOverviewClient() {
       }
       catalogSections={
         <>
-          <CompanyOwnedList
-            company={entity}
-            error={Boolean(distilleryList.error)}
-            items={distilleryList.data?.results}
-            pending={distilleryList.isPending}
-            retry={() => void distilleryList.refetch()}
-            section="distilleries"
-          />
-          <CompanyOwnedList
-            company={entity}
-            error={Boolean(brandList.error)}
-            items={brandList.data?.results}
-            pending={brandList.isPending}
-            retry={() => void brandList.refetch()}
-            section="brands"
-          />
-          <CompanyOwnedList
-            company={entity}
-            error={Boolean(bottlerAndCompanyList.error)}
-            items={bottlerAndCompanyList.data?.results}
-            pending={bottlerAndCompanyList.isPending}
-            retry={() => void bottlerAndCompanyList.refetch()}
-            section="operates"
-          />
+          {companyPortfolioQuery.isPending || companyPortfolioQuery.error ? (
+            <CompanyOwnedList
+              company={entity}
+              error={Boolean(companyPortfolioQuery.error)}
+              pending={companyPortfolioQuery.isPending}
+              retry={() => void companyPortfolioQuery.refetch()}
+              section="portfolio"
+            />
+          ) : (
+            <>
+              <CompanyOwnedList
+                company={entity}
+                error={false}
+                href={`${getEntityUrl(entity)}/portfolio?kind=brand`}
+                items={companyPortfolioQuery.data?.previews.brands}
+                pending={false}
+                retry={() => void companyPortfolioQuery.refetch()}
+                section="brands"
+                total={companyPortfolioQuery.data?.totals.brands}
+              />
+              <CompanyOwnedList
+                company={entity}
+                error={false}
+                href={`${getEntityUrl(entity)}/portfolio?kind=distillery`}
+                items={companyPortfolioQuery.data?.previews.distilleries}
+                pending={false}
+                retry={() => void companyPortfolioQuery.refetch()}
+                section="distilleries"
+                total={companyPortfolioQuery.data?.totals.distilleries}
+              />
+              <CompanyOwnedList
+                company={entity}
+                error={false}
+                href={`${getEntityUrl(entity)}/portfolio?kind=bottler`}
+                items={companyPortfolioQuery.data?.previews.bottlers}
+                pending={false}
+                retry={() => void companyPortfolioQuery.refetch()}
+                section="bottlers"
+                total={companyPortfolioQuery.data?.totals.bottlers}
+              />
+            </>
+          )}
           <EntityReleaseOverview
             entity={entity}
             error={Boolean(releaseListQuery.error)}
@@ -119,6 +134,15 @@ export function EntityOverviewClient() {
       }
       relationships={
         <>
+          <CompanyOwnedList
+            company={entity}
+            error={false}
+            items={companyPortfolioQuery.data?.groupCompanies.results}
+            pending={false}
+            retry={() => void companyPortfolioQuery.refetch()}
+            section="groupCompanies"
+            total={companyPortfolioQuery.data?.groupCompanies.total}
+          />
           <EntityMap entity={entity} />
           {entity.kind === "distillery" ? (
             <div {...stylex.props(styles.flavorProfile)}>

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewQueries.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewQueries.ts
@@ -14,44 +14,14 @@ export const entityOverviewQueries = {
     orpc.entities.events.list.queryOptions({
       input: { entity: entity.id },
     }),
-  companyBrands: (orpc: ORPCQueryUtils, entity: Entity) => {
+  companyPortfolio: (orpc: ORPCQueryUtils, entity: Entity) => {
     const companyId = entity.kind === "company" ? entity.id : undefined;
 
     return {
-      ...orpc.brands.list.queryOptions({
+      ...orpc.entities.portfolio.queryOptions({
         input: {
-          limit: 4,
-          owner: companyId,
-          sort: "-bottles",
-        },
-      }),
-      enabled: Boolean(companyId),
-    };
-  },
-  companyDistilleries: (orpc: ORPCQueryUtils, entity: Entity) => {
-    const companyId = entity.kind === "company" ? entity.id : undefined;
-
-    return {
-      ...orpc.distilleries.list.queryOptions({
-        input: {
-          limit: 4,
-          owner: companyId,
-          sort: "-bottles",
-        },
-      }),
-      enabled: Boolean(companyId),
-    };
-  },
-  companyBottlersAndCompanies: (orpc: ORPCQueryUtils, entity: Entity) => {
-    const companyId = entity.kind === "company" ? entity.id : undefined;
-
-    return {
-      ...orpc.entities.list.queryOptions({
-        input: {
-          kinds: ["bottler", "company"],
-          limit: 4,
-          owner: companyId,
-          sort: "-bottles",
+          company: companyId ?? entity.id,
+          limit: 1,
         },
       }),
       enabled: Boolean(companyId),

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -45,32 +45,47 @@ describe("getEntityClassification", () => {
 });
 
 describe("getEntityTabs", () => {
-  it("keeps company bottles with stored counts but omits tastings", () => {
+  it("uses computed Company portfolio and Bottle totals", () => {
     expect(
-      getEntityTabs({
-        id: 5558,
-        kind: "company",
-        name: "Diageo",
-        shortName: null,
-        totalBottles: 10,
-        totalTastings: 20,
-      }),
+      getEntityTabs(
+        {
+          id: 5558,
+          kind: "company",
+          name: "Diageo",
+          shortName: null,
+          totalBottles: 10,
+          totalTastings: 20,
+        },
+        { bottles: 400, portfolio: 62 },
+      ),
     ).toEqual([
       { href: "/companies/5558-diageo", label: "Overview" },
-      { href: "/companies/5558-diageo/bottles", label: "Bottles", count: 10 },
+      {
+        href: "/companies/5558-diageo/portfolio",
+        label: "Portfolio",
+        count: 62,
+      },
+      {
+        href: "/companies/5558-diageo/bottles",
+        label: "Bottles",
+        count: 400,
+      },
     ]);
   });
 
   it("omits the bottle tab for companies with no bottles", () => {
     expect(
-      getEntityTabs({
-        id: 5558,
-        kind: "company",
-        name: "Diageo",
-        shortName: null,
-        totalBottles: 0,
-        totalTastings: 0,
-      }),
+      getEntityTabs(
+        {
+          id: 5558,
+          kind: "company",
+          name: "Diageo",
+          shortName: null,
+          totalBottles: 0,
+          totalTastings: 0,
+        },
+        { bottles: 0, portfolio: 0 },
+      ),
     ).toEqual([{ href: "/companies/5558-diageo", label: "Overview" }]);
   });
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -7,6 +7,10 @@ type EntityTabSource = Pick<
   Entity,
   "id" | "kind" | "name" | "shortName" | "totalBottles" | "totalTastings"
 >;
+export type CompanyPageCounts = {
+  bottles: number;
+  portfolio: number;
+};
 const entityKindPresentation = {
   bottler: {
     bottleSectionLabel: "Bottles",
@@ -66,15 +70,28 @@ export function getEntityLocationLabel(entity: Entity) {
 
 export function getEntityTabs(
   entity: EntityTabSource,
+  companyCounts?: CompanyPageCounts,
 ): [PageTabItem, ...PageTabItem[]] {
   const baseUrl = getEntityUrl(entity);
   const tabs: [PageTabItem, ...PageTabItem[]] = [
     { href: baseUrl, label: "Overview" },
   ];
 
-  if (entityHasBottleCatalog(entity) || entity.totalBottles > 0) {
+  if (entity.kind === "company" && companyCounts?.portfolio) {
     tabs.push({
-      count: entity.totalBottles,
+      count: companyCounts.portfolio,
+      href: `${baseUrl}/portfolio`,
+      label: "Portfolio",
+    });
+  }
+
+  const totalBottles =
+    entity.kind === "company"
+      ? (companyCounts?.bottles ?? entity.totalBottles)
+      : entity.totalBottles;
+  if (entityHasBottleCatalog(entity) || totalBottles > 0) {
+    tabs.push({
+      count: totalBottles,
       href: `${baseUrl}/bottles`,
       label: "Bottles",
     });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -29,6 +29,7 @@ import {
   getEntityCurrentHref,
   getEntityPresentation,
   getEntityTabs,
+  type CompanyPageCounts,
   type Entity,
 } from "./entityPageData";
 
@@ -145,9 +146,11 @@ function EntityActions({ entity }: { entity: Entity }) {
 
 export function EntityPageFrameClient({
   children,
+  companyCounts,
   initialEntity,
 }: {
   children: ReactNode;
+  companyCounts?: CompanyPageCounts;
   initialEntity: Entity;
 }) {
   const orpc = useORPC();
@@ -214,7 +217,7 @@ export function EntityPageFrameClient({
           <PageTabs
             ariaLabel={`${entity.name} sections`}
             currentHref={currentHref}
-            items={getEntityTabs(entity)}
+            items={getEntityTabs(entity, companyCounts)}
           />
         </div>
 

--- a/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
@@ -1,5 +1,9 @@
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
-import { getEntityPage } from "@peated/web/lib/entityPage.server";
+import {
+  getCompanyPageCounts,
+  getEntityPage,
+} from "@peated/web/lib/entityPage.server";
+import { logError } from "@peated/web/lib/log";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
 import { getEntitySeoMetadata } from "@peated/web/lib/seoMetadata";
 import { getSession } from "@peated/web/lib/session.server";
@@ -23,6 +27,14 @@ export default async function EntityLayout(props: {
 }) {
   const { entityId } = await props.params;
   const canonicalEntity = await getEntityPage(parseCatalogRouteId(entityId));
+  let companyCounts;
+  if (canonicalEntity.kind === "company") {
+    try {
+      companyCounts = await getCompanyPageCounts(canonicalEntity.id);
+    } catch (error) {
+      logError(error, { context: "company_page_counts" });
+    }
+  }
   const session = await getSession();
   // EntityLayout reuses public details; only members need a second read for following state.
   let entity = canonicalEntity;
@@ -54,7 +66,10 @@ export default async function EntityLayout(props: {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <EntityPageFrameClient initialEntity={entity}>
+      <EntityPageFrameClient
+        companyCounts={companyCounts}
+        initialEntity={entity}
+      >
         {props.children}
       </EntityPageFrameClient>
     </>

--- a/apps/web/src/app/(app)/entities/[entityId]/portfolio/companyPortfolioClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/portfolio/companyPortfolioClient.stylex.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import * as stylex from "@stylexjs/stylex";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useOptimistic, useTransition } from "react";
+
+import { PageTabs } from "@peated/web/components";
+import { EntityCatalogList } from "@peated/web/components/pages/entityCatalog.stylex";
+import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
+import { toEntityCatalogItem } from "@peated/web/lib/entityCatalogItem";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { space } from "../../../../../styles/tokens.stylex";
+
+import {
+  companyPortfolioKinds,
+  getCompanyPortfolioInput,
+  type CompanyPortfolioKind,
+} from "./companyPortfolioParams";
+
+type CompanyPortfolio = Outputs["entities"]["portfolio"];
+
+const sortOptions = [
+  { label: "Most bottles", value: "-bottles" },
+  { label: "Most tasted", value: "-tastings" },
+  { label: "Name", value: "name" },
+] as const;
+
+const kindLabels = {
+  brand: "Brands",
+  distillery: "Distilleries",
+  bottler: "Bottlers",
+} as const;
+
+export function CompanyPortfolioClient({
+  companyId,
+  companyName,
+  initialPortfolio,
+}: {
+  companyId: number;
+  companyName: string;
+  initialPortfolio: CompanyPortfolio;
+}) {
+  const orpc = useORPC();
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isNavigating, startTransition] = useTransition();
+  const [displayedParams, setDisplayedParams] = useOptimistic(
+    searchParams.toString(),
+  );
+  const displayedSearchParams = new URLSearchParams(displayedParams);
+  const queryInput = getCompanyPortfolioInput(companyId, searchParams);
+  const { data: portfolio, isFetching } = useSuspenseQuery({
+    ...orpc.entities.portfolio.queryOptions({ input: queryInput }),
+    initialData: initialPortfolio,
+  });
+  const selectedKind = companyPortfolioKinds.find(
+    (kind) => kind === displayedSearchParams.get("kind"),
+  );
+  const page = Number(searchParams.get("cursor") ?? "1") || 1;
+  const sort = displayedSearchParams.get("sort") ?? "-bottles";
+
+  function navigate(nextParams: URLSearchParams) {
+    startTransition(() => {
+      setDisplayedParams(nextParams.toString());
+      router.push(buildSearchHref(pathname, nextParams), { scroll: false });
+    });
+  }
+
+  function getKindHref(kind?: CompanyPortfolioKind) {
+    const nextParams = new URLSearchParams(searchParams);
+    if (kind) nextParams.set("kind", kind);
+    else nextParams.delete("kind");
+    nextParams.delete("cursor");
+    return buildSearchHref(pathname, nextParams);
+  }
+
+  function updateSort(value: string) {
+    const nextParams = new URLSearchParams(displayedSearchParams);
+    nextParams.set("sort", value);
+    nextParams.delete("cursor");
+    navigate(nextParams);
+  }
+
+  const noun = selectedKind
+    ? kindLabels[selectedKind]
+        .toLowerCase()
+        .replace(/ies$/, "y")
+        .replace(/s$/, "")
+    : "result";
+  const items = portfolio.results.map((entity) => {
+    const ownerPath = entity.ownershipPath
+      .slice(1)
+      .map(({ name }) => name)
+      .join(" › ");
+
+    return {
+      ...toEntityCatalogItem(entity),
+      ownerPath: ownerPath || undefined,
+    };
+  });
+
+  return (
+    <div {...stylex.props(styles.content)}>
+      <div {...stylex.props(styles.views)}>
+        <PageTabs
+          ariaLabel={`${companyName} portfolio filters`}
+          currentHref={getKindHref(selectedKind)}
+          items={[
+            {
+              count: portfolio.totals.all,
+              href: getKindHref(),
+              label: "All",
+            },
+            {
+              count: portfolio.totals.brands,
+              href: getKindHref("brand"),
+              label: "Brands",
+            },
+            {
+              count: portfolio.totals.distilleries,
+              href: getKindHref("distillery"),
+              label: "Distilleries",
+            },
+            {
+              count: portfolio.totals.bottlers,
+              href: getKindHref("bottler"),
+              label: "Bottlers",
+            },
+          ]}
+        />
+      </div>
+      <EntityCatalogList
+        emptyDescription={
+          selectedKind
+            ? `No recorded ${noun}s are part of ${companyName}.`
+            : `${companyName} has no recorded brands, distilleries, or bottlers.`
+        }
+        emptyHeading={selectedKind ? `No ${noun}s yet` : "No portfolio yet"}
+        items={items}
+        nextHref={getCursorHref(
+          pathname,
+          searchParams,
+          portfolio.rel.nextCursor,
+        )}
+        noun={noun}
+        onSortChange={updateSort}
+        page={page}
+        pending={isNavigating || isFetching}
+        previousHref={getCursorHref(
+          pathname,
+          searchParams,
+          portfolio.rel.prevCursor,
+        )}
+        sort={sort}
+        sortOptions={sortOptions}
+        total={portfolio.total}
+      />
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  content: {
+    minWidth: 0,
+    paddingTop: space.x6,
+  },
+  views: {
+    marginBottom: space.x6,
+  },
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/portfolio/companyPortfolioParams.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/portfolio/companyPortfolioParams.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { getCompanyPortfolioInput } from "./companyPortfolioParams";
+
+describe("getCompanyPortfolioInput", () => {
+  it("maps a URL kind to the Company portfolio contract", () => {
+    expect(
+      getCompanyPortfolioInput(
+        1383,
+        new URLSearchParams({
+          cursor: "2",
+          kind: "brand",
+          sort: "name",
+        }),
+      ),
+    ).toEqual({
+      company: 1383,
+      cursor: 2,
+      kinds: ["brand"],
+      limit: 25,
+      sort: "name",
+    });
+  });
+
+  it("drops unknown filters and uses stable defaults", () => {
+    expect(
+      getCompanyPortfolioInput(
+        1383,
+        new URLSearchParams({
+          cursor: "nope",
+          kind: "company",
+          sort: "newest",
+        }),
+      ),
+    ).toEqual({
+      company: 1383,
+      cursor: 1,
+      kinds: undefined,
+      limit: 25,
+      sort: "-bottles",
+    });
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/portfolio/companyPortfolioParams.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/portfolio/companyPortfolioParams.ts
@@ -1,0 +1,43 @@
+import { CompanyPortfolioInputSchema } from "@peated/server/orpc/contracts/entities/portfolio";
+import {
+  getApiQueryParams,
+  type SearchParamSource,
+} from "@peated/web/lib/apiQueryParams";
+
+export const companyPortfolioKinds = [
+  "brand",
+  "distillery",
+  "bottler",
+] as const;
+export type CompanyPortfolioKind = (typeof companyPortfolioKinds)[number];
+
+export const companyPortfolioSorts = [
+  "-bottles",
+  "-tastings",
+  "name",
+  "-name",
+  "bottles",
+  "tastings",
+] as const;
+
+export function getCompanyPortfolioInput(
+  company: number,
+  searchParams: SearchParamSource,
+) {
+  const params = getApiQueryParams(searchParams, {
+    allowedValues: {
+      kind: companyPortfolioKinds,
+      sort: companyPortfolioSorts,
+    },
+    defaults: { cursor: 1, sort: "-bottles" },
+    fields: ["cursor", "kind", "sort"],
+    numericFields: ["cursor"],
+  });
+  return CompanyPortfolioInputSchema.parse({
+    company,
+    cursor: Number(params.cursor),
+    kinds: params.kind ? [params.kind] : undefined,
+    limit: 25,
+    sort: params.sort,
+  });
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/portfolio/loading.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/portfolio/loading.tsx
@@ -1,0 +1,5 @@
+import { EntityTabLoading } from "../entityTabLoading.stylex";
+
+export default function CompanyPortfolioLoading() {
+  return <EntityTabLoading label="Loading whisky portfolio" />;
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/portfolio/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/portfolio/page.tsx
@@ -1,0 +1,35 @@
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+import { getEntityPage } from "@peated/web/lib/entityPage.server";
+import { getPageCompanyPortfolio } from "@peated/web/lib/publicCatalog.server";
+import { getEntityUrl } from "@peated/web/lib/urls";
+import { redirect } from "next/navigation";
+
+import { CompanyPortfolioClient } from "./companyPortfolioClient.stylex";
+import { getCompanyPortfolioInput } from "./companyPortfolioParams";
+
+export default async function CompanyPortfolioPage(props: {
+  params: Promise<{ entityId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { entityId } = await props.params;
+  const searchParams = await props.searchParams;
+  const entity = await getEntityPage(parseCatalogRouteId(entityId));
+  if (entity.kind !== "company") {
+    redirect(getEntityUrl(entity));
+  }
+
+  const portfolio = await getPageCompanyPortfolio(
+    getCompanyPortfolioInput(entity.id, searchParams),
+  );
+  if (!portfolio.totals.all) {
+    redirect(getEntityUrl(entity));
+  }
+
+  return (
+    <CompanyPortfolioClient
+      companyId={entity.id}
+      companyName={entity.name}
+      initialPortfolio={portfolio}
+    />
+  );
+}

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -24,6 +24,7 @@ export type EntityCatalogItem = EntityListItem & {
   createBottleHref?: string;
   id: number;
   isFollowing: boolean;
+  ownerPath?: string;
   totalBottles: number;
   totalTastings: number;
 };
@@ -201,6 +202,15 @@ function EntityCatalogTable({
       width: "count",
     },
   ];
+
+  if (items.some((item) => item.ownerPath)) {
+    columns.splice(1, 0, {
+      cell: (item) => item.ownerPath ?? "",
+      header: "Part of",
+      key: "owner",
+      priority: "secondary",
+    });
+  }
 
   if (onToggleFollowing || items.some((item) => item.createBottleHref)) {
     columns.push({

--- a/apps/web/src/components/pages/entityCatalog.test.tsx
+++ b/apps/web/src/components/pages/entityCatalog.test.tsx
@@ -1,6 +1,8 @@
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  EntityCatalogList,
   getEntityRowActionGroups,
   type EntityCatalogItem,
 } from "./entityCatalog.stylex";
@@ -65,5 +67,29 @@ describe("getEntityRowActionGroups", () => {
       disabled: false,
       label: "Follow",
     });
+  });
+});
+
+describe("EntityCatalogList", () => {
+  it("shows recorded owner paths when the caller supplies them", () => {
+    const html = renderToStaticMarkup(
+      <EntityCatalogList
+        items={[
+          {
+            ...item,
+            ownerPath: "Suntory Global Spirits › Jim Beam",
+          },
+        ]}
+        noun="result"
+        onSortChange={() => undefined}
+        page={1}
+        sort="-bottles"
+        sortOptions={[{ label: "Most bottles", value: "-bottles" }]}
+        total={1}
+      />,
+    );
+
+    expect(html).toContain("Part of");
+    expect(html).toContain("Suntory Global Spirits › Jim Beam");
   });
 });

--- a/apps/web/src/lib/bottleCatalogQueryParams.ts
+++ b/apps/web/src/lib/bottleCatalogQueryParams.ts
@@ -13,6 +13,7 @@ export const BOTTLE_CATALOG_QUERY_FIELDS = [
   "brand",
   "bottler",
   "category",
+  "company",
   "cursor",
   "distiller",
   "entity",

--- a/apps/web/src/lib/entityPage.server.ts
+++ b/apps/web/src/lib/entityPage.server.ts
@@ -11,3 +11,18 @@ async function loadEntityPage(entityId: number) {
 }
 
 export const getEntityPage = cache(loadEntityPage);
+
+async function loadCompanyPageCounts(company: number) {
+  const { client } = await getAnonymousServerClient();
+  const [portfolio, bottles] = await Promise.all([
+    client.entities.portfolio({ company, limit: 1 }),
+    client.bottles.list({ company, limit: 1 }),
+  ]);
+
+  return {
+    bottles: bottles.total,
+    portfolio: portfolio.totals.all,
+  };
+}
+
+export const getCompanyPageCounts = cache(loadCompanyPageCounts);

--- a/apps/web/src/lib/publicCatalog.server.ts
+++ b/apps/web/src/lib/publicCatalog.server.ts
@@ -1,6 +1,7 @@
 "server only";
 
 import { BottleListInputSchema } from "@peated/server/orpc/contracts/bottles/list";
+import { CompanyPortfolioInputSchema } from "@peated/server/orpc/contracts/entities/portfolio";
 import type { Inputs } from "@peated/server/orpc/router";
 import { unstable_cache } from "next/cache";
 import {
@@ -10,6 +11,7 @@ import {
 import { getSession } from "./session.server";
 
 type BottleListInput = Inputs["bottles"]["list"];
+type CompanyPortfolioInput = Inputs["entities"]["portfolio"];
 
 const loadEntityCatalog = unstable_cache(
   async (entity: number) => {
@@ -23,15 +25,44 @@ const loadEntityCatalog = unstable_cache(
 const loadBottleList = unstable_cache(
   async (
     entity: number | null,
+    company: number | null,
     series: number | null,
     distilleryView: BottleListInput["distilleryView"],
     sort: BottleListInput["sort"],
     limit: number,
   ) => {
     const { client } = await createAnonymousServerClient();
-    return client.bottles.list({ entity, series, distilleryView, sort, limit });
+    return client.bottles.list({
+      entity,
+      company,
+      series,
+      distilleryView,
+      sort,
+      limit,
+    });
   },
   ["public-catalog-bottles"],
+  { revalidate: 300 },
+);
+
+const loadCompanyPortfolio = unstable_cache(
+  async (
+    company: number,
+    kinds: CompanyPortfolioInput["kinds"],
+    cursor: number,
+    limit: number,
+    sort: CompanyPortfolioInput["sort"],
+  ) => {
+    const { client } = await createAnonymousServerClient();
+    return client.entities.portfolio({
+      company,
+      kinds,
+      cursor,
+      limit,
+      sort,
+    });
+  },
+  ["public-company-portfolio"],
   { revalidate: 300 },
 );
 
@@ -55,6 +86,7 @@ export async function getPageBottleList(input: BottleListInput) {
   }
   const {
     entity,
+    company,
     series,
     distilleryView,
     sort,
@@ -67,7 +99,7 @@ export async function getPageBottleList(input: BottleListInput) {
 
   // Public catalog caching owns anonymous snapshots, never Library or following state.
   if (
-    (!entity && !series) ||
+    (!entity && !company && !series) ||
     cursor !== 1 ||
     query ||
     filter !== "all" ||
@@ -79,9 +111,23 @@ export async function getPageBottleList(input: BottleListInput) {
 
   return loadBottleList(
     entity ?? null,
+    company ?? null,
     series ?? null,
     distilleryView ?? null,
     sort,
     limit,
   );
+}
+
+/** Caches public Company portfolio pages and their exact category totals. */
+export async function getPageCompanyPortfolio(input: CompanyPortfolioInput) {
+  const session = await getSession();
+  const parsed = CompanyPortfolioInputSchema.safeParse(input);
+  if (session.accessToken || !parsed.success) {
+    const { client } = await getPublicPageServerClient();
+    return client.entities.portfolio(input);
+  }
+
+  const { company, kinds, cursor, limit, sort } = parsed.data;
+  return loadCompanyPortfolio(company, kinds, cursor, limit, sort);
 }

--- a/openspec/changes/improve-company-pages/.openspec.yaml
+++ b/openspec/changes/improve-company-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/improve-company-pages/company-page-prototype.html
+++ b/openspec/changes/improve-company-pages/company-page-prototype.html
@@ -1,0 +1,741 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Suntory company page directions</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --ground: #101210;
+        --surface: #1b1e1a;
+        --inset: #292d27;
+        --ink: #e8eae3;
+        --muted: rgb(232 234 227 / 0.68);
+        --hairline: rgb(232 234 227 / 0.1);
+        --rule: rgb(232 234 227 / 0.16);
+        --accent: #d9922f;
+        --display: "Space Grotesk", "Arial Narrow", sans-serif;
+        --reading: Karla, system-ui, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--ground);
+        color: var(--ink);
+        font: 15px/1.5 var(--reading);
+      }
+      button,
+      input {
+        font: inherit;
+      }
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+      a:hover,
+      a:focus-visible,
+      button:focus-visible {
+        color: var(--accent);
+        outline: none;
+      }
+      .direction-bar {
+        position: sticky;
+        z-index: 10;
+        top: 0;
+        display: grid;
+        grid-template-columns: minmax(210px, 0.7fr) minmax(0, 1.3fr);
+        gap: 24px;
+        padding: 16px max(24px, calc((100vw - 1180px) / 2));
+        border-bottom: 1px solid var(--rule);
+        background: rgb(16 18 16 / 0.96);
+        backdrop-filter: blur(12px);
+      }
+      .direction-bar__eyebrow {
+        display: block;
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .direction-bar__title {
+        margin-top: 2px;
+        font: 700 17px/1.25 var(--display);
+      }
+      .direction-picker {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        justify-content: flex-end;
+      }
+      .direction-button {
+        min-height: 38px;
+        padding: 7px 12px;
+        border: 1px solid var(--rule);
+        border-radius: 3px;
+        background: transparent;
+        color: var(--muted);
+        cursor: pointer;
+      }
+      .direction-button[aria-pressed="true"] {
+        border-color: var(--accent);
+        background: rgb(217 146 47 / 0.1);
+        color: var(--ink);
+      }
+      .direction-note {
+        grid-column: 1 / -1;
+        margin: -8px 0 0;
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .site-header {
+        border-bottom: 1px solid var(--rule);
+      }
+      .site-header__inner,
+      main {
+        width: min(1180px, calc(100% - 48px));
+        margin: 0 auto;
+      }
+      .site-header__inner {
+        min-height: 64px;
+        display: flex;
+        align-items: center;
+        gap: 30px;
+      }
+      .logo {
+        font: 700 21px/1 var(--display);
+        letter-spacing: -0.04em;
+      }
+      .search {
+        width: min(520px, 50vw);
+        height: 38px;
+        padding: 0 12px;
+        border: 0;
+        border-radius: 3px;
+        background: var(--inset);
+        color: var(--ink);
+      }
+      .header {
+        padding: 46px 0 24px;
+      }
+      h1,
+      h2 {
+        font-family: var(--display);
+      }
+      h1 {
+        margin: 0;
+        font-size: clamp(44px, 7vw, 68px);
+        line-height: 0.98;
+        letter-spacing: -0.055em;
+      }
+      .kind {
+        margin-top: 8px;
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .description {
+        max-width: 710px;
+        margin: 18px 0 0;
+        line-height: 1.65;
+      }
+      .tabs {
+        display: flex;
+        gap: 28px;
+        min-height: 46px;
+        border-bottom: 1px solid var(--rule);
+      }
+      .tab {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        border-bottom: 2px solid transparent;
+        font-weight: 700;
+      }
+      .tab.active {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      .count {
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 600;
+      }
+      .overview {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 336px;
+        gap: 48px;
+        align-items: start;
+      }
+      .facts {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 16px;
+        padding: 24px 0 0;
+      }
+      .fact dt {
+        color: var(--muted);
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .fact dd {
+        margin: 2px 0 0;
+      }
+      .section {
+        padding-top: 34px;
+      }
+      .section-heading {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 20px;
+        padding-bottom: 11px;
+      }
+      h2 {
+        margin: 0;
+        font-size: 20px;
+        line-height: 1.2;
+        letter-spacing: -0.025em;
+      }
+      .section-action {
+        flex: none;
+        color: var(--accent);
+        font-size: 13px;
+        font-weight: 700;
+      }
+      .rows {
+        border-top: 1px solid var(--hairline);
+      }
+      .row {
+        min-height: 66px;
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 20px;
+        align-items: center;
+        padding: 10px 0;
+        border-bottom: 1px solid var(--hairline);
+      }
+      .row__name {
+        display: block;
+        font: 700 17px/1.25 var(--display);
+        letter-spacing: -0.02em;
+      }
+      .row__meta,
+      .row__path,
+      .section-intro {
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .row__path {
+        max-width: 230px;
+        text-align: right;
+      }
+      .section-intro {
+        max-width: 600px;
+        margin: -2px 0 14px;
+      }
+      .sidebar {
+        padding-top: 24px;
+      }
+      .image-placeholder {
+        aspect-ratio: 8 / 5;
+        display: grid;
+        place-items: center;
+        border: 1px solid var(--hairline);
+        border-radius: 3px;
+        background: repeating-linear-gradient(
+          45deg,
+          var(--surface),
+          var(--surface) 10px,
+          var(--ground) 10px,
+          var(--ground) 20px
+        );
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .sidebar .row {
+        min-height: 58px;
+        display: block;
+      }
+      .sidebar .row__name {
+        font-size: 15px;
+      }
+      .ownership-note {
+        margin: 22px 0 48px;
+        padding-top: 14px;
+        border-top: 1px solid var(--hairline);
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .variant {
+        display: none;
+      }
+      body[data-variant="minimal"] .variant--minimal,
+      body[data-variant="categorized"] .variant--categorized,
+      body[data-variant="combined"] .variant--combined {
+        display: block;
+      }
+      body[data-variant="minimal"] .portfolio-tab {
+        display: none;
+      }
+      @media (max-width: 820px) {
+        .direction-bar {
+          position: static;
+          display: block;
+          padding: 16px 20px;
+        }
+        .direction-picker {
+          justify-content: flex-start;
+          margin-top: 12px;
+          overflow-x: auto;
+        }
+        .direction-button {
+          flex: none;
+        }
+        .direction-note {
+          margin-top: 10px;
+        }
+        .site-header__inner,
+        main {
+          width: min(100% - 32px, 600px);
+        }
+        .site-header__inner {
+          gap: 16px;
+        }
+        .search {
+          flex: 1;
+          width: auto;
+        }
+        .header {
+          padding-top: 32px;
+        }
+        .tabs {
+          gap: 20px;
+          overflow-x: auto;
+        }
+        .overview {
+          display: flex;
+          flex-direction: column;
+          gap: 0;
+        }
+        .sidebar {
+          width: 100%;
+          order: -1;
+        }
+        .image-placeholder {
+          margin-top: 8px;
+        }
+        .facts {
+          grid-template-columns: 1fr 1fr;
+        }
+        .row {
+          grid-template-columns: minmax(0, 1fr);
+          gap: 3px;
+        }
+        .row__path {
+          max-width: none;
+          text-align: left;
+        }
+      }
+    </style>
+  </head>
+  <body data-variant="categorized">
+    <section class="direction-bar" aria-label="Design direction picker">
+      <div>
+        <span class="direction-bar__eyebrow">Company page study</span>
+        <div class="direction-bar__title">
+          Choose how the portfolio is grouped
+        </div>
+      </div>
+      <div class="direction-picker">
+        <button
+          class="direction-button"
+          data-choose="minimal"
+          aria-pressed="false"
+        >
+          A · Minimal
+        </button>
+        <button
+          class="direction-button"
+          data-choose="categorized"
+          aria-pressed="true"
+        >
+          B · Categorized
+        </button>
+        <button
+          class="direction-button"
+          data-choose="combined"
+          aria-pressed="false"
+        >
+          C · Combined
+        </button>
+      </div>
+      <p class="direction-note" id="direction-note">
+        Recommended — familiar sections, complete descendant counts, and direct
+        companies in the same group kept separate.
+      </p>
+    </section>
+
+    <header class="site-header">
+      <div class="site-header__inner">
+        <a class="logo" href="#">Peated</a>
+        <input
+          class="search"
+          aria-label="Search"
+          placeholder="bottles, series, distillers, brands…"
+        />
+      </div>
+    </header>
+
+    <main>
+      <header class="header">
+        <h1>Suntory</h1>
+        <div class="kind">Company</div>
+        <p class="description">
+          Suntory is a Japanese drinks company founded by Shinjiro Torii in
+          1899. Its whisky portfolio includes Yamazaki, Hakushu, Hibiki, Toki,
+          and Kakubin.
+        </p>
+      </header>
+
+      <nav class="tabs" aria-label="Suntory sections">
+        <a class="tab active" href="#">Overview</a>
+        <a class="tab portfolio-tab" href="#"
+          >Portfolio <span class="count">55</span></a
+        >
+        <a class="tab" href="#">Bottles</a>
+      </nav>
+
+      <div class="overview">
+        <div class="main">
+          <dl class="facts">
+            <div class="fact">
+              <dt>Region</dt>
+              <dd>Japan</dd>
+            </div>
+            <div class="fact">
+              <dt>Established</dt>
+              <dd>1899</dd>
+            </div>
+            <div class="fact">
+              <dt>Website</dt>
+              <dd><a href="#">suntory.com</a></dd>
+            </div>
+          </dl>
+
+          <div class="variant variant--minimal">
+            <section class="section">
+              <div class="section-heading">
+                <h2>Brands</h2>
+                <a class="section-action" href="#">View all 37</a>
+              </div>
+              <div class="rows">
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Jim Beam</span
+                    ><span class="row__meta">Brand · United States</span></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Maker’s Mark</span
+                    ><span class="row__meta">Brand · United States</span></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Hibiki</span
+                    ><span class="row__meta">Brand · Japan</span></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Canadian Club</span
+                    ><span class="row__meta">Brand · Canada</span></span
+                  ></a
+                >
+              </div>
+            </section>
+            <section class="section">
+              <div class="section-heading">
+                <h2>Distilleries</h2>
+                <a class="section-action" href="#">View all 14</a>
+              </div>
+              <div class="rows">
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Yamazaki</span
+                    ><span class="row__meta"
+                      >Distillery · Osaka, Japan</span
+                    ></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Laphroaig</span
+                    ><span class="row__meta"
+                      >Distillery · Islay, Scotland</span
+                    ></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Bowmore</span
+                    ><span class="row__meta"
+                      >Distillery · Islay, Scotland</span
+                    ></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Hakushu</span
+                    ><span class="row__meta">Distillery · Japan</span></span
+                  ></a
+                >
+              </div>
+            </section>
+            <section class="section">
+              <div class="section-heading">
+                <h2>Operates</h2>
+                <a class="section-action" href="#">View all 9</a>
+              </div>
+              <div class="rows">
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Suntory Global Spirits</span
+                    ><span class="row__meta"
+                      >Company · United States</span
+                    ></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Morrison Bowmore Distillers</span
+                    ><span class="row__meta">Company · Scotland</span></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Jim Beam</span
+                    ><span class="row__meta"
+                      >Company · United States</span
+                    ></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Bellows &amp; Company</span
+                    ><span class="row__meta"
+                      >Company · United States</span
+                    ></span
+                  ></a
+                >
+              </div>
+            </section>
+          </div>
+
+          <div class="variant variant--categorized">
+            <section class="section">
+              <div class="section-heading">
+                <h2>Brands <span class="count">37</span></h2>
+                <a class="section-action" href="#">View all</a>
+              </div>
+              <div class="rows">
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Jim Beam</span
+                    ><span class="row__meta">Brand · United States</span></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Maker’s Mark</span
+                    ><span class="row__meta">Brand · United States</span></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Hibiki</span
+                    ><span class="row__meta">Brand · Japan</span></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Canadian Club</span
+                    ><span class="row__meta">Brand · Canada</span></span
+                  ></a
+                >
+              </div>
+            </section>
+            <section class="section">
+              <div class="section-heading">
+                <h2>Distilleries <span class="count">14</span></h2>
+                <a class="section-action" href="#">View all</a>
+              </div>
+              <div class="rows">
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Yamazaki</span
+                    ><span class="row__meta"
+                      >Distillery · Osaka, Japan</span
+                    ></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Laphroaig</span
+                    ><span class="row__meta"
+                      >Distillery · Islay, Scotland</span
+                    ></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Bowmore</span
+                    ><span class="row__meta"
+                      >Distillery · Islay, Scotland</span
+                    ></span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Hakushu</span
+                    ><span class="row__meta">Distillery · Japan</span></span
+                  ></a
+                >
+              </div>
+            </section>
+            <section class="section">
+              <div class="section-heading">
+                <h2>Bottlers <span class="count">4</span></h2>
+                <a class="section-action" href="#">View all</a>
+              </div>
+              <p class="section-intro">
+                Shown only when the company has recorded bottlers.
+              </p>
+            </section>
+          </div>
+
+          <div class="variant variant--combined">
+            <section class="section">
+              <div class="section-heading">
+                <h2>Whisky portfolio</h2>
+                <a class="section-action" href="#">View all 55</a>
+              </div>
+              <p class="section-intro">
+                Brands, distilleries, and bottlers in one list, ordered by
+                catalog activity.
+              </p>
+              <div class="rows">
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Jim Beam</span
+                    ><span class="row__meta">Brand · United States</span></span
+                  ><span class="row__path">via Suntory Global Spirits</span></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Yamazaki</span
+                    ><span class="row__meta"
+                      >Distillery · Osaka, Japan</span
+                    ></span
+                  ><span class="row__path">via Suntory Global Spirits</span></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Laphroaig</span
+                    ><span class="row__meta"
+                      >Distillery · Islay, Scotland</span
+                    ></span
+                  ><span class="row__path">via Suntory Global Spirits</span></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Hibiki</span
+                    ><span class="row__meta">Brand · Japan</span></span
+                  ><span class="row__path">via Suntory Global Spirits</span></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Bowmore</span
+                    ><span class="row__meta"
+                      >Distillery · Islay, Scotland</span
+                    ></span
+                  ><span class="row__path"
+                    >via Morrison Bowmore Distillers</span
+                  ></a
+                >
+                <a class="row" href="#"
+                  ><span
+                    ><span class="row__name">Maker’s Mark</span
+                    ><span class="row__meta">Brand · United States</span></span
+                  ><span class="row__path">via Suntory Global Spirits</span></a
+                >
+              </div>
+            </section>
+          </div>
+        </div>
+
+        <aside class="sidebar">
+          <div class="image-placeholder">No company image</div>
+          <div class="variant variant--categorized variant--combined">
+            <section class="section">
+              <div class="section-heading">
+                <h2>Companies in this group</h2>
+              </div>
+              <div class="rows">
+                <a class="row" href="#"
+                  ><span class="row__name">Suntory Global Spirits</span
+                  ><span class="row__meta">Company · United States</span></a
+                >
+                <a class="row" href="#"
+                  ><span class="row__name">Bellows &amp; Company</span
+                  ><span class="row__meta">Company · United States</span></a
+                >
+              </div>
+            </section>
+            <p class="ownership-note">
+              Portfolio sections follow every recorded “Part of” link. Group
+              companies lists only Suntory’s direct company relationships.
+            </p>
+          </div>
+          <div class="variant variant--minimal">
+            <p class="ownership-note">
+              The current sections are unchanged visually; only their queries
+              and totals become recursive.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </main>
+
+    <script>
+      const descriptions = {
+        minimal:
+          "Smallest change — the current Brands, Distilleries, and Operates sections simply include every descendant.",
+        categorized:
+          "Recommended — familiar sections, complete descendant counts, and directly owned companies kept separate.",
+        combined:
+          "Most compact — one mixed portfolio list makes indirect ownership explicit, but is harder to scan by type.",
+      };
+      for (const button of document.querySelectorAll("[data-choose]")) {
+        button.addEventListener("click", () => {
+          const variant = button.dataset.choose;
+          document.body.dataset.variant = variant;
+          document.querySelector("#direction-note").textContent =
+            descriptions[variant];
+          for (const peer of document.querySelectorAll("[data-choose]")) {
+            peer.setAttribute("aria-pressed", String(peer === button));
+          }
+          localStorage.setItem("company-page-variant", variant);
+        });
+      }
+      const saved = localStorage.getItem("company-page-variant");
+      if (saved && descriptions[saved]) {
+        document.querySelector(`[data-choose="${saved}"]`).click();
+      }
+    </script>
+  </body>
+</html>

--- a/openspec/changes/improve-company-pages/design.md
+++ b/openspec/changes/improve-company-pages/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Company pages reuse the Entity detail frame but do not have a company-scoped catalog. Their overview makes three direct-owner requests—Brands, Distilleries, and bottlers or Companies—each limited to four results. Companies are also excluded from ordinary Entity catalog queries, so popular Bottles and latest releases do not appear unless a Bottle happens to reference the Company itself.
+
+That behavior exposes the storage hierarchy instead of the useful catalog relationship. Suntory currently has 60 descendants across four ownership levels, including 55 non-Company portfolio Entities, but its overview can show only its directly owned slice. The existing `ownerId` tree, owner index, cycle validation, Entity kinds, and Bottle relationships already contain enough information to compute the intended view.
+
+The non-normative [company page prototype](./company-page-prototype.html) shows the proposed hierarchy and responsive composition with current Suntory data. It follows the existing Entity page frame, typography, colors, flat sections, shared identity rows, and narrow-screen ordering.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make a Company page answer which whisky brands and producers are part of its recorded group.
+- Preserve meaningful intermediate Companies while removing the need to visit each one to discover the portfolio.
+- Provide complete, filterable Portfolio and Bottle collections with exact totals.
+- Reuse the current Entity and Bottle identity rows and the established detail-page composition.
+- Keep recursive reads deterministic, cycle-safe, and efficient on the indexed owner tree.
+
+**Non-Goals:**
+
+- Changing `ownerId`, Entity kinds, ownership history, or the rules for creating a Company.
+- Adding multiple owners, ownership percentages, legal-entity metadata, or a general relationship graph.
+- Editing or backfilling production ownership data.
+- Showing a nested corporate organization chart.
+- Adding a new visual system or universal catalog-page abstraction.
+
+## Decisions
+
+### Derive one portfolio from the existing owner tree
+
+Add a Company portfolio read that starts at one Company and follows `entities.ownerId` through every descendant level. The portfolio contains descendant Brands, Distilleries, and Bottlers once each; descendant Companies carry the traversal but appear only in the separate group-company presentation. Each portfolio result includes its immediate owner and its ordered path from the requested Company so a complete collection can explain indirect membership when needed.
+
+The server will use a recursive CTE with a visited-id path in addition to existing write-time loop checks. Results use the established Entity serializer, deterministic sort tie-breakers, bounded pagination, and an exact total.
+
+Alternative: flatten every portfolio Entity onto the ultimate Company. Rejected because it discards meaningful intermediate ownership and turns a single company acquisition into many unrelated owner updates.
+
+Alternative: merge intermediate Companies such as Suntory Global Spirits into their parents. Rejected because a recognizable portfolio company with its own ownership history is useful catalog structure even when visitors normally browse from the parent.
+
+### Keep the familiar categories and separate group structure
+
+The overview retains the current **Brands** and **Distilleries** sections, but each preview uses the complete descendant portfolio rather than only direct children. A **Bottlers** section appears when matching descendants exist. Each heading shows its exact total and links into the full Portfolio collection with that kind selected.
+
+The side column uses **Companies in this group** for directly owned Companies only. It does not recursively repeat the company tree or include Bottlers. A visitor can follow a Company row to inspect that intermediate company.
+
+The overview keeps the existing facts, media, and other available sections. It does not add popular-Bottle, latest-release, metric, or ownership-chart widgets. The purpose of this change is to make the existing company information complete, not turn the page into a dashboard.
+
+Alternative: replace the categories with one mixed Whisky portfolio list. Rejected because visitors commonly arrive looking for either a Brand or producer, and the current headings already support that scan.
+
+Alternative: render an expandable organization tree. Rejected because the common task is finding whisky, not studying corporate structure, and deep trees work poorly in the existing narrow column and on mobile.
+
+### Give Companies first-class Portfolio and Bottles collections
+
+Company tabs become Overview, Portfolio, and Bottles when the corresponding computed totals are nonzero. `/companies/{company}/portfolio` lists the complete descendant portfolio with kind filters, normal pagination, and sorting. Overview **View all** links open this collection with Brands, Distilleries, or Bottlers selected. `/companies/{company}/bottles` lists the group's active Bottles under the same header.
+
+The Bottle list contract gains a Company scope. A Bottle matches when its Brand, Bottler, or any Distiller is the Company itself or one of its descendants. SQL returns each Bottle once even when several matching descendants appear on the same Bottle. Overview previews and the Bottle tab use this same rule, so their counts cannot disagree.
+
+Company totals are computed live rather than copied into the existing Entity counters. Summing descendant counters was rejected because one Bottle can reference several descendants and would be counted more than once. Stored Company aggregate counters were rejected because they would add update fanout, a migration, and another stale-data risk without a current need.
+
+### Keep the page dense and consistent with other catalog pages
+
+The existing Entity frame, `PageHeader`, `PageTabs`, two-column overview, `PageSection`, `EntityIdentityRow`, `BottleIdentityRow`, `RailList`, loading rows, and section errors remain the visual vocabulary. The main column owns the categorized portfolio previews; the 336px side column owns media and direct group-company context. The established mobile order is retained.
+
+No ownership badges, cards, tree lines, decorative counts, or new accent colors are introduced. Ownership-path text is supporting context on the complete Portfolio list, not part of the reusable Entity identity row.
+
+### Treat partial data and failures as ordinary states
+
+A Company with no recorded descendants omits Portfolio and Companies in this group and retains its ordinary facts and history. A Company with direct Bottle relationships but no descendants can still expose Bottles. Each overview query keeps its current local loading, error, and retry state so a failed portfolio request does not replace the entire page.
+
+## Risks / Trade-offs
+
+- [A large ownership tree makes recursive reads or distinct Bottle matching slow] → Use the owner index, bound page sizes, inspect representative query plans, cache public page reads through existing boundaries, and avoid stored aggregates until measurements justify them.
+- [Bad or missing owner links produce an incomplete portfolio] → Present recorded relationships without inference; this change does not silently repair catalog data.
+- [One Bottle matches several descendants] → Count and paginate distinct Bottle IDs before serialization.
+- [A loop introduced outside the application could make recursion unsafe] → Track visited IDs in the recursive query and retain current write-time loop rejection.
+- [Several category sections make long pages] → Keep four-row previews, omit empty kinds, and route complete browsing through one filterable Portfolio collection.
+
+## Migration Plan
+
+1. Add and verify the recursive portfolio read and Company-scoped Bottle filtering without changing existing callers.
+2. Add the Portfolio route and Company tab behavior, then switch the Company overview to the new queries.
+3. Verify direct-only, nested, deep, empty, and duplicate-Bottle cases with deterministic tests and desktop/mobile browser QA.
+4. Deploy without production data writes. If the UI must roll back, restore the previous overview and tabs; the additive read contracts can remain.
+
+## Open Questions
+
+None.

--- a/openspec/changes/improve-company-pages/proposal.md
+++ b/openspec/changes/improve-company-pages/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Company overviews expose only a four-item preview of directly owned Entities, so a company with a meaningful ownership chain appears to have a small or empty whisky portfolio. Visitors should be able to understand and browse the complete whisky portfolio without knowing the corporate structure stored between the company and its brands or producers.
+
+## What Changes
+
+- Add a company portfolio read that follows the existing current-owner chain and returns descendant whisky Entities with their ownership path.
+- Keep the existing Brands and Distilleries sections, but populate them from the complete descendant portfolio and show exact totals.
+- Separate recursive Bottlers from directly owned Companies so the page does not mix whisky roles with company structure.
+- Give Company pages a Bottles section whose count and results cover distinct active Bottles associated with the company or any descendant portfolio Entity.
+- Replace silent four-item truncation with explicit totals and links to complete, paginated portfolio and Bottle collections.
+- Preserve the current Entity kinds, single `ownerId`, owner history, Company records, IDs, URLs, and ownership data.
+- Omit empty optional sections and keep failures local to the section that could not load.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `entity-identity`: Expand Company page behavior from direct-owned previews to a complete descendant whisky portfolio while retaining direct company relationships as supporting group structure.
+
+## Impact
+
+- Entity and Bottle list contracts and server routes need company-descendant filters and distinct totals.
+- Company overview queries, tabs, the nested Portfolio collection, mock API data, and focused web tests will change.
+- Existing shared page sections, Entity rows, Bottle rows, and pagination controls will be reused; the visual design system and ownership model do not change.
+- No migration, backfill, production catalog write, dependency, or public URL replacement is required.

--- a/openspec/changes/improve-company-pages/specs/entity-identity/spec.md
+++ b/openspec/changes/improve-company-pages/specs/entity-identity/spec.md
@@ -1,0 +1,106 @@
+## ADDED Requirements
+
+### Requirement: Complete Company whisky portfolio
+
+The system SHALL derive a Company's whisky portfolio from every descendant Brand, Distillery, and Bottler reachable through one or more current-owner links. It MUST return each portfolio Entity once and MUST preserve the recorded owner chain.
+
+#### Scenario: Directly owned portfolio Entity
+
+- **WHEN** a Company directly owns a Brand, Distillery, or Bottler
+- **THEN** that Entity appears in the Company's whisky portfolio
+
+#### Scenario: Portfolio Entity below an intermediate Company
+
+- **WHEN** a Company owns another Company that owns a whisky Entity
+- **THEN** the whisky Entity appears in both Companies' portfolios
+- **AND** its recorded path from each requested Company remains available
+
+#### Scenario: Portfolio Entity below a non-Company Entity
+
+- **WHEN** a descendant Brand, Distillery, or Bottler owns another whisky Entity
+- **THEN** traversal continues through that Entity and includes the lower descendant
+
+#### Scenario: Company has no portfolio
+
+- **WHEN** a Company has no descendant Brand, Distillery, or Bottler
+- **THEN** its portfolio is empty and the page does not invent or infer relationships
+
+### Requirement: Direct Company group context
+
+A Company overview SHALL list directly owned Companies separately from its recursive whisky portfolio. It MUST NOT present indirectly owned Companies or Bottlers as Companies in this group.
+
+#### Scenario: Company owns an intermediate Company
+
+- **WHEN** a Company directly owns another Company
+- **THEN** the overview lists that Entity under Companies in this group
+- **AND** links to the intermediate Company's own page
+
+#### Scenario: Company has only indirect Company descendants
+
+- **WHEN** a Company has no directly owned Companies
+- **THEN** its overview omits Companies in this group even if a lower portfolio Entity owns a Company
+
+### Requirement: Company portfolio collection
+
+A Company with a nonempty whisky portfolio SHALL provide a Portfolio collection under the existing Company page header. The collection SHALL expose kind filters, exact totals, deterministic sorting, and bounded pagination.
+
+#### Scenario: Browse a complete portfolio
+
+- **WHEN** a visitor selects Portfolio on a Company page
+- **THEN** the page lists descendant whisky Entities under the same Company header
+- **AND** each row uses the Entity's stored identity and kind
+- **AND** the visitor can filter the collection to Brands, Distilleries, or Bottlers
+
+#### Scenario: Overview portfolio is truncated
+
+- **WHEN** the Company overview shows fewer portfolio Entities than the exact total
+- **THEN** it provides a View all action containing that total and linking to the Portfolio collection
+
+#### Scenario: Stable portfolio order
+
+- **WHEN** two portfolio Entities have the same value for the selected sort
+- **THEN** the system uses a stable Entity ID tie-breaker
+
+### Requirement: Company Bottle catalog
+
+The system SHALL provide a Company-scoped Bottle collection containing each active Bottle whose Brand, Bottler, or Distiller is the Company itself or one of its descendants. The collection and its exact total MUST count each Bottle once.
+
+#### Scenario: Bottle belongs through an indirect Brand
+
+- **WHEN** a Bottle's Brand is below an intermediate Company in the requested Company's owner chain
+- **THEN** the Bottle appears in the requested Company's Bottle collection
+
+#### Scenario: Bottle matches several portfolio Entities
+
+- **WHEN** a Bottle references more than one Entity in the requested Company's portfolio
+- **THEN** the Bottle appears once and contributes one to the exact total
+
+#### Scenario: Bottle directly references the Company
+
+- **WHEN** an active Bottle directly uses the Company as its Brand, Bottler, or Distiller
+- **THEN** the Bottle appears even when the Company has no descendant portfolio Entities
+
+#### Scenario: Inactive Bottle matches the portfolio
+
+- **WHEN** an inactive Bottle references the Company or one of its descendants
+- **THEN** the public Company Bottle collection excludes it
+
+### Requirement: Company overview discovery
+
+A Company overview SHALL preview descendant Brands, Distilleries, and Bottlers in separate sections. Each section SHALL show its exact total and link to the matching Portfolio filter. Optional empty sections SHALL be omitted, and a failure in one section MUST NOT replace successful Company content.
+
+#### Scenario: View a Company with a nested portfolio
+
+- **WHEN** a visitor opens a Company whose whisky Entities are below intermediate owners
+- **THEN** the overview includes those Entities in the section matching their stored kind
+- **AND** each truncated section links to its complete filtered collection
+
+#### Scenario: Company has sparse data
+
+- **WHEN** a Company has facts or history but no portfolio or Bottles
+- **THEN** the overview retains the available content and omits the empty discovery sections
+
+#### Scenario: Portfolio request fails
+
+- **WHEN** the portfolio request fails while other Company data loads
+- **THEN** the overview shows a local retryable portfolio error and retains the other content

--- a/openspec/changes/improve-company-pages/tasks.md
+++ b/openspec/changes/improve-company-pages/tasks.md
@@ -1,0 +1,26 @@
+## 1. Company Portfolio API
+
+- [x] 1.1 Add a cycle-safe recursive Company descendant query that returns portfolio Entities, direct Company children, exact totals, stable sorting, and bounded pagination
+- [x] 1.2 Add the Company portfolio contract, route, router registration, serializers, and focused integration tests for direct, nested, deep, empty, and stable-order results
+- [x] 1.3 Add representative Company portfolio responses to the mock API for ordinary, sparse, and nested ownership pages
+
+## 2. Company Bottle Scope
+
+- [x] 2.1 Add a Company filter to the Bottle list contract and implement distinct matching through the Company itself and every descendant Entity used by a Bottle
+- [x] 2.2 Add Bottle list integration tests for indirect ownership, direct Company relationships, several matching descendants, inactive Bottles, exact totals, sorting, and pagination
+- [x] 2.3 Add representative recursive Company Bottle responses to the mock API
+
+## 3. Company Page Structure
+
+- [x] 3.1 Update Entity page data helpers to expose Company Portfolio and Bottle tabs from computed totals without changing non-Company tabs
+- [x] 3.2 Make the Brands and Distilleries previews recursive, add an optional Bottlers preview, and move direct Companies into a Companies in this group section using existing Entity rows and section states
+- [x] 3.3 Add the nested Company Portfolio page with kind filters, exact totals, deterministic sorting, pagination, and immediate-owner path context
+- [x] 3.4 Update the existing Company Bottles page to use the recursive Company scope under the shared Entity header
+- [x] 3.5 Add focused web tests for Company tabs, categorized preview totals and links, directly owned Companies, sparse content, and local loading or error states
+
+## 4. Verification
+
+- [x] 4.1 Run focused server and web tests, server and web typechecks, lint, and formatting for the affected files
+- [x] 4.2 Run desktop and mobile browser QA for Suntory-like nested ownership, a direct-only Company, a Company with direct Bottles, and an empty Company
+- [x] 4.3 Verify recursive query plans and response sizes for representative small and large Company trees
+- [x] 4.4 Confirm the final diff contains no migration, production data write, ownership-model change, or unrelated visual-system change


### PR DESCRIPTION
Company pages now follow the recorded owner chain instead of stopping at direct children. Overviews group descendant brands, distilleries, and bottlers with exact totals and filtered “View all” links; directly owned companies stay separate. New Portfolio and recursive Bottles tabs provide complete, paginated lists with ownership context, while empty sections remain hidden.

The server adds an additive company-portfolio read and Company filter for Bottle lists. Both reads are cycle-safe, deterministic, bounded, and count a Bottle once even when several descendants match. Anonymous page data uses the existing five-minute public cache boundary, while signed-in reads remain fresh.

Ownership storage and editing rules are unchanged: there is no migration, backfill, or production data write. The UI reuses the existing page, row, tab, loading, and error components. Focused coverage includes nested, direct-only, empty, inactive, duplicate-match, and invalid-filter cases, with desktop and mobile browser checks for the resulting layouts.
