### PR TITLE
feat(ratings): migrate old star ratings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,12 +67,16 @@ Peated is a public record of whisky, freely accessible to everyone.
   `serialize(...)`.
 - Generate migrations with `pnpm db:generate`. Never hand-write migration SQL or
   manually edit `apps/server/migrations/meta/*`.
-- `pnpm dev*` and `pnpm cli <cmd>` load `.env.local`; backend tests load
-  `.env.test`.
+- `pnpm dev*` loads `.env.local`; backend tests load `.env.test`.
+- Direct database-backed CLI command groups are legacy. Do not add or recommend
+  them for operations. Add a protected API route and use the authenticated API
+  client instead.
 
 ## Production Access
 
 - API: `https://api.peated.com`, not `https://peated.com`.
+- Use `pnpm cli auth ...` for OAuth and `pnpm cli api ...` for production API
+  reads and writes. These are the only supported production CLI surfaces.
 - Sentry: organization/project `peated/peated` at `https://peated.sentry.io`.
   Use [Sentry CLI](https://cli.sentry.dev) (`sentry`) with target detection;
   specify `peated/peated` only if detection is wrong.

--- a/apps/server/src/lib/oldStarRatingConversion.test.ts
+++ b/apps/server/src/lib/oldStarRatingConversion.test.ts
@@ -1,0 +1,138 @@
+import { db } from "@peated/server/db";
+import { tastings } from "@peated/server/db/schema";
+import {
+  convertOldStarRatings,
+  getRatingForOldStars,
+  OldStarRatingPreviewChangedError,
+  previewOldStarRatingConversion,
+} from "@peated/server/lib/oldStarRatingConversion";
+import { asc } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+describe("old star rating conversion", () => {
+  test.each([
+    [0, null],
+    [0.25, "mediocre"],
+    [2, "mediocre"],
+    [2.25, "good"],
+    [3, "good"],
+    [3.25, "very_good"],
+    [4, "very_good"],
+    [4.25, "outstanding"],
+    [4.5, "outstanding"],
+    [4.75, "unicorn"],
+    [5, "unicorn"],
+    [-0.25, null],
+    [3.1, null],
+    [5.25, null],
+    [Number.NaN, null],
+  ] as const)("maps %s stars to %s", (starRating, expected) => {
+    expect(getRatingForOldStars(starRating)).toBe(expected);
+  });
+
+  test("converts supported ratings and keeps the old values", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const inputs = [
+      { legacyStarRating: 0.25, legacySimpleRating: -1, ratingBand: null },
+      { legacyStarRating: 2, legacySimpleRating: -1, ratingBand: null },
+      { legacyStarRating: 2.25, legacySimpleRating: 1, ratingBand: null },
+      { legacyStarRating: 3.75, legacySimpleRating: 1, ratingBand: null },
+      { legacyStarRating: 4.25, legacySimpleRating: 2, ratingBand: null },
+      { legacyStarRating: 4.75, legacySimpleRating: 2, ratingBand: null },
+      { legacyStarRating: 0, legacySimpleRating: -1, ratingBand: null },
+      { legacyStarRating: 3.1, legacySimpleRating: 1, ratingBand: null },
+      { legacyStarRating: 5, legacySimpleRating: 2, ratingBand: "good" },
+    ] as const;
+    for (const input of inputs) {
+      await fixtures.Tasting({ bottleId: bottle.id, ...input });
+    }
+
+    const before = await db
+      .select({
+        legacySimpleRating: tastings.legacySimpleRating,
+        legacyStarRating: tastings.legacyStarRating,
+        ratingBand: tastings.ratingBand,
+      })
+      .from(tastings)
+      .orderBy(asc(tastings.id));
+    const preview = await previewOldStarRatingConversion();
+
+    expect(preview).toEqual({
+      bottleIds: [bottle.id],
+      alreadyRated: 1,
+      converted: 0,
+      ratings: {
+        mediocre: 2,
+        good: 1,
+        very_good: 1,
+        outstanding: 1,
+        unicorn: 1,
+      },
+      willConvert: 6,
+      oldStarRatings: 9,
+      notConverted: 2,
+      notConvertedValues: { "0": 1, "3.1": 1 },
+    });
+    expect(
+      await db
+        .select({ ratingBand: tastings.ratingBand })
+        .from(tastings)
+        .orderBy(asc(tastings.id)),
+    ).toEqual(before.map(({ ratingBand }) => ({ ratingBand })));
+
+    await expect(convertOldStarRatings(5)).rejects.toBeInstanceOf(
+      OldStarRatingPreviewChangedError,
+    );
+    expect(
+      await db
+        .select({ ratingBand: tastings.ratingBand })
+        .from(tastings)
+        .orderBy(asc(tastings.id)),
+    ).toEqual(before.map(({ ratingBand }) => ({ ratingBand })));
+
+    const result = await convertOldStarRatings(6);
+    expect(result.converted).toBe(6);
+    const after = await db
+      .select({
+        legacySimpleRating: tastings.legacySimpleRating,
+        legacyStarRating: tastings.legacyStarRating,
+        ratingBand: tastings.ratingBand,
+      })
+      .from(tastings)
+      .orderBy(asc(tastings.id));
+    expect(after.map(({ ratingBand }) => ratingBand)).toEqual([
+      "mediocre",
+      "mediocre",
+      "good",
+      "very_good",
+      "outstanding",
+      "unicorn",
+      null,
+      null,
+      "good",
+    ]);
+    expect(
+      after.map(({ legacySimpleRating, legacyStarRating }) => ({
+        legacySimpleRating,
+        legacyStarRating,
+      })),
+    ).toEqual(
+      before.map(({ legacySimpleRating, legacyStarRating }) => ({
+        legacySimpleRating,
+        legacyStarRating,
+      })),
+    );
+
+    const repeated = await convertOldStarRatings(0);
+    expect(repeated).toMatchObject({
+      bottleIds: [bottle.id],
+      alreadyRated: 7,
+      converted: 0,
+      willConvert: 0,
+      oldStarRatings: 9,
+      notConverted: 2,
+    });
+  });
+});

--- a/apps/server/src/lib/oldStarRatingConversion.ts
+++ b/apps/server/src/lib/oldStarRatingConversion.ts
@@ -1,0 +1,189 @@
+import type { RatingBandId, TastingBandCounts } from "@peated/server/constants";
+import {
+  EMPTY_TASTING_BAND_COUNTS,
+  RATING_BAND_IDS,
+} from "@peated/server/constants";
+import { db, type AnyConnection, type AnyDatabase } from "@peated/server/db";
+import { tastings } from "@peated/server/db/schema";
+import { and, asc, inArray, isNotNull, isNull } from "drizzle-orm";
+
+type OldTastingRating = {
+  bottleId: number;
+  id: number;
+  legacyStarRating: number;
+  ratingBand: RatingBandId | null;
+};
+
+export type OldStarRatingConversionReport = {
+  bottleIds: number[];
+  alreadyRated: number;
+  converted: number;
+  ratings: TastingBandCounts;
+  willConvert: number;
+  oldStarRatings: number;
+  notConverted: number;
+  notConvertedValues: Record<string, number>;
+};
+
+export class OldStarRatingPreviewChangedError extends Error {
+  constructor(
+    readonly expectedConversions: number,
+    readonly currentConversions: number,
+  ) {
+    super(
+      `The number of tastings to convert changed from ${expectedConversions} to ${currentConversions}. Preview again.`,
+    );
+    this.name = "OldStarRatingPreviewChangedError";
+  }
+}
+
+export class OldStarRatingConversionConflictError extends Error {
+  constructor(
+    readonly plannedConversions: number,
+    readonly converted: number,
+  ) {
+    super(
+      `The number of tastings ready to convert changed during the request (${plannedConversions} to ${converted}). No changes were saved. Preview again.`,
+    );
+    this.name = "OldStarRatingConversionConflictError";
+  }
+}
+
+/** Maps supported old quarter-star values without inventing a rating for zero. */
+export function getRatingForOldStars(starRating: number): RatingBandId | null {
+  if (
+    !Number.isFinite(starRating) ||
+    starRating <= 0 ||
+    starRating > 5 ||
+    !Number.isInteger(starRating * 4)
+  ) {
+    return null;
+  }
+  if (starRating <= 2) return "mediocre";
+  if (starRating <= 3) return "good";
+  if (starRating <= 4) return "very_good";
+  if (starRating <= 4.5) return "outstanding";
+  return "unicorn";
+}
+
+async function loadOldStarRatings(
+  database: AnyDatabase,
+): Promise<OldTastingRating[]> {
+  const rows = await database
+    .select({
+      bottleId: tastings.bottleId,
+      id: tastings.id,
+      legacyStarRating: tastings.legacyStarRating,
+      ratingBand: tastings.ratingBand,
+    })
+    .from(tastings)
+    .where(isNotNull(tastings.legacyStarRating))
+    .orderBy(asc(tastings.id));
+
+  return rows.map((row) => {
+    if (row.legacyStarRating === null) {
+      throw new Error(`Tasting ${row.id} has no old star rating.`);
+    }
+    return { ...row, legacyStarRating: row.legacyStarRating };
+  });
+}
+
+function buildOldStarRatingConversionReport(
+  rows: OldTastingRating[],
+): OldStarRatingConversionReport {
+  const bottleIds = new Set<number>();
+  const ratings: TastingBandCounts = { ...EMPTY_TASTING_BAND_COUNTS };
+  const notConvertedValues = new Map<string, number>();
+  let alreadyRated = 0;
+  let willConvert = 0;
+  let notConverted = 0;
+
+  for (const row of rows) {
+    const ratingBand = getRatingForOldStars(row.legacyStarRating);
+    if (ratingBand === null) {
+      notConverted += 1;
+      const value = String(row.legacyStarRating);
+      notConvertedValues.set(value, (notConvertedValues.get(value) ?? 0) + 1);
+      continue;
+    }
+
+    bottleIds.add(row.bottleId);
+    if (row.ratingBand !== null) {
+      alreadyRated += 1;
+      continue;
+    }
+
+    willConvert += 1;
+    ratings[ratingBand] += 1;
+  }
+
+  return {
+    bottleIds: [...bottleIds].sort((left, right) => left - right),
+    alreadyRated,
+    converted: 0,
+    ratings,
+    willConvert,
+    oldStarRatings: rows.length,
+    notConverted,
+    notConvertedValues: Object.fromEntries(
+      [...notConvertedValues].sort(
+        ([left], [right]) => Number(left) - Number(right),
+      ),
+    ),
+  };
+}
+
+export async function previewOldStarRatingConversion(
+  database: AnyDatabase = db,
+): Promise<OldStarRatingConversionReport> {
+  return buildOldStarRatingConversionReport(await loadOldStarRatings(database));
+}
+
+/** Converts the previewed tastings only while every current rating remains null. */
+export async function convertOldStarRatings(
+  expectedConversions: number,
+  database: AnyConnection = db,
+): Promise<OldStarRatingConversionReport> {
+  return await database.transaction(async (tx) => {
+    const rows = await loadOldStarRatings(tx);
+    const report = buildOldStarRatingConversionReport(rows);
+    if (report.willConvert !== expectedConversions) {
+      throw new OldStarRatingPreviewChangedError(
+        expectedConversions,
+        report.willConvert,
+      );
+    }
+
+    let converted = 0;
+    for (const ratingBand of RATING_BAND_IDS) {
+      const tastingIds = rows.flatMap((row) =>
+        row.ratingBand === null &&
+        getRatingForOldStars(row.legacyStarRating) === ratingBand
+          ? [row.id]
+          : [],
+      );
+      if (!tastingIds.length) continue;
+
+      const updated = await tx
+        .update(tastings)
+        .set({ ratingBand })
+        .where(
+          and(
+            inArray(tastings.id, tastingIds),
+            isNull(tastings.ratingBand),
+            isNotNull(tastings.legacyStarRating),
+          ),
+        )
+        .returning({ id: tastings.id });
+      converted += updated.length;
+    }
+
+    if (converted !== report.willConvert) {
+      throw new OldStarRatingConversionConflictError(
+        report.willConvert,
+        converted,
+      );
+    }
+    return { ...report, converted };
+  });
+}

--- a/apps/server/src/orpc/routes/admin/convert-old-star-ratings.test.ts
+++ b/apps/server/src/orpc/routes/admin/convert-old-star-ratings.test.ts
@@ -1,0 +1,152 @@
+import { db } from "@peated/server/db";
+import { tastings } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import * as workerClient from "@peated/server/lib/test/workerDispatch";
+import { routerClient } from "@peated/server/orpc/router";
+import { asc, eq } from "drizzle-orm";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+beforeEach(() => {
+  vi.mocked(workerClient.pushJob).mockReset().mockResolvedValue(undefined);
+});
+
+describe("POST /admin/tastings/star-rating-conversion", () => {
+  test("requires an administrator", async ({ defaults, fixtures }) => {
+    const moderator = await fixtures.User({ mod: true });
+
+    for (const user of [defaults.user, moderator]) {
+      await expect(
+        waitError(
+          routerClient.admin.convertOldStarRatings(
+            { expectedConversions: 0 },
+            { context: { user } },
+          ),
+        ),
+      ).resolves.toMatchObject({ message: "Unauthorized." });
+    }
+  });
+
+  test("rejects an invalid preview count", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+
+    await expect(
+      routerClient.admin.convertOldStarRatings(
+        { expectedConversions: -1 },
+        { context: { user: admin } },
+      ),
+    ).rejects.toThrow("Input validation failed");
+    expect(workerClient.pushJob).not.toHaveBeenCalled();
+  });
+
+  test("stops when the preview changes, converts, and starts Bottle total updates", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const bottle = await fixtures.Bottle();
+    await fixtures.Tasting({
+      bottleId: bottle.id,
+      legacyStarRating: 2.25,
+      ratingBand: null,
+    });
+    await fixtures.Tasting({
+      bottleId: bottle.id,
+      legacyStarRating: 4.75,
+      ratingBand: null,
+    });
+    await fixtures.Tasting({
+      bottleId: bottle.id,
+      legacyStarRating: 0,
+      ratingBand: null,
+    });
+
+    const options = { context: { user: admin } };
+    const staleError = await waitError(
+      routerClient.admin.convertOldStarRatings(
+        { expectedConversions: 1 },
+        options,
+      ),
+    );
+    expect(staleError).toMatchInlineSnapshot(
+      `[Error: The number of tastings to convert changed from 1 to 2. Preview again.]`,
+    );
+    expect(workerClient.pushJob).not.toHaveBeenCalled();
+
+    const result = await routerClient.admin.convertOldStarRatings(
+      { expectedConversions: 2 },
+      options,
+    );
+    expect(result).toMatchObject({
+      willConvert: 2,
+      converted: 2,
+      bottles: 1,
+      bottleTotalsStarted: 1,
+      bottleTotalsFailed: 0,
+    });
+    expect(
+      await db
+        .select({ ratingBand: tastings.ratingBand })
+        .from(tastings)
+        .orderBy(asc(tastings.id)),
+    ).toEqual([
+      { ratingBand: "good" },
+      { ratingBand: "unicorn" },
+      { ratingBand: null },
+    ]);
+    expect(workerClient.pushJob).toHaveBeenCalledWith(
+      "UpdateBottleStats",
+      { bottleId: bottle.id },
+      { delay: 5000, removeOnComplete: true, removeOnFail: false },
+    );
+
+    vi.mocked(workerClient.pushJob).mockClear();
+    await expect(
+      routerClient.admin.convertOldStarRatings(
+        { expectedConversions: 0 },
+        options,
+      ),
+    ).resolves.toMatchObject({
+      willConvert: 0,
+      converted: 0,
+      bottles: 1,
+      bottleTotalsStarted: 1,
+      bottleTotalsFailed: 0,
+    });
+    expect(workerClient.pushJob).toHaveBeenCalledWith(
+      "UpdateBottleStats",
+      { bottleId: bottle.id },
+      { delay: 5000, removeOnComplete: true, removeOnFail: false },
+    );
+  });
+
+  test("keeps saved ratings when a Bottle total update cannot start", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const bottle = await fixtures.Bottle();
+    const tasting = await fixtures.Tasting({
+      bottleId: bottle.id,
+      legacyStarRating: 3,
+      ratingBand: null,
+    });
+    vi.mocked(workerClient.pushJob).mockRejectedValueOnce(
+      new Error("Queue unavailable"),
+    );
+
+    await expect(
+      routerClient.admin.convertOldStarRatings(
+        { expectedConversions: 1 },
+        { context: { user: admin } },
+      ),
+    ).resolves.toMatchObject({
+      converted: 1,
+      bottleTotalsStarted: 0,
+      bottleTotalsFailed: 1,
+    });
+    await expect(
+      db
+        .select({ ratingBand: tastings.ratingBand })
+        .from(tastings)
+        .where(eq(tastings.id, tasting.id)),
+    ).resolves.toEqual([{ ratingBand: "good" }]);
+  });
+});

--- a/apps/server/src/orpc/routes/admin/convert-old-star-ratings.ts
+++ b/apps/server/src/orpc/routes/admin/convert-old-star-ratings.ts
@@ -1,0 +1,69 @@
+import { logError } from "@peated/server/lib/log";
+import {
+  convertOldStarRatings,
+  OldStarRatingConversionConflictError,
+  OldStarRatingPreviewChangedError,
+} from "@peated/server/lib/oldStarRatingConversion";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import { pushJob } from "@peated/server/worker/dispatch";
+import { z } from "zod";
+import {
+  OldStarRatingConversionReportSchema,
+  serializeOldStarRatingConversionReport,
+} from "./old-star-rating-conversion-schema";
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "POST",
+    path: "/admin/tastings/star-rating-conversion",
+    summary: "Convert old star ratings",
+    description:
+      "Convert the old star ratings counted by the latest preview. Then start Bottle rating-total updates and report how many started or failed. Administrator only.",
+    operationId: "convertOldStarRatings",
+  })
+  .input(
+    z
+      .object({
+        expectedConversions: z.number().int().nonnegative(),
+      })
+      .strict(),
+  )
+  .output(OldStarRatingConversionReportSchema)
+  .handler(async ({ input, errors }) => {
+    let report;
+    try {
+      report = await convertOldStarRatings(input.expectedConversions);
+    } catch (error) {
+      if (
+        error instanceof OldStarRatingPreviewChangedError ||
+        error instanceof OldStarRatingConversionConflictError
+      ) {
+        throw errors.CONFLICT({ message: error.message, cause: error });
+      }
+      throw error;
+    }
+
+    let bottleTotalsStarted = 0;
+    for (const bottleId of report.bottleIds) {
+      try {
+        await pushJob(
+          "UpdateBottleStats",
+          { bottleId },
+          { delay: 5000, removeOnComplete: true, removeOnFail: false },
+        );
+        bottleTotalsStarted += 1;
+      } catch (error) {
+        // Background-work policy: this route owns logging after ratings are saved.
+        logError(error, {
+          extra: { bottleId, operation: "convertOldStarRatings" },
+        });
+      }
+    }
+
+    return serializeOldStarRatingConversionReport(report, {
+      failed: report.bottleIds.length - bottleTotalsStarted,
+      started: bottleTotalsStarted,
+    });
+  });

--- a/apps/server/src/orpc/routes/admin/index.ts
+++ b/apps/server/src/orpc/routes/admin/index.ts
@@ -1,12 +1,16 @@
 import { base } from "../..";
 import catalogCoverage from "./catalog-coverage";
+import convertOldStarRatings from "./convert-old-star-ratings";
 import moderation from "./moderation";
 import oauthClients from "./oauth-clients";
+import getOldStarRatingConversion from "./preview-old-star-rating-conversion";
 import repairBottleCounts from "./repair-bottle-counts";
 
 export default base.tag("admin").router({
   catalogCoverage,
+  convertOldStarRatings,
   moderation,
   oauthClients,
   repairBottleCounts,
+  getOldStarRatingConversion,
 });

--- a/apps/server/src/orpc/routes/admin/old-star-rating-conversion-schema.ts
+++ b/apps/server/src/orpc/routes/admin/old-star-rating-conversion-schema.ts
@@ -1,0 +1,46 @@
+import type { OldStarRatingConversionReport } from "@peated/server/lib/oldStarRatingConversion";
+import { z } from "zod";
+
+export const OldStarRatingConversionReportSchema = z
+  .object({
+    oldStarRatings: z.number().int().nonnegative(),
+    willConvert: z.number().int().nonnegative(),
+    alreadyRated: z.number().int().nonnegative(),
+    notConverted: z.number().int().nonnegative(),
+    converted: z.number().int().nonnegative(),
+    bottles: z.number().int().nonnegative(),
+    bottleTotalsStarted: z.number().int().nonnegative(),
+    bottleTotalsFailed: z.number().int().nonnegative(),
+    ratings: z
+      .object({
+        mediocre: z.number().int().nonnegative(),
+        good: z.number().int().nonnegative(),
+        very_good: z.number().int().nonnegative(),
+        outstanding: z.number().int().nonnegative(),
+        unicorn: z.number().int().nonnegative(),
+      })
+      .strict(),
+    notConvertedValues: z.record(z.string(), z.number().int().positive()),
+  })
+  .strict();
+
+export function serializeOldStarRatingConversionReport(
+  report: OldStarRatingConversionReport,
+  bottleTotals: { failed: number; started: number } = {
+    failed: 0,
+    started: 0,
+  },
+) {
+  return {
+    oldStarRatings: report.oldStarRatings,
+    willConvert: report.willConvert,
+    alreadyRated: report.alreadyRated,
+    notConverted: report.notConverted,
+    converted: report.converted,
+    bottles: report.bottleIds.length,
+    bottleTotalsStarted: bottleTotals.started,
+    bottleTotalsFailed: bottleTotals.failed,
+    ratings: report.ratings,
+    notConvertedValues: report.notConvertedValues,
+  };
+}

--- a/apps/server/src/orpc/routes/admin/preview-old-star-rating-conversion.test.ts
+++ b/apps/server/src/orpc/routes/admin/preview-old-star-rating-conversion.test.ts
@@ -1,0 +1,66 @@
+import waitError from "@peated/server/lib/test/waitError";
+import * as workerClient from "@peated/server/lib/test/workerDispatch";
+import { routerClient } from "@peated/server/orpc/router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+beforeEach(() => {
+  vi.mocked(workerClient.pushJob).mockReset().mockResolvedValue(undefined);
+});
+
+describe("GET /admin/tastings/star-rating-conversion", () => {
+  test("previews the repair without changing anything", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const bottle = await fixtures.Bottle();
+    await fixtures.Tasting({
+      bottleId: bottle.id,
+      legacyStarRating: 2.25,
+      ratingBand: null,
+    });
+    await fixtures.Tasting({
+      bottleId: bottle.id,
+      legacyStarRating: 4.75,
+      ratingBand: null,
+    });
+    await fixtures.Tasting({
+      bottleId: bottle.id,
+      legacyStarRating: 0,
+      ratingBand: null,
+    });
+
+    await expect(
+      routerClient.admin.getOldStarRatingConversion(undefined, {
+        context: { user: admin },
+      }),
+    ).resolves.toEqual({
+      oldStarRatings: 3,
+      willConvert: 2,
+      alreadyRated: 0,
+      notConverted: 1,
+      converted: 0,
+      bottles: 1,
+      bottleTotalsStarted: 0,
+      bottleTotalsFailed: 0,
+      ratings: {
+        mediocre: 0,
+        good: 1,
+        very_good: 0,
+        outstanding: 0,
+        unicorn: 1,
+      },
+      notConvertedValues: { "0": 1 },
+    });
+    expect(workerClient.pushJob).not.toHaveBeenCalled();
+  });
+
+  test("requires an administrator", async ({ defaults }) => {
+    await expect(
+      waitError(
+        routerClient.admin.getOldStarRatingConversion(undefined, {
+          context: { user: defaults.user },
+        }),
+      ),
+    ).resolves.toMatchObject({ message: "Unauthorized." });
+  });
+});

--- a/apps/server/src/orpc/routes/admin/preview-old-star-rating-conversion.ts
+++ b/apps/server/src/orpc/routes/admin/preview-old-star-rating-conversion.ts
@@ -1,0 +1,24 @@
+import { previewOldStarRatingConversion } from "@peated/server/lib/oldStarRatingConversion";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import {
+  OldStarRatingConversionReportSchema,
+  serializeOldStarRatingConversionReport,
+} from "./old-star-rating-conversion-schema";
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "GET",
+    path: "/admin/tastings/star-rating-conversion",
+    summary: "Preview old star rating conversion",
+    description:
+      "Count old star ratings and show how they would change. Makes no changes. Administrator only.",
+    operationId: "getOldStarRatingConversion",
+  })
+  .output(OldStarRatingConversionReportSchema)
+  .handler(async () =>
+    serializeOldStarRatingConversionReport(
+      await previewOldStarRatingConversion(),
+    ),
+  );

--- a/apps/web/e2e/maintenance.spec.ts
+++ b/apps/web/e2e/maintenance.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test, type TestInfo } from "./test";
+
+import { adminUser, testAccessToken } from "./rpc-fixtures.mjs";
+import { signIn } from "./session";
+
+test("previews and runs the old star rating repair", async ({
+  context,
+  page,
+  snapshot,
+}, testInfo) => {
+  await signIn(context, {
+    accessToken: uniqueAccessToken(testInfo),
+    user: adminUser,
+  });
+
+  await page.goto("/admin/maintenance");
+
+  await expect(
+    page.getByRole("heading", { name: "Maintenance", exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("232", { exact: true })).toHaveCount(2);
+  await expect(
+    page.getByRole("button", { name: "Convert 232 tastings" }),
+  ).toBeVisible();
+  await snapshot("admin/maintenance", {
+    ready: page.getByRole("button", { name: "Convert 232 tastings" }),
+  });
+
+  await page.getByRole("button", { name: "Convert 232 tastings" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(
+    dialog.getByRole("heading", { name: "Convert old star ratings?" }),
+  ).toBeVisible();
+  await expect(dialog).toContainText(
+    "It will not replace ratings people chose, and it keeps the saved stars.",
+  );
+
+  const conversionRequest = page.waitForRequest((request) =>
+    request.url().includes("/rpc/admin/convertOldStarRatings"),
+  );
+  await dialog.getByRole("button", { name: "Convert 232 tastings" }).click();
+  await conversionRequest;
+
+  await expect(page.getByText("Nothing to convert")).toBeVisible();
+  await expect(page.getByText("Converted 232 tastings.")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Refresh totals for 175 Bottles" }),
+  ).toBeVisible();
+  const totalRefreshRequest = page.waitForRequest((request) =>
+    request.url().includes("/rpc/admin/convertOldStarRatings"),
+  );
+  await page
+    .getByRole("button", { name: "Refresh totals for 175 Bottles" })
+    .click();
+  await totalRefreshRequest;
+  await expect(
+    page.getByText("Started recalculating rating totals for 175 Bottles."),
+  ).toBeVisible();
+
+  const bottleCountRequest = page.waitForRequest((request) =>
+    request.url().includes("/rpc/admin/repairBottleCounts"),
+  );
+  await page.getByRole("button", { name: "Check Bottle counts" }).click();
+  await bottleCountRequest;
+  await expect(page.getByText("Bottle count check started.")).toBeVisible();
+});
+
+test("@mobile shows the old star rating repair", async ({
+  context,
+  page,
+  snapshot,
+}, testInfo) => {
+  await signIn(context, {
+    accessToken: uniqueAccessToken(testInfo),
+    user: adminUser,
+  });
+
+  await page.goto("/admin/maintenance");
+
+  await snapshot("admin/maintenance-mobile", {
+    ready: page.getByRole("button", { name: "Convert 232 tastings" }),
+  });
+});
+
+function uniqueAccessToken(testInfo: TestInfo): string {
+  return `${testAccessToken}-maintenance-${testInfo.project.name}-${testInfo.workerIndex}`;
+}

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -97,6 +97,7 @@ const pendingUploadStateByToken = new Map();
 const userModeratorStateByToken = new Map();
 const appliedQueueProposalTokens = new Set();
 const ignoredInconclusiveProposalTokens = new Set();
+const convertedOldStarRatingTokens = new Set();
 let collectionBottleId = 1;
 let pendingUploadId = 1;
 let releasePageReady = Promise.resolve();
@@ -560,6 +561,35 @@ async function handleRpcRequest({ request, response, url }) {
       sendRpcResponse(response, bottle);
       return true;
     }
+    case "admin/getOldStarRatingConversion": {
+      const token = getAccessToken(request);
+      sendRpcResponse(
+        response,
+        buildOldStarRatingReport(convertedOldStarRatingTokens.has(token)),
+      );
+      return true;
+    }
+    case "admin/convertOldStarRatings": {
+      const token = getAccessToken(request);
+      const converted = convertedOldStarRatingTokens.has(token);
+      if (
+        (input?.expectedConversions !== 232 || converted) &&
+        (input?.expectedConversions !== 0 || !converted)
+      ) {
+        sendRpcError(response, "Unexpected old star rating conversion payload");
+        return true;
+      }
+      convertedOldStarRatingTokens.add(token);
+      sendRpcResponse(response, {
+        ...buildOldStarRatingReport(converted),
+        converted: converted ? 0 : 232,
+        bottleTotalsStarted: 175,
+      });
+      return true;
+    }
+    case "admin/repairBottleCounts":
+      sendRpcResponse(response, { status: "queued" });
+      return true;
     case "admin/moderation/listTasks": {
       const token = getAccessToken(request);
       if (token.includes("queue-inconclusive")) {
@@ -2587,6 +2617,27 @@ function getBottleGroup(groupId) {
     default:
       return null;
   }
+}
+
+function buildOldStarRatingReport(converted) {
+  return {
+    oldStarRatings: 232,
+    willConvert: converted ? 0 : 232,
+    alreadyRated: converted ? 232 : 0,
+    notConverted: 0,
+    converted: 0,
+    bottles: 175,
+    bottleTotalsStarted: 0,
+    bottleTotalsFailed: 0,
+    ratings: {
+      mediocre: converted ? 0 : 6,
+      good: converted ? 0 : 27,
+      very_good: converted ? 0 : 139,
+      outstanding: converted ? 0 : 46,
+      unicorn: converted ? 0 : 14,
+    },
+    notConvertedValues: {},
+  };
 }
 
 async function readRpcInput(request, url) {

--- a/apps/web/src/app/(admin)/admin/(default)/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/layout.tsx
@@ -19,6 +19,7 @@ const navigationGroups = [
       { href: "/admin/badges", label: "Badges" },
       { href: "/admin/events", label: "Events" },
       { href: "/admin/locations", label: "Locations" },
+      { href: "/admin/maintenance", label: "Maintenance" },
       { href: "/admin/oauth-clients", label: "OAuth clients" },
       { href: "/admin/sites", label: "Scrapers" },
       { href: "/admin/tags", label: "Tags" },

--- a/apps/web/src/app/(admin)/admin/(default)/maintenance/maintenancePage.stylex.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/maintenance/maintenancePage.stylex.tsx
@@ -1,0 +1,277 @@
+"use client";
+
+import { useState } from "react";
+
+import { AdminButton as Button } from "@peated/web/components/admin/adminButton.stylex";
+import {
+  AdminBreadcrumbs,
+  AdminPage,
+  AdminPageHeader,
+  AdminSection,
+  AdminStat,
+  AdminStatGrid,
+  AdminStatus,
+} from "@peated/web/components/admin/adminContent.stylex";
+import { AdminAlert as Alert } from "@peated/web/components/admin/adminUtility.stylex";
+import ConfirmationDialog from "@peated/web/components/confirmationDialog.client";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import * as stylex from "@stylexjs/stylex";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+
+import { space } from "../../../../../styles/tokens.stylex";
+
+function formatCount(value: number) {
+  return new Intl.NumberFormat().format(value);
+}
+
+function countLabel(value: number, singular: string, plural = `${singular}s`) {
+  return `${formatCount(value)} ${value === 1 ? singular : plural}`;
+}
+
+export default function MaintenancePage() {
+  const orpc = useORPC();
+  const queryClient = useQueryClient();
+  const previewOptions = orpc.admin.getOldStarRatingConversion.queryOptions();
+  const { data } = useSuspenseQuery(previewOptions);
+  const conversion = useMutation(
+    orpc.admin.convertOldStarRatings.mutationOptions(),
+  );
+  const bottleCountRepair = useMutation(
+    orpc.admin.repairBottleCounts.mutationOptions(),
+  );
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
+  const [bottleCountError, setBottleCountError] = useState<string | null>(null);
+  const [bottleCountNotice, setBottleCountNotice] = useState<string | null>(
+    null,
+  );
+
+  async function runOldRatingRepair() {
+    const converting = data.willConvert > 0;
+    setConfirming(false);
+    setError(null);
+    setSuccess(null);
+    setWarning(null);
+
+    try {
+      const result = await conversion.mutateAsync({
+        expectedConversions: data.willConvert,
+      });
+      setSuccess(
+        converting
+          ? `Converted ${countLabel(result.converted, "tasting")}. Started recalculating rating totals for ${countLabel(result.bottleTotalsStarted, "Bottle")}.`
+          : `Started recalculating rating totals for ${countLabel(result.bottleTotalsStarted, "Bottle")}.`,
+      );
+      if (result.bottleTotalsFailed > 0) {
+        setWarning(
+          `Could not start recalculating rating totals for ${countLabel(result.bottleTotalsFailed, "Bottle")}. Try the refresh again.`,
+        );
+      }
+      await queryClient.invalidateQueries({
+        queryKey: previewOptions.queryKey,
+      });
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : "The old star ratings could not be converted.",
+      );
+    }
+  }
+
+  async function startBottleCountRepair() {
+    setBottleCountError(null);
+    setBottleCountNotice(null);
+    try {
+      await bottleCountRepair.mutateAsync({});
+      setBottleCountNotice("Bottle count check started.");
+    } catch {
+      setBottleCountError("The Bottle count check could not start. Try again.");
+    }
+  }
+
+  const skippedValues = Object.entries(data.notConvertedValues);
+  const oldRatingActionLabel =
+    data.willConvert > 0
+      ? `Convert ${countLabel(data.willConvert, "tasting")}`
+      : `Refresh totals for ${countLabel(data.bottles, "Bottle")}`;
+
+  return (
+    <>
+      <AdminPage>
+        <AdminBreadcrumbs
+          items={[
+            { label: "Admin", href: "/admin" },
+            {
+              label: "Maintenance",
+              href: "/admin/maintenance",
+              current: true,
+            },
+          ]}
+        />
+        <AdminPageHeader
+          title="Maintenance"
+          description="Preview and run one-off repairs. Each repair checks the current data again before saving."
+        />
+
+        <AdminSection
+          title="Bottle counts"
+          description="Check every brand and producer’s Bottle count, and fix counts that are wrong. Bottle editing can continue while this runs."
+        >
+          <div {...stylex.props(styles.sectionContent)}>
+            <div {...stylex.props(styles.actionRow)}>
+              <Button
+                disabled={bottleCountRepair.isPending}
+                loading={bottleCountRepair.isPending}
+                onClick={() => void startBottleCountRepair()}
+                variant="default"
+              >
+                Check Bottle counts
+              </Button>
+            </div>
+            {bottleCountNotice ? (
+              <Alert type="success">{bottleCountNotice}</Alert>
+            ) : null}
+            {bottleCountError ? (
+              <Alert type="error">{bottleCountError}</Alert>
+            ) : null}
+          </div>
+        </AdminSection>
+
+        <AdminSection
+          title="Old star ratings"
+          description="Give older tastings one of today’s five ratings. Existing ratings stay as they are, and the old stars stay on each tasting."
+        >
+          <div {...stylex.props(styles.sectionContent)}>
+            <div {...stylex.props(styles.actionRow)}>
+              {data.willConvert === 0 ? (
+                <AdminStatus tone="success">Nothing to convert</AdminStatus>
+              ) : null}
+              {data.willConvert > 0 || data.bottles > 0 ? (
+                <Button
+                  disabled={conversion.isPending}
+                  loading={conversion.isPending}
+                  onClick={() => {
+                    if (data.willConvert > 0) {
+                      setConfirming(true);
+                    } else {
+                      void runOldRatingRepair();
+                    }
+                  }}
+                  variant="default"
+                >
+                  {oldRatingActionLabel}
+                </Button>
+              ) : null}
+            </div>
+            {success ? <Alert type="success">{success}</Alert> : null}
+            {warning ? <Alert type="warn">{warning}</Alert> : null}
+            {error ? <Alert type="error">{error}</Alert> : null}
+
+            <AdminStatGrid>
+              <AdminStat
+                label="Old ratings"
+                value={formatCount(data.oldStarRatings)}
+                detail="Tastings that still have stars"
+              />
+              <AdminStat
+                label="Will convert"
+                value={formatCount(data.willConvert)}
+                detail="Tastings that will get a rating"
+              />
+              <AdminStat
+                label="Already rated"
+                value={formatCount(data.alreadyRated)}
+                detail="Current ratings that stay unchanged"
+              />
+              <AdminStat
+                label="Skipped"
+                value={formatCount(data.notConverted)}
+                detail="Old values Peated cannot safely convert"
+              />
+              <AdminStat
+                label="Bottles"
+                value={formatCount(data.bottles)}
+                detail="Rating totals that will update"
+              />
+            </AdminStatGrid>
+
+            {skippedValues.length > 0 ? (
+              <Alert type="warn">
+                Skipped old values:{" "}
+                {skippedValues
+                  .map(([value, count]) => `${value} (${formatCount(count)})`)
+                  .join(", ")}
+              </Alert>
+            ) : null}
+          </div>
+        </AdminSection>
+
+        {data.willConvert > 0 ? (
+          <AdminSection
+            title="Ratings to add"
+            description="How the old stars will be split."
+          >
+            <AdminStatGrid>
+              <AdminStat
+                label="Mediocre"
+                value={formatCount(data.ratings.mediocre)}
+              />
+              <AdminStat label="Good" value={formatCount(data.ratings.good)} />
+              <AdminStat
+                label="Very good"
+                value={formatCount(data.ratings.very_good)}
+              />
+              <AdminStat
+                label="Outstanding"
+                value={formatCount(data.ratings.outstanding)}
+              />
+              <AdminStat
+                label="Unicorn"
+                value={formatCount(data.ratings.unicorn)}
+              />
+            </AdminStatGrid>
+          </AdminSection>
+        ) : null}
+      </AdminPage>
+
+      <ConfirmationDialog
+        continueLabel={oldRatingActionLabel}
+        isOpen={confirming}
+        message={
+          data.willConvert > 0
+            ? `This adds a rating to ${countLabel(data.willConvert, "tasting")} with saved stars. It will not replace ratings people chose, and it keeps the saved stars. Rating totals for ${countLabel(data.bottles, "Bottle")} will update afterward.`
+            : `This recalculates rating totals for ${countLabel(data.bottles, "Bottle")}. It does not change any tastings.`
+        }
+        onCancel={() => setConfirming(false)}
+        onContinue={() => void runOldRatingRepair()}
+        title={
+          data.willConvert > 0
+            ? "Convert old star ratings?"
+            : "Refresh Bottle rating totals?"
+        }
+      />
+    </>
+  );
+}
+
+const styles = stylex.create({
+  actionRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: space.x3,
+    justifyContent: "flex-end",
+    flexWrap: "wrap",
+  },
+  sectionContent: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space.x4,
+  },
+});

--- a/apps/web/src/app/(admin)/admin/(default)/maintenance/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/maintenance/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "./maintenancePage.stylex";

--- a/apps/web/src/app/(app)/about/ratings/page.tsx
+++ b/apps/web/src/app/(app)/about/ratings/page.tsx
@@ -51,7 +51,7 @@ export default function RatingsPage() {
   return (
     <AboutPage
       currentHref="/about/ratings"
-      description="Tastings use five named ratings. Reviews keep their original scores. Bottle ratings show both without turning a tasting into an exact score."
+      description="Tastings use five named ratings. Reviews keep their original scores. Older tastings used stars; those stars map to the five current ratings."
       rail={
         <RailSection heading="Where these appear">
           <RailList ariaLabel="Rating examples">
@@ -82,6 +82,21 @@ export default function RatingsPage() {
           Pick the rating that describes the whole whisky. The same five choices
           on every tasting make bottles easier to compare.
         </AboutText>
+      </PageSection>
+
+      <PageSection heading="Old star ratings">
+        <AboutTextStack>
+          <AboutText>
+            Peated used stars before the current five ratings. We convert the
+            saved stars like this: ¼–2 becomes Mediocre; 2¼–3 becomes Good; 3¼–4
+            becomes Very good; 4¼–4½ becomes Outstanding; and 4¾–5 becomes
+            Unicorn.
+          </AboutText>
+          <AboutText>
+            A saved zero meant Not rated, so it stays unrated. We keep the
+            original stars on the tasting.
+          </AboutText>
+        </AboutTextStack>
       </PageSection>
 
       <PageSection heading="Writing a review">

--- a/apps/web/src/components/admin/moderation/automationPage.tsx
+++ b/apps/web/src/components/admin/moderation/automationPage.tsx
@@ -38,17 +38,12 @@ export default function AutomationPage() {
   const cancel = useMutation(
     orpc.prices.matchQueue.cancelRetryRun.mutationOptions(),
   );
-  const repairBottleCounts = useMutation(
-    orpc.admin.repairBottleCounts.mutationOptions(),
-  );
   const activeRun = useSuspenseQuery(
     orpc.prices.matchQueue.activeRetryRun.queryOptions({
       refetchInterval: 5_000,
     }),
   );
   const [error, setError] = useState<string | null>(null);
-  const [repairNotice, setRepairNotice] = useState<string | null>(null);
-  const [repairError, setRepairError] = useState<string | null>(null);
 
   async function refresh() {
     await Promise.all([
@@ -89,17 +84,6 @@ export default function AutomationPage() {
     }
   }
 
-  async function startBottleCountRepair() {
-    setRepairNotice(null);
-    setRepairError(null);
-    try {
-      await repairBottleCounts.mutateAsync({});
-      setRepairNotice("Repair requested.");
-    } catch {
-      setRepairError("The repair could not be started. Try again.");
-    }
-  }
-
   return (
     <>
       <ModerationNav />
@@ -119,28 +103,6 @@ export default function AutomationPage() {
           <AdminStat label="Failed" value={data.counts.failed} />
           <AdminStat label="Cleared today" value={data.counts.clearedToday} />
         </AdminStatGrid>
-        <AdminSection
-          title="Bottle counts"
-          description="Check the bottle count for every brand and producer, and fix any that are wrong. You can keep editing bottles while this runs."
-          action={
-            <Button
-              disabled={repairBottleCounts.isPending}
-              loading={repairBottleCounts.isPending}
-              onClick={() => void startBottleCountRepair()}
-              size="sm"
-            >
-              Repair counts
-            </Button>
-          }
-        >
-          {repairError ? (
-            <Alert type="error">{repairError}</Alert>
-          ) : repairNotice ? (
-            <Alert type="success">{repairNotice}</Alert>
-          ) : (
-            "This checks one brand or producer at a time."
-          )}
-        </AdminSection>
         {activeRun.data.run ? (
           <AdminSection
             title={`Active listing retry · Run #${activeRun.data.run.id}`}

--- a/docs/architecture/ratings.md
+++ b/docs/architecture/ratings.md
@@ -40,9 +40,45 @@ tasting. Repeat tastings by one member count as separate experiences. The UI
 shows band names, ranges, and raw counts. It does not turn bands into stars,
 percentages, or five-point values.
 
-Historical tastings can still have `legacySimpleRating` or
-`legacyStarRating`. These fields are read-only. They do not enter any new
-summary. Their Drizzle fields contain the same rule beside the schema.
+Old tastings can still have `legacySimpleRating` or `legacyStarRating`. These
+fields are read-only and do not affect rating totals. The one-time conversion
+uses `legacyStarRating` only when the tasting does not have one of today's
+ratings. It keeps both old values on the record.
+
+### Converting old star ratings
+
+The first tasting form used quarter-star steps. The conversion follows the old
+Pass, Sip, and Savor ranges, then splits them into today's five ratings:
+
+| Old stars | Rating      |
+| --------- | ----------- |
+| 0.25–2.00 | Mediocre    |
+| 2.25–3.00 | Good        |
+| 3.25–4.00 | Very good   |
+| 4.25–4.50 | Outstanding |
+| 4.75–5.00 | Unicorn     |
+
+Zero meant Not rated in the old form. The conversion also skips values outside
+0–5 and values that are not quarter-star steps. It never replaces a rating
+someone has already chosen.
+
+The conversion lives on Admin → Maintenance. It does not run during deployment.
+The page loads a preview before it offers the conversion. It shows how many old
+ratings exist, how many will convert, how many already have a current rating,
+which values will be skipped, and how many Bottle totals need an update.
+
+Choose **Convert tastings** and confirm the exact preview count. The server
+checks that count again before it saves anything. If the count changed, it saves
+nothing and the administrator must load a new preview. After a successful
+conversion, Peated updates the rating totals for each affected Bottle and
+BottleGroup, then the page reloads the preview. It must say there is nothing left
+to convert. If any rating-total updates could not start, the page reports how
+many failed. Use the refresh action to try them again without changing any
+tastings.
+
+After production is verified, remove the completed repair from the Maintenance
+page along with its API requests and conversion code. Keep the Maintenance page
+for future one-off repairs and keep this mapping as the record of what changed.
 
 ## Public tasting pages
 
@@ -165,12 +201,12 @@ finishes. This includes member review writes, tasting band changes, external
 review imports, moderation changes, assignments, and review publication
 changes. Large publication changes queue work in batches.
 
-Run `pnpm cli bottles fix-stats [bottleIds...]` to rebuild active Bottle and
-BottleGroup summaries. The command also checks each stored external score count
+Use **Bottle counts** on Admin → Maintenance to rebuild active Bottle and
+BottleGroup summaries. The repair also checks each saved external score count
 against the shared external-review rule.
 
-Migration 0268 starts existing review score ranges at zero. Run the command
-once after deploying that migration to fill the ranges for existing Bottles and
+Migration 0268 starts existing review score ranges at zero. After deploying
+that migration, run the repair once to fill the ranges for existing Bottles and
 BottleGroups.
 
 ## Recommendations

--- a/openspec/changes/backfill-legacy-star-ratings/.openspec.yaml
+++ b/openspec/changes/backfill-legacy-star-ratings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/backfill-legacy-star-ratings/design.md
+++ b/openspec/changes/backfill-legacy-star-ratings/design.md
@@ -1,0 +1,132 @@
+## Context
+
+The first Peated tasting form stored a number from 0 through 5 and presented
+quarter-star steps. The 2025 simple-rating migration retained that number and
+derived Pass for values through 2, Sip for values above 2 through 4, and Savor
+for values above 4. The current tasting model stores one of five named ratings
+and deliberately leaves both historical columns out of current behavior.
+
+A read-only production API inventory found 232 visible historical star ratings.
+Every value was a quarter-star increment, every simple rating matched the 2025
+conversion, and none of those rows had a current rating. The existing tasting
+API cannot expose private members outside the current account's visibility, so
+the administrator preview operation is the authoritative production inventory.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Recover current tasting ratings from historical stars with a fixed,
+  reviewable mapping.
+- Never overwrite a current rating.
+- Preserve the historical values as evidence.
+- Make the production operation previewable, stale-safe, repeatable, and easy
+  to verify.
+- Refresh every affected Bottle and BottleGroup summary.
+
+**Non-Goals:**
+
+- Convert historical values into member review scores.
+- Convert zero, out-of-range numbers, or values outside quarter-star steps.
+- Delete either historical rating column.
+- Change the current tasting or member-review write APIs.
+
+## Decisions
+
+### Keep the earlier meaning while adding more detail
+
+Use this mapping:
+
+| Historical stars | Current rating |
+| ---------------- | -------------- |
+| 0.25–2.00        | Mediocre       |
+| 2.25–3.00        | Good           |
+| 3.25–4.00        | Very good      |
+| 4.25–4.50        | Outstanding    |
+| 4.75–5.00        | Unicorn        |
+
+The first range keeps the old Pass population together. The next two divide
+the old Sip population, and the final two divide the old Savor population.
+This also preserves the current recommendation rule in which Outstanding and
+Unicorn replace Savor.
+
+A linear `stars * 20` conversion was rejected because it would label 3.75
+stars Mediocre. Rounding stars to five ordinal buckets was rejected because it
+would promote old Pass values into Good and old Sip values into Outstanding.
+
+Zero stays unchanged because the old form displayed zero as “Not rated.” Values
+outside 0–5 or outside quarter-star steps are also reported without being
+changed. Peated does not guess when the old value is unclear.
+
+### Keep the rules and database change in tested server code
+
+Keep the star-to-rating function beside the code that reads and changes the
+database. The preview reports all old star ratings, the number ready to convert,
+the number already rated, and the values that will be skipped. The conversion
+changes only tastings whose current rating is empty. It keeps both old values.
+
+Save the selected changes together. Check again that each rating is empty so a
+member's newer choice wins. If the saved count differs from the preview, save
+nothing and require another preview.
+
+### Provide separate administrator preview and convert requests
+
+Add a GET request that only counts records and a POST request that converts
+them. Both require an administrator. The POST body includes
+`expectedConversions`, copied from `willConvert` in the preview. The request
+stops if the number has changed. The Admin Maintenance page calls both
+requests. It loads the preview when the page opens, shows the counts in plain
+language, and asks for confirmation before it converts anything. This is a
+direct page for one-off repairs, not a general job system or repair framework.
+
+After a successful conversion, start the existing Bottle rating-total update
+once for each affected Bottle. Sending `expectedConversions: 0` starts those
+updates again without changing any tasting. A queue failure does not change the
+successful conversion into a failed response: log the affected Bottle ID,
+report how many updates could not start, and let the administrator retry the
+updates from Maintenance.
+
+### Keep the source values after migration
+
+Do not clear `legacyStarRating` or `legacySimpleRating`. They provide the
+evidence needed to audit the conversion and make the operation reversible.
+Current UI and summary behavior continues to read `ratingBand`.
+
+## Risks / Trade-offs
+
+- **The mapping approximates member intent** → Use the prior migration's
+  published meaning, retain the exact source value, and document the policy.
+- **A current rating could be overwritten** → Select and change only empty
+  current ratings, then compare the preview and saved counts before committing.
+- **The production set can change after preview** → Require the exact preview
+  count in the conversion request.
+- **Updating totals can fail after ratings are saved** → Report the failed
+  starts and keep a **Refresh Bottle totals** action that starts every affected
+  update again.
+- **Converted top ratings change recommendations and profile insights** → Treat
+  this as intended recovered history and cover the shared mapping in tests.
+
+## Migration Plan
+
+1. Deploy the conversion helper, protected API operations, tests, and
+   documentation.
+2. Open Admin → Maintenance and review the old star rating preview.
+3. Review `notConverted`, `notConvertedValues`, and `alreadyRated`. Stop if the
+   counts are unexpected.
+4. Confirm the conversion on the Maintenance page. The page sends the previewed
+   count with the request.
+5. Wait for the Bottle rating totals to update and run the preview again. It
+   must report `willConvert: 0` with the same old-star total.
+6. Verify Bottle and BottleGroup rating totals and sample public
+   tasting pages without exposing private tasting content.
+7. Remove the completed repair from the Maintenance page with its temporary API
+   requests and conversion code. Keep the Maintenance page, the documented
+   mapping, and the old database values.
+
+There is no automatic rollback. The old columns remain available to check the
+work, but a later current rating may be a member's new choice. Any rollback must
+review the current records rather than clearing ratings from the mapping alone.
+
+## Open Questions
+
+None.

--- a/openspec/changes/backfill-legacy-star-ratings/proposal.md
+++ b/openspec/changes/backfill-legacy-star-ratings/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Old five-star tasting ratings are preserved but excluded from current rating
+displays, totals, profiles, and recommendations. The retained
+quarter-star values and their earlier Pass/Sip/Savor conversion provide enough
+information to place them in the current five tasting ratings without changing
+newer member choices.
+
+## What Changes
+
+- Convert historical star ratings into the current Mediocre, Good, Very good,
+  Outstanding, and Unicorn tasting ratings with one fixed mapping.
+- Convert only tastings that retain a star rating and do not already have a
+  current rating.
+- Keep the original star and Pass/Sip/Savor values on the record.
+- Let administrators preview the exact number before converting anything.
+- Add a Maintenance page where administrators can preview and start this
+  one-off repair.
+- Rebuild affected Bottle and BottleGroup rating totals after the conversion.
+- Update public and internal rating documentation to describe the historical
+  conversion.
+
+## Capabilities
+
+### New Capabilities
+
+- `legacy-star-rating-backfill`: Old star conversion, write protection, preview
+  counts, and rating-total rebuilding.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Historical tasting rows and their stored `rating_band` values.
+- Bottle and BottleGroup tasting-rating totals.
+- Profile rating totals, flavor summaries, activity displays, tasting pages,
+  and Bottle recommendations that already read current tasting ratings.
+- A protected administrator API, a simple Admin Maintenance page, the rating
+  architecture guide, and the public rating guide.
+- No schema or public API changes; the new operations are internal.

--- a/openspec/changes/backfill-legacy-star-ratings/specs/legacy-star-rating-backfill/spec.md
+++ b/openspec/changes/backfill-legacy-star-ratings/specs/legacy-star-rating-backfill/spec.md
@@ -1,0 +1,130 @@
+## ADDED Requirements
+
+### Requirement: Old star conversion
+
+The system SHALL convert supported historical quarter-star values to current
+tasting ratings using this fixed mapping: 0.25–2.00 to Mediocre, 2.25–3.00 to
+Good, 3.25–4.00 to Very good, 4.25–4.50 to Outstanding, and 4.75–5.00 to
+Unicorn. It MUST leave zero, out-of-range values, and values outside
+quarter-star steps unconverted.
+
+#### Scenario: Supported star value
+
+- **WHEN** a historical tasting has 3.75 stars and no current rating
+- **THEN** the conversion assigns Very good
+
+#### Scenario: Historical zero
+
+- **WHEN** a historical tasting has zero stars
+- **THEN** the preview reports it as not converted and does not assign a current
+  rating
+
+#### Scenario: Unsupported star value
+
+- **WHEN** a historical tasting has an out-of-range or non-quarter-star value
+- **THEN** the preview reports it as not converted and does not assign a current
+  rating
+
+### Requirement: Current rating wins
+
+The system MUST assign a converted rating only when the tasting's current
+rating is null. It MUST preserve both historical rating values whether or not
+it assigns a current rating.
+
+#### Scenario: Tasting already has a current rating
+
+- **WHEN** a historical tasting already has a current rating
+- **THEN** the conversion leaves that rating unchanged
+- **AND** reports the tasting as already rated
+
+#### Scenario: Historical evidence is retained
+
+- **WHEN** the conversion assigns a current rating
+- **THEN** the exact historical star and Pass/Sip/Savor values remain unchanged
+
+#### Scenario: Concurrent member edit
+
+- **WHEN** a tasting gains a current rating after preview but before conversion
+- **THEN** the conversion does not overwrite the member's rating
+- **AND** rolls back the stale write set
+
+### Requirement: Fresh preview count
+
+The system SHALL provide an administrator-only preview that reports
+`oldStarRatings`, `willConvert`, `alreadyRated`, `notConverted`, `ratings`, and
+`bottles`. A separate administrator-only conversion request MUST require
+`expectedConversions` copied from `willConvert` in a current preview.
+
+#### Scenario: Preview request
+
+- **WHEN** an administrator requests a preview
+- **THEN** it reports what would change without changing a tasting or starting
+  Bottle total updates
+
+#### Scenario: Matching expected count
+
+- **WHEN** an administrator requests conversion with the current preview count
+- **THEN** it applies exactly that many conversions
+
+#### Scenario: Stale expected count
+
+- **WHEN** `expectedConversions` differs from the current `willConvert` count
+- **THEN** the API returns a conflict before changing any tasting
+
+#### Scenario: Non-administrator request
+
+- **WHEN** a non-administrator requests preview or conversion
+- **THEN** the API rejects the request
+
+### Requirement: Bottle rating totals
+
+After a successful conversion, the system SHALL start the existing rating-total
+update for every Bottle that has a converted old star rating. Sending
+`expectedConversions: 0` after every row is converted SHALL start the same
+updates without changing tasting rows.
+
+#### Scenario: Successful conversion
+
+- **WHEN** the conversion changes one or more old tastings
+- **THEN** Peated starts updating the affected Bottle and BottleGroup rating
+  totals
+
+#### Scenario: Summary retry
+
+- **WHEN** the ratings are already converted and an administrator sends
+  `expectedConversions: 0`
+- **THEN** no tasting changes
+- **AND** the affected Bottle rating-total updates start again
+
+#### Scenario: A total update cannot start
+
+- **WHEN** a tasting conversion is saved but a Bottle rating-total update cannot
+  start
+- **THEN** the conversion still succeeds
+- **AND** the response reports the failed update
+- **AND** the administrator can start the Bottle updates again from Maintenance
+
+### Requirement: Admin Maintenance page
+
+The system SHALL give administrators a Maintenance page that previews the old
+star rating repair and provides a direct way to start it. The page MUST show the
+current counts before offering the action and MUST ask for confirmation before
+it sends the conversion request.
+
+#### Scenario: Administrator opens Maintenance
+
+- **WHEN** an administrator opens the Maintenance page
+- **THEN** the page shows how many tastings will change, how many will not
+  change, and how many Bottles need updated totals
+
+#### Scenario: Administrator starts the repair
+
+- **WHEN** an administrator confirms the old star rating repair
+- **THEN** the page sends the previewed conversion count
+- **AND** reloads the preview after the request succeeds
+
+#### Scenario: Repair is complete
+
+- **WHEN** the preview reports no tastings left to convert
+- **THEN** the page says that there is nothing to convert
+- **AND** does not offer the conversion action

--- a/openspec/changes/backfill-legacy-star-ratings/tasks.md
+++ b/openspec/changes/backfill-legacy-star-ratings/tasks.md
@@ -1,0 +1,21 @@
+## 1. Conversion And Persistence
+
+- [x] 1.1 Add the fixed old-star conversion and preview report
+- [x] 1.2 Add the all-or-nothing conversion guarded by the preview count
+- [x] 1.3 Test the mapping, preview, saved old values, changed preview count, and safe repeat runs
+
+## 2. Operation
+
+- [x] 2.1 Add protected preview and convert API requests with Bottle rating-total updates
+- [x] 2.2 Explain the old-star conversion and operating steps in the internal and public rating guides
+
+## 3. Verification
+
+- [x] 3.1 Run focused backend tests, server and web typechecks, lint, formatting, and OpenSpec validation
+- [x] 3.2 Exercise the API operations through integration tests and confirm preview makes no changes
+
+## 4. Admin Maintenance
+
+- [x] 4.1 Add a Maintenance page with a plain-language old star rating preview
+- [x] 4.2 Add a confirmed action that sends the preview count and refreshes the result
+- [x] 4.3 Test the administrator flow and update the operating guide

--- a/skills/peated-cli/SKILL.md
+++ b/skills/peated-cli/SKILL.md
@@ -1,31 +1,30 @@
 ---
 name: peated-cli
-description: Operate the Peated repository CLI for OAuth, API reads and writes, moderation queues, classifier runs, maintenance commands, and CLI diagnosis. Use for `pnpm cli`, production API access, or `.env.local` command workflows.
+description: Use Peated's authenticated API client for OAuth-backed production API reads and writes through `pnpm cli auth` and `pnpm cli api`. Direct database-backed CLI command groups are legacy and unsupported for operations.
 ---
 
-# Peated CLI
+# Peated API Client
 
-Run from the repository root through `pnpm cli`.
+Run the authenticated client from the repository root.
 
-## Select the Boundary
+## Supported Boundary
 
-| Surface                                    | Target                                       |
-| ------------------------------------------ | -------------------------------------------- |
-| `auth`, `api`                              | OAuth-backed HTTP API; production by default |
-| `classifier`                               | `.env.local` DB, search, and model services  |
-| `bottles`, `prices`, `users`, `db`, others | `.env.local` DB, queue, or storage           |
+| Surface         | Target                                       |
+| --------------- | -------------------------------------------- |
+| `pnpm cli auth` | OAuth credentials                            |
+| `pnpm cli api`  | OAuth-backed HTTP API; production by default |
 
-For non-`api` commands, inspect `pnpm cli <domain> --help`, `.env.local`, and
-`apps/cli/src/commands/<domain>.ts` before execution.
+Do not add, recommend, or use direct database-backed command groups for
+operations. Those commands are legacy. If an operation is not available over
+HTTP, add a permission-checked API route and call it through `pnpm cli api`.
 
 ## Workflow
 
-1. Discover commands with `pnpm cli --help` and subcommand help.
-2. Resolve IDs and state read-only.
-3. Check the current OpenAPI spec or owning route before building API writes.
-4. Prefer dry-run, explicit IDs, and small limits.
-5. Obtain authorization for the exact mutation scope.
-6. Re-fetch after writes; stop on stale state, conflicts, or changed identity.
+1. Resolve IDs and state through read-only API requests.
+2. Check the current OpenAPI spec or owning route before building API writes.
+3. Prefer preview routes, explicit IDs, and small limits.
+4. Obtain authorization for the exact mutation scope.
+5. Re-fetch after writes; stop on stale state, conflicts, or changed identity.
 
 Never expose tokens, OAuth codes, authorization headers, or private user data.
 Never infer write permission from a request to inspect, diagnose, or review.
@@ -34,9 +33,6 @@ Read only the relevant reference:
 
 - OAuth or generic API: [authenticated-api.md](references/authenticated-api.md)
 - Price-match review or resolution: [moderation.md](references/moderation.md)
-
-For classifier commands, first inspect `pnpm cli classifier --help`. Live runs
-may use paid model/search services; use stored tests or evals when sufficient.
 
 Report target environment, read/write status, affected IDs or bounded counts,
 verification, and skipped ambiguous items.


### PR DESCRIPTION
Peated can now recover current tasting ratings from the original quarter-star system through Admin → Maintenance. The page previews the exact affected count, preserves existing ratings and saved stars, requires confirmation, and converts the supported ranges in one guarded transaction. Bottle rating totals are recalculated afterward, with failed job starts reported and a safe refresh action available.

Maintenance now also owns the existing Bottle-count repair instead of mixing it into moderation automation. The public ratings guide records the historical mapping, and the repository’s operating guidance now limits production CLI use to the authenticated OAuth/API client.
