### PR TITLE
feat(server): keep location bottle counts current

### DIFF
--- a/apps/server/src/lib/createBottle.test.ts
+++ b/apps/server/src/lib/createBottle.test.ts
@@ -8,7 +8,9 @@ import {
   bottles,
   bottlesToDistillers,
   changes,
+  countries,
   entities,
+  regions,
   type User,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
@@ -33,6 +35,37 @@ interface BottleCreateAttempt {
 }
 
 describe("Bottle creation", () => {
+  test("updates production-location Bottle counts", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const country = await fixtures.Country({ totalBottles: 0 });
+    const region = await fixtures.Region({
+      countryId: country.id,
+      totalBottles: 0,
+    });
+    const distillery = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+    });
+
+    await createBottle({
+      context: contextFor(defaults.user),
+      input: {
+        name: "Located Bottle",
+        brand: (await fixtures.Entity()).id,
+        distillers: [distillery.id],
+      },
+    });
+
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, country.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, region.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+  });
+
   test("creates an atomic singleton graph from flat Bottle input", async ({
     defaults,
     fixtures,

--- a/apps/server/src/lib/createBottle.ts
+++ b/apps/server/src/lib/createBottle.ts
@@ -40,6 +40,10 @@ import {
   updateEntityBottleCounts,
 } from "@peated/server/lib/entityBottleCounts";
 import { formatBottleName } from "@peated/server/lib/format";
+import {
+  getBottleProductionLocations,
+  updateLocationBottleCounts,
+} from "@peated/server/lib/locationBottleCounts";
 import { logError } from "@peated/server/lib/log";
 import { resolveActiveBottleIds } from "@peated/server/lib/resolveActiveBottleIds";
 import { buildBottleSearchVector } from "@peated/server/lib/search";
@@ -631,6 +635,10 @@ export async function createBottleInTransaction(
     bottleResult.bottle.id,
   ]);
   await updateEntityBottleCounts(tx, [], bottleEntityLinks);
+  const bottleLocations = await getBottleProductionLocations(tx, [
+    bottleResult.bottle.id,
+  ]);
+  await updateLocationBottleCounts(tx, [], bottleLocations);
 
   return {
     ...bottleResult,

--- a/apps/server/src/lib/locationBottleCounts.test.ts
+++ b/apps/server/src/lib/locationBottleCounts.test.ts
@@ -1,0 +1,240 @@
+import { db } from "@peated/server/db";
+import {
+  bottleTombstones,
+  bottlesToDistillers,
+  countries,
+  regions,
+} from "@peated/server/db/schema";
+import { eq } from "drizzle-orm";
+import {
+  checkLocationBottleCounts,
+  getBottleProductionLocations,
+  repairLocationBottleCount,
+  updateLocationBottleCounts,
+} from "./locationBottleCounts";
+
+describe("location Bottle counts", () => {
+  test("counts one Bottle once when Distilleries share a location", async ({
+    fixtures,
+  }) => {
+    const country = await fixtures.Country({ totalBottles: 0 });
+    const region = await fixtures.Region({
+      countryId: country.id,
+      totalBottles: 0,
+    });
+    const firstDistillery = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+    });
+    const secondDistillery = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+    });
+    const bottle = await fixtures.Bottle({
+      distillerIds: [firstDistillery.id, secondDistillery.id],
+    });
+    await db.update(countries).set({ totalBottles: 0 });
+    await db.update(regions).set({ totalBottles: 0 });
+
+    await db.transaction(async (tx) => {
+      const after = await getBottleProductionLocations(tx, [bottle.id]);
+      await updateLocationBottleCounts(tx, [], after);
+    });
+
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, country.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, region.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+  });
+
+  test("moves a Bottle between production locations", async ({ fixtures }) => {
+    const oldCountry = await fixtures.Country({ totalBottles: 0 });
+    const oldRegion = await fixtures.Region({
+      countryId: oldCountry.id,
+      totalBottles: 0,
+    });
+    const newCountry = await fixtures.Country({ totalBottles: 0 });
+    const newRegion = await fixtures.Region({
+      countryId: newCountry.id,
+      totalBottles: 0,
+    });
+    const oldDistillery = await fixtures.Entity({
+      countryId: oldCountry.id,
+      regionId: oldRegion.id,
+    });
+    const newDistillery = await fixtures.Entity({
+      countryId: newCountry.id,
+      regionId: newRegion.id,
+    });
+    const bottle = await fixtures.Bottle({
+      distillerIds: [oldDistillery.id],
+    });
+
+    await db.transaction(async (tx) => {
+      const before = await getBottleProductionLocations(tx, [bottle.id]);
+      await tx
+        .delete(bottlesToDistillers)
+        .where(eq(bottlesToDistillers.bottleId, bottle.id));
+      await tx.insert(bottlesToDistillers).values({
+        bottleId: bottle.id,
+        distillerId: newDistillery.id,
+      });
+      const after = await getBottleProductionLocations(tx, [bottle.id]);
+      await updateLocationBottleCounts(tx, before, after);
+    });
+
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, oldCountry.id) }),
+    ).resolves.toMatchObject({ totalBottles: 0 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, oldRegion.id) }),
+    ).resolves.toMatchObject({ totalBottles: 0 });
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, newCountry.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, newRegion.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+  });
+
+  test("repairs an old undercount when removing a Bottle", async ({
+    fixtures,
+  }) => {
+    const country = await fixtures.Country({ totalBottles: 0 });
+    const region = await fixtures.Region({
+      countryId: country.id,
+      totalBottles: 0,
+    });
+    const distillery = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+    });
+    const removedBottle = await fixtures.Bottle({
+      distillerIds: [distillery.id],
+    });
+    await fixtures.Bottle({ distillerIds: [distillery.id] });
+    await db
+      .update(countries)
+      .set({ totalBottles: 0 })
+      .where(eq(countries.id, country.id));
+    await db
+      .update(regions)
+      .set({ totalBottles: 0 })
+      .where(eq(regions.id, region.id));
+
+    await db.transaction(async (tx) => {
+      const before = await getBottleProductionLocations(tx, [removedBottle.id]);
+      await tx.insert(bottleTombstones).values({
+        bottleId: removedBottle.id,
+      });
+      const after = await getBottleProductionLocations(tx, [removedBottle.id]);
+      await updateLocationBottleCounts(tx, before, after);
+    });
+
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, country.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, region.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+  });
+
+  test("counts concurrent Bottles without losing an update", async ({
+    fixtures,
+  }) => {
+    const country = await fixtures.Country({ totalBottles: 0 });
+    const region = await fixtures.Region({
+      countryId: country.id,
+      totalBottles: 0,
+    });
+    const distillery = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+    });
+    const first = await fixtures.Bottle({ distillerIds: [distillery.id] });
+    const second = await fixtures.Bottle({ distillerIds: [distillery.id] });
+    await db
+      .update(countries)
+      .set({ totalBottles: 0 })
+      .where(eq(countries.id, country.id));
+    await db
+      .update(regions)
+      .set({ totalBottles: 0 })
+      .where(eq(regions.id, region.id));
+
+    await Promise.all(
+      [first.id, second.id].map((bottleId) =>
+        db.transaction(async (tx) => {
+          const after = await getBottleProductionLocations(tx, [bottleId]);
+          await updateLocationBottleCounts(tx, [], after);
+        }),
+      ),
+    );
+
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, country.id) }),
+    ).resolves.toMatchObject({ totalBottles: 2 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, region.id) }),
+    ).resolves.toMatchObject({ totalBottles: 2 });
+  });
+
+  test("finds and repairs wrong saved counts", async ({ fixtures }) => {
+    const country = await fixtures.Country({ totalBottles: 0 });
+    const region = await fixtures.Region({
+      countryId: country.id,
+      totalBottles: 0,
+    });
+    const correctEmptyCountry = await fixtures.Country({ totalBottles: 0 });
+    const distillery = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+    });
+    await fixtures.Bottle({ distillerIds: [distillery.id] });
+    await db
+      .update(countries)
+      .set({ totalBottles: 9 })
+      .where(eq(countries.id, country.id));
+    await db
+      .update(regions)
+      .set({ totalBottles: 8 })
+      .where(eq(regions.id, region.id));
+
+    const locations = [
+      { kind: "country" as const, locationId: country.id },
+      { kind: "country" as const, locationId: correctEmptyCountry.id },
+      { kind: "region" as const, locationId: region.id },
+    ];
+    await expect(checkLocationBottleCounts(locations)).resolves.toEqual([
+      {
+        kind: "country",
+        locationId: country.id,
+        savedCount: 9,
+        actualCount: 1,
+      },
+      {
+        kind: "region",
+        locationId: region.id,
+        savedCount: 8,
+        actualCount: 1,
+      },
+    ]);
+    await expect(checkLocationBottleCounts([])).resolves.toEqual([]);
+
+    await expect(repairLocationBottleCount(locations[0]!)).resolves.toEqual({
+      kind: "country",
+      locationId: country.id,
+      savedCount: 9,
+      actualCount: 1,
+    });
+    await expect(repairLocationBottleCount(locations[2]!)).resolves.toEqual({
+      kind: "region",
+      locationId: region.id,
+      savedCount: 8,
+      actualCount: 1,
+    });
+    await expect(checkLocationBottleCounts(locations)).resolves.toEqual([]);
+  });
+});

--- a/apps/server/src/lib/locationBottleCounts.ts
+++ b/apps/server/src/lib/locationBottleCounts.ts
@@ -1,0 +1,382 @@
+import { db, type AnyDatabase, type AnyTransaction } from "@peated/server/db";
+import {
+  bottleTombstones,
+  bottles,
+  bottlesToDistillers,
+  countries,
+  entities,
+  regions,
+} from "@peated/server/db/schema";
+import {
+  and,
+  asc,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  sql,
+} from "drizzle-orm";
+
+export type BottleProductionLocations = {
+  bottleId: number;
+  countryIds: number[];
+  regionIds: number[];
+};
+
+export type BottleCountLocation =
+  | { kind: "country"; locationId: number }
+  | { kind: "region"; locationId: number };
+
+export type WrongLocationBottleCount = BottleCountLocation & {
+  savedCount: number;
+  actualCount: number;
+};
+
+function uniqueSorted(values: readonly number[]): number[] {
+  return Array.from(new Set(values)).sort((left, right) => left - right);
+}
+
+/** Returns each active Bottle's distinct producing Country and Region IDs. */
+export async function getBottleProductionLocations(
+  tx: AnyTransaction,
+  bottleIds: readonly number[],
+): Promise<BottleProductionLocations[]> {
+  const ids = uniqueSorted(bottleIds);
+  if (!ids.length) return [];
+
+  const rows = await tx
+    .select({
+      bottleId: bottles.id,
+      countryId: entities.countryId,
+      regionId: entities.regionId,
+    })
+    .from(bottles)
+    .innerJoin(
+      bottlesToDistillers,
+      eq(bottlesToDistillers.bottleId, bottles.id),
+    )
+    .innerJoin(entities, eq(entities.id, bottlesToDistillers.distillerId))
+    .leftJoin(bottleTombstones, eq(bottleTombstones.bottleId, bottles.id))
+    .where(
+      and(
+        inArray(bottles.id, ids),
+        isNotNull(bottles.groupId),
+        isNull(bottleTombstones.bottleId),
+      ),
+    )
+    .orderBy(asc(bottles.id), asc(entities.countryId), asc(entities.regionId));
+
+  const locations = new Map<
+    number,
+    { countryIds: Set<number>; regionIds: Set<number> }
+  >();
+  for (const row of rows) {
+    const bottleLocations = locations.get(row.bottleId) ?? {
+      countryIds: new Set<number>(),
+      regionIds: new Set<number>(),
+    };
+    if (row.countryId !== null) bottleLocations.countryIds.add(row.countryId);
+    if (row.regionId !== null) bottleLocations.regionIds.add(row.regionId);
+    locations.set(row.bottleId, bottleLocations);
+  }
+
+  return Array.from(locations, ([bottleId, bottleLocations]) => ({
+    bottleId,
+    countryIds: uniqueSorted(Array.from(bottleLocations.countryIds)),
+    regionIds: uniqueSorted(Array.from(bottleLocations.regionIds)),
+  })).sort((left, right) => left.bottleId - right.bottleId);
+}
+
+function addLocationChanges(
+  changes: Map<number, number>,
+  locations: readonly BottleProductionLocations[],
+  key: "countryIds" | "regionIds",
+  change: number,
+) {
+  for (const bottleLocations of locations) {
+    for (const locationId of bottleLocations[key]) {
+      changes.set(locationId, (changes.get(locationId) ?? 0) + change);
+    }
+  }
+}
+
+type CountQueryRow = {
+  kind: "country" | "region";
+  locationId: number | string;
+  savedCount: number | string;
+  actualCount: number | string;
+};
+
+async function findWrongLocationBottleCounts(
+  database: AnyDatabase,
+  locations?: readonly BottleCountLocation[],
+): Promise<WrongLocationBottleCount[]> {
+  const countryIds =
+    locations === undefined
+      ? undefined
+      : uniqueSorted(
+          locations.flatMap((location) =>
+            location.kind === "country" ? [location.locationId] : [],
+          ),
+        );
+  const regionIds =
+    locations === undefined
+      ? undefined
+      : uniqueSorted(
+          locations.flatMap((location) =>
+            location.kind === "region" ? [location.locationId] : [],
+          ),
+        );
+  if (countryIds?.length === 0 && regionIds?.length === 0) return [];
+
+  const countrySourceFilter =
+    countryIds === undefined
+      ? sql`TRUE`
+      : countryIds.length
+        ? inArray(entities.countryId, countryIds)
+        : sql`FALSE`;
+  const regionSourceFilter =
+    regionIds === undefined
+      ? sql`TRUE`
+      : regionIds.length
+        ? inArray(entities.regionId, regionIds)
+        : sql`FALSE`;
+  const countryFilter =
+    countryIds === undefined
+      ? sql`TRUE`
+      : countryIds.length
+        ? inArray(countries.id, countryIds)
+        : sql`FALSE`;
+  const regionFilter =
+    regionIds === undefined
+      ? sql`TRUE`
+      : regionIds.length
+        ? inArray(regions.id, regionIds)
+        : sql`FALSE`;
+
+  const result = await database.execute<CountQueryRow>(sql`
+    WITH active_bottle_locations AS (
+      SELECT
+        ${bottles.id} AS bottle_id,
+        'country'::text AS kind,
+        ${entities.countryId} AS location_id
+      FROM ${bottles}
+      INNER JOIN ${bottlesToDistillers}
+        ON ${bottlesToDistillers.bottleId} = ${bottles.id}
+      INNER JOIN ${entities}
+        ON ${entities.id} = ${bottlesToDistillers.distillerId}
+      WHERE ${bottles.groupId} IS NOT NULL
+        AND ${entities.countryId} IS NOT NULL
+        AND ${countrySourceFilter}
+        AND NOT EXISTS (
+          SELECT 1 FROM ${bottleTombstones}
+          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
+        )
+
+      UNION
+
+      SELECT
+        ${bottles.id} AS bottle_id,
+        'region'::text AS kind,
+        ${entities.regionId} AS location_id
+      FROM ${bottles}
+      INNER JOIN ${bottlesToDistillers}
+        ON ${bottlesToDistillers.bottleId} = ${bottles.id}
+      INNER JOIN ${entities}
+        ON ${entities.id} = ${bottlesToDistillers.distillerId}
+      WHERE ${bottles.groupId} IS NOT NULL
+        AND ${entities.regionId} IS NOT NULL
+        AND ${regionSourceFilter}
+        AND NOT EXISTS (
+          SELECT 1 FROM ${bottleTombstones}
+          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
+        )
+    ), actual_counts AS (
+      SELECT kind, location_id, COUNT(*) AS total
+      FROM active_bottle_locations
+      GROUP BY kind, location_id
+    ), saved_counts AS (
+      SELECT
+        'country'::text AS kind,
+        ${countries.id} AS location_id,
+        ${countries.totalBottles} AS saved_count
+      FROM ${countries}
+      WHERE ${countryFilter}
+
+      UNION ALL
+
+      SELECT
+        'region'::text AS kind,
+        ${regions.id} AS location_id,
+        ${regions.totalBottles} AS saved_count
+      FROM ${regions}
+      WHERE ${regionFilter}
+    )
+    SELECT
+      saved_counts.kind,
+      saved_counts.location_id AS "locationId",
+      saved_counts.saved_count AS "savedCount",
+      COALESCE(actual_counts.total, 0) AS "actualCount"
+    FROM saved_counts
+    LEFT JOIN actual_counts
+      ON actual_counts.kind = saved_counts.kind
+      AND actual_counts.location_id = saved_counts.location_id
+    WHERE saved_counts.saved_count <> COALESCE(actual_counts.total, 0)
+    ORDER BY
+      CASE saved_counts.kind WHEN 'country' THEN 0 ELSE 1 END,
+      saved_counts.location_id
+  `);
+
+  return result.rows.map((row) => ({
+    kind: row.kind,
+    locationId: Number(row.locationId),
+    savedCount: Number(row.savedCount),
+    actualCount: Number(row.actualCount),
+  }));
+}
+
+async function repairExistingLocationBottleCount(
+  tx: AnyTransaction,
+  location: BottleCountLocation,
+): Promise<WrongLocationBottleCount | null> {
+  const [difference] = await findWrongLocationBottleCounts(tx, [location]);
+  if (!difference) return null;
+
+  if (location.kind === "country") {
+    await tx
+      .update(countries)
+      .set({ totalBottles: difference.actualCount })
+      .where(eq(countries.id, location.locationId));
+  } else {
+    await tx
+      .update(regions)
+      .set({ totalBottles: difference.actualCount })
+      .where(eq(regions.id, location.locationId));
+  }
+  return difference;
+}
+
+async function updateCountryBottleCount(
+  tx: AnyTransaction,
+  countryId: number,
+  change: number,
+) {
+  const [updatedCountry] = await tx
+    .update(countries)
+    .set({ totalBottles: sql`${countries.totalBottles} + ${change}` })
+    .where(
+      and(
+        eq(countries.id, countryId),
+        change < 0 ? gte(countries.totalBottles, -change) : undefined,
+      ),
+    )
+    .returning({ id: countries.id });
+  if (updatedCountry) return;
+
+  const [country] = await tx
+    .select({ id: countries.id })
+    .from(countries)
+    .where(eq(countries.id, countryId))
+    .for("update");
+  if (!country) {
+    throw new Error(
+      `Cannot update Bottle count: Country ${countryId} is missing.`,
+    );
+  }
+  await repairExistingLocationBottleCount(tx, {
+    kind: "country",
+    locationId: countryId,
+  });
+}
+
+async function updateRegionBottleCount(
+  tx: AnyTransaction,
+  regionId: number,
+  change: number,
+) {
+  const [updatedRegion] = await tx
+    .update(regions)
+    .set({ totalBottles: sql`${regions.totalBottles} + ${change}` })
+    .where(
+      and(
+        eq(regions.id, regionId),
+        change < 0 ? gte(regions.totalBottles, -change) : undefined,
+      ),
+    )
+    .returning({ id: regions.id });
+  if (updatedRegion) return;
+
+  const [region] = await tx
+    .select({ id: regions.id })
+    .from(regions)
+    .where(eq(regions.id, regionId))
+    .for("update");
+  if (!region) {
+    throw new Error(
+      `Cannot update Bottle count: Region ${regionId} is missing.`,
+    );
+  }
+  await repairExistingLocationBottleCount(tx, {
+    kind: "region",
+    locationId: regionId,
+  });
+}
+
+/** Saves production-location changes in the caller's catalog transaction. */
+export async function updateLocationBottleCounts(
+  tx: AnyTransaction,
+  locationsBefore: readonly BottleProductionLocations[],
+  locationsAfter: readonly BottleProductionLocations[],
+): Promise<void> {
+  const countryChanges = new Map<number, number>();
+  const regionChanges = new Map<number, number>();
+  addLocationChanges(countryChanges, locationsBefore, "countryIds", -1);
+  addLocationChanges(countryChanges, locationsAfter, "countryIds", 1);
+  addLocationChanges(regionChanges, locationsBefore, "regionIds", -1);
+  addLocationChanges(regionChanges, locationsAfter, "regionIds", 1);
+
+  // Bottle writes own these totals and always lock Countries before Regions,
+  // in ID order. The helpers also repair an old undercount before it can fall
+  // below zero.
+  for (const [countryId, change] of Array.from(countryChanges)
+    .filter(([, change]) => change !== 0)
+    .sort(([left], [right]) => left - right)) {
+    await updateCountryBottleCount(tx, countryId, change);
+  }
+  for (const [regionId, change] of Array.from(regionChanges)
+    .filter(([, change]) => change !== 0)
+    .sort(([left], [right]) => left - right)) {
+    await updateRegionBottleCount(tx, regionId, change);
+  }
+}
+
+/** Checks saved location Bottle totals against active Distillery links. */
+export async function checkLocationBottleCounts(
+  locations?: readonly BottleCountLocation[],
+): Promise<WrongLocationBottleCount[]> {
+  return findWrongLocationBottleCounts(db, locations);
+}
+
+/** Repairs one location after taking the row lock used by normal Bottle writes. */
+export async function repairLocationBottleCount(
+  location: BottleCountLocation,
+): Promise<WrongLocationBottleCount | null> {
+  return db.transaction(async (tx) => {
+    const rows =
+      location.kind === "country"
+        ? await tx
+            .select({ id: countries.id })
+            .from(countries)
+            .where(eq(countries.id, location.locationId))
+            .for("update")
+        : await tx
+            .select({ id: regions.id })
+            .from(regions)
+            .where(eq(regions.id, location.locationId))
+            .for("update");
+    if (!rows.length) return null;
+
+    return repairExistingLocationBottleCount(tx, location);
+  });
+}

--- a/apps/server/src/lib/mergeBottles.test.ts
+++ b/apps/server/src/lib/mergeBottles.test.ts
@@ -13,11 +13,13 @@ import {
   changes,
   collectionBottles,
   collections,
+  countries,
   entities,
   externalReviews,
   flightBottles,
   incomingBottleDecisionLogs,
   memberReviews,
+  regions,
   storePriceMatchAttempts,
   storePriceMatchProposals,
   storePrices,
@@ -443,18 +445,37 @@ describe("exact Bottle merges", () => {
   }) => {
     const mod = await fixtures.User({ mod: true });
     const brand = await fixtures.Entity({ name: "Low Count Merge Brand" });
+    const country = await fixtures.Country({ totalBottles: 0 });
+    const region = await fixtures.Region({
+      countryId: country.id,
+      totalBottles: 0,
+    });
+    const distillery = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+    });
     const source = await fixtures.Bottle({
       name: "Low Count Merge Source",
       brandId: brand.id,
+      distillerIds: [distillery.id],
     });
     const destination = await fixtures.Bottle({
       name: "Low Count Merge Destination",
       brandId: brand.id,
+      distillerIds: [distillery.id],
     });
     await db
       .update(entities)
       .set({ totalBottles: 0 })
       .where(eq(entities.id, brand.id));
+    await db
+      .update(countries)
+      .set({ totalBottles: 0 })
+      .where(eq(countries.id, country.id));
+    await db
+      .update(regions)
+      .set({ totalBottles: 0 })
+      .where(eq(regions.id, region.id));
 
     await mergeBottles({
       sourceBottleId: source.id,
@@ -467,6 +488,12 @@ describe("exact Bottle merges", () => {
     ).resolves.toBeUndefined();
     await expect(
       db.query.entities.findFirst({ where: eq(entities.id, brand.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, country.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, region.id) }),
     ).resolves.toMatchObject({ totalBottles: 1 });
   });
 

--- a/apps/server/src/lib/mergeBottles.ts
+++ b/apps/server/src/lib/mergeBottles.ts
@@ -34,6 +34,10 @@ import {
   getBottleEntityLinks,
   updateEntityBottleCounts,
 } from "@peated/server/lib/entityBottleCounts";
+import {
+  getBottleProductionLocations,
+  updateLocationBottleCounts,
+} from "@peated/server/lib/locationBottleCounts";
 import { logError } from "@peated/server/lib/log";
 import { recomputeBottleGroupStatsInTransaction } from "@peated/server/lib/recomputeBottleGroupStats";
 import { recomputeBottleStatsInTransaction } from "@peated/server/lib/recomputeBottleStats";
@@ -768,6 +772,10 @@ export async function mergeBottlesInTransaction(
     throw new BottleMergeGraphError("invalid_catalog_graph", sourceBottleId);
   }
   const entityLinksBefore = await getBottleEntityLinks(tx, requestedBottleIds);
+  const locationsBefore = await getBottleProductionLocations(
+    tx,
+    requestedBottleIds,
+  );
   const crossGroup = sourceGroupId !== destinationGroupId;
   const survivingSourceMembers = sourceMembers.filter(
     ({ id }) => id !== sourceBottleId,
@@ -945,6 +953,11 @@ export async function mergeBottlesInTransaction(
 
   const entityLinksAfter = await getBottleEntityLinks(tx, requestedBottleIds);
   await updateEntityBottleCounts(tx, entityLinksBefore, entityLinksAfter);
+  const locationsAfter = await getBottleProductionLocations(
+    tx,
+    requestedBottleIds,
+  );
+  await updateLocationBottleCounts(tx, locationsBefore, locationsAfter);
 
   if (crossGroup && sourceSingleton) {
     await tx

--- a/apps/server/src/lib/test/fixtures.ts
+++ b/apps/server/src/lib/test/fixtures.ts
@@ -56,6 +56,10 @@ import {
   updateEntityBottleCounts,
 } from "../entityBottleCounts";
 import { formatBottleName } from "../format";
+import {
+  getBottleProductionLocations,
+  updateLocationBottleCounts,
+} from "../locationBottleCounts";
 import { choose, random, sample } from "../rand";
 import {
   buildBottleSearchVector,
@@ -720,6 +724,8 @@ async function createBottleFixture(
 
     const bottleEntityLinks = await getBottleEntityLinks(tx, [bottle.id]);
     await updateEntityBottleCounts(tx, [], bottleEntityLinks);
+    const bottleLocations = await getBottleProductionLocations(tx, [bottle.id]);
+    await updateLocationBottleCounts(tx, [], bottleLocations);
 
     await tx
       .insert(bottleReferences)

--- a/apps/server/src/lib/updateBottle.test.ts
+++ b/apps/server/src/lib/updateBottle.test.ts
@@ -9,7 +9,9 @@ import {
   bottles,
   bottlesToDistillers,
   changes,
+  countries,
   entities,
+  regions,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
 import { materializeBottleForGroup } from "@peated/server/lib/bottleIdentity";
@@ -691,6 +693,58 @@ describe("Bottle updates", () => {
       }),
     ).resolves.toMatchObject({ changed: false });
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+  });
+
+  test("moves production-location Bottle counts with Distillery links", async ({
+    fixtures,
+  }) => {
+    const mod = await fixtures.User({ mod: true });
+    const oldCountry = await fixtures.Country({ totalBottles: 0 });
+    const oldRegion = await fixtures.Region({
+      countryId: oldCountry.id,
+      totalBottles: 0,
+    });
+    const newCountry = await fixtures.Country({ totalBottles: 0 });
+    const newRegion = await fixtures.Region({
+      countryId: newCountry.id,
+      totalBottles: 0,
+    });
+    const oldDistillery = await fixtures.Entity({
+      countryId: oldCountry.id,
+      regionId: oldRegion.id,
+    });
+    const newDistillery = await fixtures.Entity({
+      countryId: newCountry.id,
+      regionId: newRegion.id,
+    });
+    const { first } = await createGroup({
+      user: mod,
+      stable: {
+        name: "Location Change",
+        brand: (await fixtures.Entity()).id,
+        distillers: [oldDistillery.id],
+      },
+      exacts: [{ edition: "One" }],
+    });
+
+    await updateBottle({
+      bottleId: first.bottle.id,
+      input: { distillers: [newDistillery.id] },
+      context: contextFor(mod),
+    });
+
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, oldCountry.id) }),
+    ).resolves.toMatchObject({ totalBottles: 0 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, oldRegion.id) }),
+    ).resolves.toMatchObject({ totalBottles: 0 });
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, newCountry.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, newRegion.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
   });
 
   test("changes relationships when the old Entity count is too low", async ({

--- a/apps/server/src/lib/updateBottle.ts
+++ b/apps/server/src/lib/updateBottle.ts
@@ -54,6 +54,10 @@ import {
   updateEntityBottleCounts,
 } from "@peated/server/lib/entityBottleCounts";
 import { formatBottleName } from "@peated/server/lib/format";
+import {
+  getBottleProductionLocations,
+  updateLocationBottleCounts,
+} from "@peated/server/lib/locationBottleCounts";
 import { logError } from "@peated/server/lib/log";
 import type { Context } from "@peated/server/orpc/context";
 import { EntityChoiceInputSchema } from "@peated/server/schemas";
@@ -1397,6 +1401,9 @@ export async function updateBottleInTransaction(
   const entityLinksBefore = bottleEntityLinksChanged
     ? await getBottleEntityLinks(tx, affectedIds)
     : [];
+  const locationsBefore = groupDistillersChanged
+    ? await getBottleProductionLocations(tx, affectedIds)
+    : [];
 
   if (invalidateGeneratedDetails) {
     for (const member of affectedMembers) {
@@ -1657,6 +1664,10 @@ export async function updateBottleInTransaction(
         changedEntityIds.add(entityId);
       }
     }
+  }
+  if (groupDistillersChanged) {
+    const locationsAfter = await getBottleProductionLocations(tx, affectedIds);
+    await updateLocationBottleCounts(tx, locationsBefore, locationsAfter);
   }
 
   return {

--- a/apps/server/src/lib/updateEntity.ts
+++ b/apps/server/src/lib/updateEntity.ts
@@ -23,6 +23,10 @@ import {
   EntityOwnershipConflictError,
 } from "@peated/server/lib/entityOwnership";
 import { arraysEqual } from "@peated/server/lib/equals";
+import {
+  getBottleProductionLocations,
+  updateLocationBottleCounts,
+} from "@peated/server/lib/locationBottleCounts";
 import { logError } from "@peated/server/lib/log";
 import {
   BottleUpdateConflictError,
@@ -34,7 +38,7 @@ import {
 } from "@peated/server/lib/updateBottle";
 import { EntityInputFields } from "@peated/server/schemas/entities";
 import { pushUniqueJob } from "@peated/server/worker/dispatch";
-import { asc, eq, or, sql } from "drizzle-orm";
+import { asc, eq, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 export const EntityUpdateInputSchema = z.object({
@@ -202,8 +206,7 @@ export async function updateEntityInTransaction(
       .select()
       .from(countries)
       .where(eq(countries.id, input.country))
-      .limit(1)
-      .for("share");
+      .limit(1);
     if (!country) {
       throw new EntityUpdateNotFoundError("Country");
     }
@@ -230,8 +233,7 @@ export async function updateEntityInTransaction(
       .select()
       .from(regions)
       .where(eq(regions.id, input.region))
-      .limit(1)
-      .for("share");
+      .limit(1);
     if (!region || region.countryId !== (data.countryId ?? entity.countryId)) {
       throw new EntityUpdateNotFoundError("Region");
     }
@@ -314,6 +316,64 @@ export async function updateEntityInTransaction(
     };
   }
 
+  const productionLocationChanged =
+    data.countryId !== undefined || data.regionId !== undefined;
+  const countryIdsToLock =
+    data.countryId === undefined
+      ? []
+      : Array.from(
+          new Set(
+            [entity.countryId, data.countryId].filter(
+              (id): id is number => id !== null,
+            ),
+          ),
+        ).sort((left, right) => left - right);
+  const regionIdsToLock =
+    data.regionId === undefined
+      ? []
+      : Array.from(
+          new Set(
+            [entity.regionId, data.regionId].filter(
+              (id): id is number => id !== null,
+            ),
+          ),
+        ).sort((left, right) => left - right);
+  // Entity location edits use the same Country-then-Region, ascending-ID order
+  // as Bottle writes so two moves cannot take these locks in reverse.
+  if (countryIdsToLock.length) {
+    const lockedCountries = await transaction
+      .select({ id: countries.id })
+      .from(countries)
+      .where(inArray(countries.id, countryIdsToLock))
+      .orderBy(asc(countries.id))
+      .for("update");
+    if (lockedCountries.length !== countryIdsToLock.length) {
+      throw new EntityUpdateNotFoundError("Country");
+    }
+  }
+  if (regionIdsToLock.length) {
+    const lockedRegions = await transaction
+      .select({ id: regions.id })
+      .from(regions)
+      .where(inArray(regions.id, regionIdsToLock))
+      .orderBy(asc(regions.id))
+      .for("update");
+    if (lockedRegions.length !== regionIdsToLock.length) {
+      throw new EntityUpdateNotFoundError("Region");
+    }
+  }
+  const relatedBottleIds = productionLocationChanged
+    ? (
+        await transaction
+          .selectDistinct({ id: bottlesToDistillers.bottleId })
+          .from(bottlesToDistillers)
+          .where(eq(bottlesToDistillers.distillerId, entity.id))
+      ).map(({ id }) => id)
+    : [];
+  const locationsBefore = productionLocationChanged
+    ? await getBottleProductionLocations(transaction, relatedBottleIds)
+    : [];
+
   let newEntity: Entity | undefined;
   const bottleUpdates: BottleUpdateFinalizationManifest[] = [];
   try {
@@ -335,6 +395,18 @@ export async function updateEntityInTransaction(
   }
   if (!newEntity) {
     throw new EntityUpdateFailedError();
+  }
+
+  if (productionLocationChanged) {
+    const locationsAfter = await getBottleProductionLocations(
+      transaction,
+      relatedBottleIds,
+    );
+    await updateLocationBottleCounts(
+      transaction,
+      locationsBefore,
+      locationsAfter,
+    );
   }
 
   try {

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
@@ -15,8 +15,18 @@ describe("POST /admin/catalog/repair-bottle-counts", () => {
     await expect(
       routerClient.admin.repairBottleCounts({}, { context: { user: admin } }),
     ).resolves.toEqual({ status: "queued" });
-    expect(pushUniqueJob).toHaveBeenCalledWith(
+    expect(pushUniqueJob).toHaveBeenCalledTimes(2);
+    expect(pushUniqueJob).toHaveBeenNthCalledWith(
+      1,
       "RepairEntityBottleCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
+    expect(pushUniqueJob).toHaveBeenNthCalledWith(
+      2,
+      "RepairLocationBottleCounts",
       {},
       {
         delay: 0,

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
@@ -8,9 +8,9 @@ export default procedure
   .route({
     method: "POST",
     path: "/admin/catalog/repair-bottle-counts",
-    summary: "Repair brand and producer bottle counts",
+    summary: "Repair saved bottle counts",
     description:
-      "Check saved bottle totals for brands and producers, and fix any that are wrong. Requires administrator privileges.",
+      "Check saved bottle totals for brands, producers, countries, and regions, and fix any that are wrong. Requires administrator privileges.",
     operationId: "repairEntityBottleCounts",
   })
   .input(z.object({}).strict().default({}))
@@ -18,6 +18,13 @@ export default procedure
   .handler(async () => {
     await pushUniqueJob(
       "RepairEntityBottleCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
+    await pushUniqueJob(
+      "RepairLocationBottleCounts",
       {},
       {
         delay: 0,

--- a/apps/server/src/orpc/routes/bottles/delete.test.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.test.ts
@@ -8,10 +8,12 @@ import {
   bottleSeries,
   bottles,
   collectionBottles,
+  countries,
   entities,
   externalReviews,
   flightBottles,
   incomingBottleDecisionLogs,
+  regions,
   storePriceMatchProposals,
   storePrices,
 } from "@peated/server/db/schema";
@@ -145,12 +147,35 @@ describe("DELETE /bottles/:bottle", () => {
   }) => {
     const user = await fixtures.User({ admin: true });
     const brand = await fixtures.Entity();
-    const removedBottle = await fixtures.Bottle({ brandId: brand.id });
-    await fixtures.Bottle({ brandId: brand.id });
+    const country = await fixtures.Country({ totalBottles: 0 });
+    const region = await fixtures.Region({
+      countryId: country.id,
+      totalBottles: 0,
+    });
+    const distillery = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+    });
+    const removedBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      distillerIds: [distillery.id],
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      distillerIds: [distillery.id],
+    });
     await db
       .update(entities)
       .set({ totalBottles: 0 })
       .where(eq(entities.id, brand.id));
+    await db
+      .update(countries)
+      .set({ totalBottles: 0 })
+      .where(eq(countries.id, country.id));
+    await db
+      .update(regions)
+      .set({ totalBottles: 0 })
+      .where(eq(regions.id, region.id));
 
     await routerClient.bottles.delete(
       { bottle: removedBottle.id },
@@ -164,6 +189,12 @@ describe("DELETE /bottles/:bottle", () => {
     ).resolves.toBeUndefined();
     await expect(
       db.query.entities.findFirst({ where: eq(entities.id, brand.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, country.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, region.id) }),
     ).resolves.toMatchObject({ totalBottles: 1 });
   });
 

--- a/apps/server/src/orpc/routes/bottles/delete.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.ts
@@ -23,6 +23,10 @@ import {
   getBottleEntityLinks,
   updateEntityBottleCounts,
 } from "@peated/server/lib/entityBottleCounts";
+import {
+  getBottleProductionLocations,
+  updateLocationBottleCounts,
+} from "@peated/server/lib/locationBottleCounts";
 import { logInfo } from "@peated/server/lib/log";
 import { recomputeBottleGroupStatsInTransaction } from "@peated/server/lib/recomputeBottleGroupStats";
 import { procedure } from "@peated/server/orpc";
@@ -76,6 +80,9 @@ export default procedure
       }
 
       const entityLinksBefore = await getBottleEntityLinks(tx, [bottle.id]);
+      const locationsBefore = await getBottleProductionLocations(tx, [
+        bottle.id,
+      ]);
 
       const distillerRows = await tx
         .select({ distillerId: bottlesToDistillers.distillerId })
@@ -256,6 +263,10 @@ export default procedure
 
       const entityLinksAfter = await getBottleEntityLinks(tx, [bottle.id]);
       await updateEntityBottleCounts(tx, entityLinksBefore, entityLinksAfter);
+      const locationsAfter = await getBottleProductionLocations(tx, [
+        bottle.id,
+      ]);
+      await updateLocationBottleCounts(tx, locationsBefore, locationsAfter);
 
       if (bottle.groupId !== null) {
         if (remainingGroupMemberIds.length === 0) {

--- a/apps/server/src/orpc/routes/entities/update.test.ts
+++ b/apps/server/src/orpc/routes/entities/update.test.ts
@@ -4,8 +4,10 @@ import {
   bottleReferences,
   bottles,
   changes,
+  countries,
   entities,
   entityReferences,
+  regions,
 } from "@peated/server/db/schema";
 import { omit } from "@peated/server/lib/filter";
 import waitError from "@peated/server/lib/test/waitError";
@@ -177,6 +179,100 @@ describe("PATCH /entities/:entity", () => {
       omit(newEntity, "countryId", "regionId", "searchVector", "updatedAt"),
     );
     expect(newEntity.regionId).toBe(region.id);
+  });
+
+  test("moves linked Bottle counts when a Distillery moves", async ({
+    fixtures,
+  }) => {
+    const oldCountry = await fixtures.Country({ totalBottles: 0 });
+    const oldRegion = await fixtures.Region({
+      countryId: oldCountry.id,
+      totalBottles: 0,
+    });
+    const newCountry = await fixtures.Country({ totalBottles: 0 });
+    const newRegion = await fixtures.Region({
+      countryId: newCountry.id,
+      totalBottles: 0,
+    });
+    const movingDistillery = await fixtures.Entity({
+      countryId: oldCountry.id,
+      regionId: oldRegion.id,
+    });
+    const retainedDistillery = await fixtures.Entity({
+      countryId: oldCountry.id,
+      regionId: oldRegion.id,
+    });
+    await fixtures.Bottle({
+      distillerIds: [movingDistillery.id, retainedDistillery.id],
+    });
+    const modUser = await fixtures.User({ mod: true });
+
+    await routerClient.entities.update(
+      {
+        entity: movingDistillery.id,
+        country: newCountry.id,
+        region: newRegion.id,
+      },
+      { context: { user: modUser } },
+    );
+
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, oldCountry.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, oldRegion.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.countries.findFirst({ where: eq(countries.id, newCountry.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.regions.findFirst({ where: eq(regions.id, newRegion.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+  });
+
+  test("moves two Distilleries between Countries without losing counts", async ({
+    fixtures,
+  }) => {
+    const firstCountry = await fixtures.Country({ totalBottles: 0 });
+    const secondCountry = await fixtures.Country({ totalBottles: 0 });
+    const firstDistillery = await fixtures.Entity({
+      countryId: firstCountry.id,
+    });
+    const secondDistillery = await fixtures.Entity({
+      countryId: secondCountry.id,
+    });
+    await fixtures.Bottle({ distillerIds: [firstDistillery.id] });
+    await fixtures.Bottle({ distillerIds: [firstDistillery.id] });
+    await fixtures.Bottle({ distillerIds: [secondDistillery.id] });
+    const modUser = await fixtures.User({ mod: true });
+
+    await Promise.all([
+      routerClient.entities.update(
+        {
+          entity: firstDistillery.id,
+          country: secondCountry.id,
+        },
+        { context: { user: modUser } },
+      ),
+      routerClient.entities.update(
+        {
+          entity: secondDistillery.id,
+          country: firstCountry.id,
+        },
+        { context: { user: modUser } },
+      ),
+    ]);
+
+    await expect(
+      db.query.countries.findFirst({
+        where: eq(countries.id, firstCountry.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.countries.findFirst({
+        where: eq(countries.id, secondCountry.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 2 });
   });
 
   test("can remove region", async ({ fixtures }) => {

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -22,6 +22,7 @@ import processNotification from "./processNotification";
 import processStorePriceMatchRetryRun from "./processStorePriceMatchRetryRun";
 import reconcileStorePriceMatchProposals from "./reconcileStorePriceMatchProposals";
 import repairEntityBottleCounts from "./repairEntityBottleCounts";
+import repairLocationBottleCounts from "./repairLocationBottleCounts";
 import resolveStorePriceBottle from "./resolveStorePriceBottle";
 import runScraper from "./runScraper";
 import updateBottleStats from "./updateBottleStats";
@@ -53,6 +54,7 @@ registry.add("OnEntityChange", onEntityChange);
 registry.add("ProcessNotification", processNotification);
 registry.add("ProcessStorePriceMatchRetryRun", processStorePriceMatchRetryRun);
 registry.add("RepairEntityBottleCounts", repairEntityBottleCounts);
+registry.add("RepairLocationBottleCounts", repairLocationBottleCounts);
 registry.add(
   "ReconcileStorePriceMatchProposals",
   reconcileStorePriceMatchProposals,

--- a/apps/server/src/worker/jobs/mergeEntity.test.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.test.ts
@@ -11,6 +11,7 @@ import {
   bottleSeries,
   bottleTombstones,
   changes,
+  countries,
   entities,
   entityAliases,
   entityEvents,
@@ -18,6 +19,7 @@ import {
   entityImages,
   entityReferences,
   entityTombstones,
+  regions,
   storePriceMatchAttempts,
   storePriceMatchProposals,
   type User,
@@ -515,6 +517,58 @@ test("merge A into B", async ({ fixtures }) => {
     .from(entityTombstones)
     .where(eq(entityTombstones.entityId, entityA.id));
   expect(tombstone.newEntityId).toEqual(newEntityB.id);
+});
+
+test("moves Bottle counts when merged Distilleries have different locations", async ({
+  fixtures,
+}) => {
+  const sourceCountry = await fixtures.Country({ totalBottles: 0 });
+  const sourceRegion = await fixtures.Region({
+    countryId: sourceCountry.id,
+    totalBottles: 0,
+  });
+  const destinationCountry = await fixtures.Country({ totalBottles: 0 });
+  const destinationRegion = await fixtures.Region({
+    countryId: destinationCountry.id,
+    totalBottles: 0,
+  });
+  const source = await fixtures.Entity({
+    kind: "distillery",
+    countryId: sourceCountry.id,
+    regionId: sourceRegion.id,
+  });
+  const destination = await fixtures.Entity({
+    kind: "distillery",
+    countryId: destinationCountry.id,
+    regionId: destinationRegion.id,
+  });
+  await fixtures.Bottle({ distillerIds: [source.id] });
+
+  await mergeEntity({
+    fromEntityIds: [source.id],
+    toEntityId: destination.id,
+  });
+
+  await expect(
+    db.query.countries.findFirst({
+      where: eq(countries.id, sourceCountry.id),
+    }),
+  ).resolves.toMatchObject({ totalBottles: 0 });
+  await expect(
+    db.query.regions.findFirst({
+      where: eq(regions.id, sourceRegion.id),
+    }),
+  ).resolves.toMatchObject({ totalBottles: 0 });
+  await expect(
+    db.query.countries.findFirst({
+      where: eq(countries.id, destinationCountry.id),
+    }),
+  ).resolves.toMatchObject({ totalBottles: 1 });
+  await expect(
+    db.query.regions.findFirst({
+      where: eq(regions.id, destinationRegion.id),
+    }),
+  ).resolves.toMatchObject({ totalBottles: 1 });
 });
 
 test("moves and deduplicates display aliases", async ({ fixtures }) => {

--- a/apps/server/src/worker/jobs/repairLocationBottleCounts.test.ts
+++ b/apps/server/src/worker/jobs/repairLocationBottleCounts.test.ts
@@ -1,0 +1,47 @@
+import { db } from "@peated/server/db";
+import { countries, regions } from "@peated/server/db/schema";
+import { checkLocationBottleCounts } from "@peated/server/lib/locationBottleCounts";
+import { eq } from "drizzle-orm";
+import repairLocationBottleCountsJob from "./repairLocationBottleCounts";
+
+test("repairs wrong counts and is safe to run again", async ({ fixtures }) => {
+  const country = await fixtures.Country({ totalBottles: 0 });
+  const region = await fixtures.Region({
+    countryId: country.id,
+    totalBottles: 0,
+  });
+  const distillery = await fixtures.Entity({
+    countryId: country.id,
+    regionId: region.id,
+  });
+  await fixtures.Bottle({ distillerIds: [distillery.id] });
+  await db
+    .update(countries)
+    .set({ totalBottles: 9 })
+    .where(eq(countries.id, country.id));
+  await db
+    .update(regions)
+    .set({ totalBottles: 8 })
+    .where(eq(regions.id, region.id));
+
+  await expect(repairLocationBottleCountsJob({})).resolves.toEqual({
+    wrongCount: 2,
+    repairedCount: 2,
+  });
+  await expect(checkLocationBottleCounts()).resolves.toEqual([]);
+
+  await expect(repairLocationBottleCountsJob({})).resolves.toEqual({
+    wrongCount: 0,
+    repairedCount: 0,
+  });
+});
+
+test.each([undefined, null, [], { unexpected: true }])(
+  "rejects malformed input %#",
+  async (input) => {
+    // SAFETY: This test bypasses the type so the job can reject invalid queue input.
+    await expect(
+      repairLocationBottleCountsJob(input as never),
+    ).rejects.toThrow();
+  },
+);

--- a/apps/server/src/worker/jobs/repairLocationBottleCounts.ts
+++ b/apps/server/src/worker/jobs/repairLocationBottleCounts.ts
@@ -1,0 +1,34 @@
+import {
+  checkLocationBottleCounts,
+  repairLocationBottleCount,
+} from "@peated/server/lib/locationBottleCounts";
+import { logInfo } from "@peated/server/lib/log";
+import { z } from "zod";
+import type { JobPayload } from "../types";
+
+export const RepairLocationBottleCountsJobArgsSchema = z.object({}).strict();
+
+export default async function repairLocationBottleCountsJob(input: JobPayload) {
+  RepairLocationBottleCountsJobArgsSchema.parse(input);
+
+  const wrongCounts = await checkLocationBottleCounts();
+  let repairedCount = 0;
+
+  for (const wrongCount of wrongCounts) {
+    if (await repairLocationBottleCount(wrongCount)) {
+      repairedCount += 1;
+    }
+  }
+
+  logInfo("Finished location Bottle count repair", {
+    extra: {
+      wrongCount: wrongCounts.length,
+      repairedCount,
+    },
+  });
+
+  return {
+    wrongCount: wrongCounts.length,
+    repairedCount,
+  };
+}

--- a/apps/server/src/worker/jobs/updateCountryStats.test.ts
+++ b/apps/server/src/worker/jobs/updateCountryStats.test.ts
@@ -31,6 +31,10 @@ test("counts active Bottles by producing distillery", async ({ fixtures }) => {
     bottleId: retiredBottle.id,
     newBottleId: null,
   });
+  await db
+    .update(countries)
+    .set({ totalBottles: 7 })
+    .where(eq(countries.id, country1.id));
 
   await updateCountryStats({ countryId: country1.id });
 
@@ -39,7 +43,7 @@ test("counts active Bottles by producing distillery", async ({ fixtures }) => {
     .from(countries)
     .where(eq(countries.id, country1.id));
   expect(newCountry1).toBeDefined();
-  expect(newCountry1.totalBottles).toEqual(1);
+  expect(newCountry1.totalBottles).toEqual(7);
   expect(newCountry1.totalDistillers).toEqual(2);
 });
 

--- a/apps/server/src/worker/jobs/updateCountryStats.ts
+++ b/apps/server/src/worker/jobs/updateCountryStats.ts
@@ -6,7 +6,6 @@ import {
   countries,
   entities,
 } from "@peated/server/db/schema";
-import { bottleProducedIn } from "@peated/server/lib/bottleProductionLocation";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { JobPayload } from "../types";
@@ -37,17 +36,6 @@ export default async function updateCountryStats(input: JobPayload) {
             FROM ${bottleTombstones}
             WHERE ${bottleTombstones.bottleId} = ${bottles.id}
           )
-      )`,
-      totalBottles: sql<string>`(
-        SELECT COUNT(*)
-        FROM ${bottles}
-        WHERE ${bottleProducedIn({ countryId: countries.id })}
-        AND ${bottles.groupId} IS NOT NULL
-        AND NOT EXISTS (
-          SELECT 1
-          FROM ${bottleTombstones}
-          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
-        )
       )`,
     })
     .where(eq(countries.id, countryId));

--- a/apps/server/src/worker/jobs/updateRegionStats.test.ts
+++ b/apps/server/src/worker/jobs/updateRegionStats.test.ts
@@ -43,6 +43,10 @@ test("counts active Bottles by producing distillery", async ({ fixtures }) => {
     bottleId: retiredBottle.id,
     newBottleId: null,
   });
+  await db
+    .update(regions)
+    .set({ totalBottles: 7 })
+    .where(eq(regions.id, region1.id));
 
   await updateRegionStats({ regionId: region1.id });
 
@@ -51,7 +55,7 @@ test("counts active Bottles by producing distillery", async ({ fixtures }) => {
     .from(regions)
     .where(eq(regions.id, region1.id));
   expect(newRegion1).toBeDefined();
-  expect(newRegion1.totalBottles).toEqual(1);
+  expect(newRegion1.totalBottles).toEqual(7);
   expect(newRegion1.totalDistillers).toEqual(2);
 });
 

--- a/apps/server/src/worker/jobs/updateRegionStats.ts
+++ b/apps/server/src/worker/jobs/updateRegionStats.ts
@@ -6,7 +6,6 @@ import {
   entities,
   regions,
 } from "@peated/server/db/schema";
-import { bottleProducedIn } from "@peated/server/lib/bottleProductionLocation";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { JobPayload } from "../types";
@@ -37,17 +36,6 @@ export default async function updateRegionStats(input: JobPayload) {
             FROM ${bottleTombstones}
             WHERE ${bottleTombstones.bottleId} = ${bottles.id}
           )
-      )`,
-      totalBottles: sql<string>`(
-        SELECT COUNT(*)
-        FROM ${bottles}
-        WHERE ${bottleProducedIn({ regionId: regions.id })}
-        AND ${bottles.groupId} IS NOT NULL
-        AND NOT EXISTS (
-          SELECT 1
-          FROM ${bottleTombstones}
-          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
-        )
       )`,
     })
     .where(eq(regions.id, regionId));

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -23,6 +23,7 @@ export type JobName =
   | "ProcessStorePriceMatchRetryRun"
   | "ProcessNotification"
   | "RepairEntityBottleCounts"
+  | "RepairLocationBottleCounts"
   | "ReconcileStorePriceMatchProposals"
   | "ResolveStorePriceBottle"
   | "RunScraper"

--- a/apps/web/src/app/(admin)/admin/(default)/maintenance/maintenancePage.stylex.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/maintenance/maintenancePage.stylex.tsx
@@ -122,7 +122,7 @@ export default function MaintenancePage() {
 
         <AdminSection
           title="Bottle counts"
-          description="Check every brand and producer’s Bottle count, and fix counts that are wrong. Bottle editing can continue while this runs."
+          description="Check Bottle counts for brands, producers, countries, and regions, and fix any that are wrong. Bottle editing can continue while this runs."
         >
           <div {...stylex.props(styles.sectionContent)}>
             <div {...stylex.props(styles.actionRow)}>

--- a/openspec/changes/make-location-bottle-counters-transactional/.openspec.yaml
+++ b/openspec/changes/make-location-bottle-counters-transactional/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/make-location-bottle-counters-transactional/design.md
+++ b/openspec/changes/make-location-bottle-counters-transactional/design.md
@@ -1,0 +1,82 @@
+## Context
+
+`Country.totalBottles` and `Region.totalBottles` are saved for public filtering and sorting. They count active Bottles by the locations of their Distilleries. Brand and Bottler addresses do not establish where a Bottle was produced.
+
+The current Country and Region statistics jobs recount these totals after `UpdateEntityStats` runs. This delayed chain can leave totals stale and repeats broad count queries. Entity Bottle totals now change in the Bottle transaction, so the same transaction boundaries can also own production-location totals.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep Country and Region Bottle totals correct when normal catalog writes commit.
+- Count each Bottle once in a location even when several linked Distilleries share that location.
+- Keep normal Bottle work limited to the few Bottles and locations affected by the write.
+- Handle Distillery location edits and concurrent Bottle writes without lost changes.
+- Repair old wrong totals while catalog edits continue.
+
+**Non-Goals:**
+
+- Changing `totalDistillers`, tasting totals, or public response shapes.
+- Adding database triggers or a general counter framework.
+- Making direct maintenance SQL update totals automatically.
+- Showing progress for an individual repair run in the admin interface.
+
+## Decisions
+
+### Use active Bottle-to-Distillery links as the source of truth
+
+A Bottle belongs to each distinct Country and Region found through its active Distillery links. A Bottle with no Distillery location does not contribute there. An active Bottle has a BottleGroup and no tombstone, matching the existing location queries.
+
+Brand and Bottler locations remain excluded. This keeps the existing meaning of the totals.
+
+### Compare location sets before and after Bottle changes
+
+Shared code reads the distinct Country and Region IDs for each affected Bottle before and after its Distillery links or active state changes. It subtracts the old sets and adds the new sets. Set comparison makes several Distilleries in the same location count once.
+
+Creation, shared relationship edits, deletion, and Bottle merges call this code inside the same transaction that changes the Bottle. Entity merges already move Bottle relationships through the shared update and merge functions, so they use the same rule.
+
+Updating all Countries and Regions after every Bottle write was considered, but its cost grows with the catalog. Keeping the delayed jobs was also considered, but a saved Bottle and its location totals could then disagree.
+
+### Handle Distillery location edits in the Entity transaction
+
+When an Entity's Country or Region changes, the Entity transaction reads production-location sets for the active Bottles linked to that Distillery before and after the update. It applies only the combined changes for those Bottles.
+
+This work grows with the changed Distillery's Bottles, not the whole catalog. Location edits are rare, and the query does not lock Bottle rows. A more specialized set of count queries would save memory but would repeat the rule and be harder to verify.
+
+### Update and repair location rows in a stable order
+
+Normal changes use atomic additions and subtractions. Country rows are updated by ID first, followed by Region rows by ID. A guarded decrease prevents a negative total. If old data is too low, the transaction locks that one location and saves its exact total from current Bottle links instead of blocking the valid Bottle change.
+
+Stable ordering prevents two transactions that touch the same locations in different ways from taking locks in opposite orders.
+
+### Add location work to the existing admin repair action
+
+An independent query finds wrong Country and Region Bottle totals. A new worker repairs one location per transaction, using the same row locks as normal writes. The existing admin action starts both the Entity and location repair jobs, so production does not gain another control or CLI command.
+
+Starting the action again keeps one active copy of each job. The repair scans can be broad, but they run only when explicitly requested and do not hold a catalog-wide write lock.
+
+### Leave Distillery totals in the existing jobs
+
+`UpdateCountryStats` and `UpdateRegionStats` stop writing `totalBottles` but continue to recalculate `totalDistillers`. Their existing dispatch remains until that separate counter is addressed.
+
+## Risks / Trade-offs
+
+- [A Bottle write path skips the shared code] → Use the same four Bottle transaction boundaries as Entity totals and test creation, updates, deletion, and merges against an independent count query.
+- [A Distillery has many Bottles] → Read only that Distillery's active Bottles and update only changed Country and Region rows; do not lock the Bottle rows.
+- [Two writes touch the same locations] → Apply atomic changes with a fixed Country-then-Region, ascending-ID order.
+- [A production total is already wrong] → Repair one locked location at a time through the admin-started worker.
+- [A decrease exposes an old undercount] → Recount the locked location inside the current transaction so the valid catalog write can finish.
+
+## Migration Plan
+
+1. Add the shared location count, check, and repair code.
+2. Call it from Bottle writes and Distillery location updates.
+3. Stop the location statistics jobs from writing Bottle totals.
+4. Extend the existing admin action to start the location repair.
+5. After deployment, run the existing Bottle-count repair action once.
+
+Rollback restores the old worker recount fields. The saved totals remain compatible because no schema changes are required.
+
+## Open Questions
+
+None.

--- a/openspec/changes/make-location-bottle-counters-transactional/proposal.md
+++ b/openspec/changes/make-location-bottle-counters-transactional/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Country and Region Bottle totals are still recalculated by delayed jobs. A missed or delayed job can leave public location lists wrong, and each recount searches a growing part of the Bottle catalog.
+
+## What Changes
+
+- Update `Country.totalBottles` and `Region.totalBottles` in the same transaction that changes a Bottle's active Distillery links.
+- Count a Bottle once per Country or Region even when it has several producing Distilleries in the same location.
+- Keep location totals correct when a Distillery's Country or Region changes.
+- Add an admin-started repair for existing wrong location totals that can run while Bottle and Entity edits continue.
+- Stop the Country and Region statistics jobs from recalculating Bottle totals while leaving their Distillery totals unchanged.
+- Cover creation, deletion, relationship updates, Bottle merges, Entity merges, Distillery location changes, and concurrent writes.
+
+## Capabilities
+
+### New Capabilities
+
+- `location-bottle-counters`: Correct Country and Region Bottle totals derived from active Bottle-to-Distillery links.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Bottle creation, editing, deletion, and merge transactions.
+- Distillery location updates and Entity merges.
+- Country and Region statistics workers.
+- Server count helpers, the existing admin Bottle-count repair action, worker jobs, and integration tests.
+- No public API shape changes, migration, or new runtime dependency.

--- a/openspec/changes/make-location-bottle-counters-transactional/specs/location-bottle-counters/spec.md
+++ b/openspec/changes/make-location-bottle-counters-transactional/specs/location-bottle-counters/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Transactional location Bottle totals
+
+The system SHALL update every affected Country and Region Bottle total in the same transaction that changes the active Bottle-to-Distillery links.
+
+#### Scenario: Create an active Bottle
+
+- **WHEN** a Bottle is created with Distilleries that have saved locations
+- **THEN** each distinct Country and Region represented by those Distilleries gains one Bottle in the creation transaction
+
+#### Scenario: Change producing Distilleries
+
+- **WHEN** an active Bottle changes its Distillery relationships
+- **THEN** totals change only for Countries and Regions that leave or enter the Bottle's production-location sets
+
+#### Scenario: Delete or merge Bottles
+
+- **WHEN** a Bottle is deleted or merged into another Bottle
+- **THEN** each affected Country and Region total reflects the active Bottles remaining at commit
+
+#### Scenario: Several Distilleries share a location
+
+- **WHEN** one Bottle has several Distilleries in the same Country or Region
+- **THEN** that Bottle contributes exactly one to that location total
+
+### Requirement: Distillery location changes
+
+The system SHALL update location Bottle totals in the Entity transaction when a linked Distillery's Country or Region changes.
+
+#### Scenario: Move a Distillery
+
+- **WHEN** a Distillery with active Bottles moves from one saved Country or Region to another
+- **THEN** the old and new location totals reflect each affected Bottle at commit
+
+#### Scenario: Another Distillery preserves the location
+
+- **WHEN** a Bottle has another Distillery in a location that the changed Distillery leaves
+- **THEN** the Bottle remains counted once in that location
+
+### Requirement: Safe location count updates
+
+The system SHALL apply atomic location count changes in a stable row order and SHALL repair an old undercount exposed by a valid catalog change.
+
+#### Scenario: Concurrent Bottle creation
+
+- **WHEN** concurrent transactions add different Bottles produced in the same location
+- **THEN** the final location total includes both Bottles without a lost update
+
+#### Scenario: Existing undercount
+
+- **WHEN** deleting, merging, or updating a Bottle requires a decrease greater than the saved location total
+- **THEN** the transaction locks that location, saves its exact total from the remaining active Bottle links, and completes the catalog change
+
+### Requirement: Separate location count repair
+
+The system SHALL check saved location totals against an independent calculation and SHALL allow an administrator to repair wrong totals while catalog edits continue.
+
+#### Scenario: Check correct totals
+
+- **WHEN** saved Country and Region totals match active Bottle-to-Distillery links
+- **THEN** the check reports no differences and changes no data
+
+#### Scenario: Repair wrong totals
+
+- **WHEN** an administrator starts the Bottle-count repair and a location total is wrong
+- **THEN** the system locks, recounts, and saves that location separately
+
+#### Scenario: Start the repair twice
+
+- **WHEN** an administrator starts the repair while the same repair jobs are waiting or running
+- **THEN** the system keeps one active copy of each repair job
+
+### Requirement: Queue-independent location totals
+
+Normal Country and Region Bottle total correctness SHALL NOT depend on a queued job completing.
+
+#### Scenario: Statistics jobs do not run
+
+- **WHEN** a Bottle or Distillery location transaction commits and no later statistics job runs
+- **THEN** every affected Country and Region Bottle total is already correct

--- a/openspec/changes/make-location-bottle-counters-transactional/tasks.md
+++ b/openspec/changes/make-location-bottle-counters-transactional/tasks.md
@@ -1,0 +1,24 @@
+## 1. Shared Location Count Code
+
+- [x] 1.1 Read each active Bottle's distinct Country and Region sets and apply before-and-after count changes.
+- [x] 1.2 Add independent checks and one-location repair functions for Country and Region Bottle totals.
+- [x] 1.3 Repair an old undercount inside the current catalog transaction instead of blocking a valid decrease.
+
+## 2. Catalog Writes
+
+- [x] 2.1 Update Bottle creation and shared Distillery edits to maintain location Bottle totals.
+- [x] 2.2 Update Bottle deletion and Bottle merges to maintain location Bottle totals.
+- [x] 2.3 Update Distillery location edits and verify Entity merges use the same Bottle write rule.
+
+## 3. Queue And Admin Repair
+
+- [x] 3.1 Stop Country and Region statistics jobs from recalculating Bottle totals while preserving Distillery totals.
+- [x] 3.2 Add a strict, unique location repair job that repairs one Country or Region per transaction.
+- [x] 3.3 Start both Bottle-count repairs from the existing admin action and update its plain-language copy.
+
+## 4. Checks
+
+- [x] 4.1 Cover Bottle creation, Distillery updates, deletion, merges, and duplicate locations with integration tests.
+- [x] 4.2 Cover Distillery location moves, concurrent changes, and old undercounts with integration tests.
+- [x] 4.3 Cover independent checks, repairs, worker input, admin permission, and unique dispatch.
+- [x] 4.4 Run focused tests, server and web typechecks, lint, formatting, and strict OpenSpec validation.


### PR DESCRIPTION
Country and Region bottle totals now change in the same transaction as the catalog edit that affects them. Creation, Distillery changes, deletion, Bottle merges, Entity merges, and Distillery location edits all use the same rule, and a Bottle counts once per location even when several linked Distilleries share it.

The existing admin repair action now also starts a location repair job. It checks independently and repairs one Country or Region per transaction while normal edits continue. The older Country and Region jobs still maintain Distillery totals, but no longer overwrite bottle totals. This adds no migration, CLI command, new admin control, or public API change.

The main review point is the shared location-count module and its before-and-after calls at the existing catalog transaction boundaries. Integration coverage includes concurrent writes, old undercounts, every supported change path, repair permissions, and repeat-safe job dispatch.

Refs #1042
