### PR TITLE
fix(web): declare supported color schemes

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -21,6 +21,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
+  colorScheme: "light dark",
   themeColor: [
     {
       color: config.THEME_COLOR_LIGHT,


### PR DESCRIPTION
Peated now declares support for both light and dark color schemes in its viewport metadata, allowing browser-rendered form controls, including native select menus, to follow the operating system preference. This keeps the existing `prefers-color-scheme` styling unchanged and avoids forcing either scheme.
