### PR TITLE
feat(scrapers): prepare Words of Whisky migration

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -78,6 +78,15 @@ function prepareWhiskeyReviewer(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareWordsOfWhisky(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "wordsofwhisky", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareCompassBox(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "compassbox", ...input },
@@ -106,7 +115,8 @@ function codeOwnedSource(
     | "kilchoman"
     | "whiskeyreviewer"
     | "whiskysaga"
-    | "whiskystudy",
+    | "whiskystudy"
+    | "wordsofwhisky",
 ) {
   return defineScraperSource({
     key,
@@ -143,6 +153,13 @@ const whiskeyReviewerCanonicalUrl =
 const whiskeyReviewerRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("whiskeyreviewer")!],
   sources: [codeOwnedSource("whiskeyreviewer")],
+});
+
+const wordsOfWhiskyCanonicalUrl =
+  "https://wordsofwhisky.com/example-multi-bottle-review";
+const wordsOfWhiskyRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("wordsofwhisky")!],
+  sources: [codeOwnedSource("wordsofwhisky")],
 });
 
 const compassBoxRegistry = createScraperRegistry({
@@ -365,6 +382,86 @@ async function setupWhiskeyReviewerMigration(bottleId: number | null = null) {
     completedAt: new Date(),
   });
   return { site, article, review };
+}
+
+function wordsOfWhiskyReviewKey(name: string, reviewerName: string | null) {
+  const digest = createHash("sha256")
+    .update(
+      [wordsOfWhiskyCanonicalUrl, name, reviewerName ?? ""]
+        .map((value) =>
+          value.replaceAll(/\s+/g, " ").trim().toLocaleLowerCase("en"),
+        )
+        .join("\n"),
+    )
+    .digest("hex");
+  return `wordsofwhisky:${digest}`;
+}
+
+async function setupWordsOfWhiskyMigration(bottleIds: [number, number]) {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "wordsofwhisky",
+      name: "Words of Whisky",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(wordsOfWhiskyRegistry);
+  const [article] = await db
+    .insert(externalReviewArticles)
+    .values({
+      externalSiteId: site.id,
+      canonicalUrl: wordsOfWhiskyCanonicalUrl,
+      title: "Two Example Whiskies",
+      publishedAt: new Date("2026-08-19"),
+    })
+    .returning();
+  const reviewerName = "Example Writer";
+  const reviews = await db
+    .insert(externalReviews)
+    .values([
+      {
+        articleId: article.id,
+        sourceKey: wordsOfWhiskyReviewKey("First Example", reviewerName),
+        name: "First Example",
+        reviewerName,
+        bottleId: bottleIds[0],
+        hidden: true,
+        nativeScoreValue: 8.7,
+        nativeScoreScale: 10,
+        nativeScoreDisplay: "8.7/10",
+      },
+      {
+        articleId: article.id,
+        sourceKey: wordsOfWhiskyReviewKey("Second Example", reviewerName),
+        name: "Second Example",
+        reviewerName,
+        bottleId: bottleIds[1],
+        hidden: false,
+        nativeScoreValue: 9,
+        nativeScoreScale: 10,
+        nativeScoreDisplay: "9/10",
+      },
+    ])
+    .returning();
+  await db.insert(externalReviewBodies).values(
+    reviews.map((review) => ({
+      externalReviewId: review.id,
+      body: `Stored body for ${review.name}.`,
+      fetchedAt: new Date(),
+    })),
+  );
+  await db.insert(externalReviewPublications).values({
+    externalSiteId: site.id,
+    approvedAt: new Date(),
+  });
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return { site, article, reviews };
 }
 
 async function setupCompassBoxMigration() {
@@ -715,6 +812,89 @@ describe("POST /admin/scrape-sources/prepare", () => {
         createdById: admin.id,
       }),
     ]);
+  });
+
+  test("prepares Words of Whisky without replacing multi-review records", async ({
+    fixtures,
+  }) => {
+    const firstBottle = await fixtures.Bottle();
+    const secondBottle = await fixtures.Bottle();
+    const { site, article, reviews } = await setupWordsOfWhiskyMigration([
+      firstBottle.id,
+      secondBottle.id,
+    ]);
+    const bodies = await db.select().from(externalReviewBodies);
+    const publications = await db.select().from(externalReviewPublications);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareWordsOfWhisky()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      reviewCount: 2,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(externalReviews)).toEqual(reviews);
+
+    const applied = await prepareWordsOfWhisky({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      reviewCount: 2,
+      applied: true,
+    });
+    await syncScraperDefinitions(wordsOfWhiskyRegistry);
+    expect(await db.select().from(externalReviewArticles)).toEqual([article]);
+    expect(await db.select().from(externalReviews)).toEqual([
+      { ...reviews[0], sourceKey: `${wordsOfWhiskyCanonicalUrl}#review-1` },
+      { ...reviews[1], sourceKey: `${wordsOfWhiskyCanonicalUrl}#review-2` },
+    ]);
+    expect(await db.select().from(externalReviewBodies)).toEqual(bodies);
+    expect(await db.select().from(externalReviewPublications)).toEqual(
+      publications,
+    );
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "review",
+        listUrl: "https://wordsofwhisky.com/",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+  });
+
+  test("refuses an unknown Words of Whisky review key", async ({
+    fixtures,
+  }) => {
+    const firstBottle = await fixtures.Bottle();
+    const secondBottle = await fixtures.Bottle();
+    const { reviews } = await setupWordsOfWhiskyMigration([
+      firstBottle.id,
+      secondBottle.id,
+    ]);
+    await db
+      .update(externalReviews)
+      .set({ sourceKey: "unexpected" })
+      .where(eq(externalReviews.id, reviews[1].id));
+    const before = await db.select().from(externalReviews);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareWordsOfWhisky({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining(
+        "Check the URL and review records for Words of Whisky article",
+      ),
+    });
+    expect(await db.select().from(externalReviews)).toEqual(before);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
+    expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 
   test("prepares Compass Box without replacing prices or Bottle matches", async ({

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -7,6 +7,7 @@ import { prepareKilchomanSource } from "@peated/server/scraper/configured/prepar
 import { prepareWhiskeyReviewerSource } from "@peated/server/scraper/configured/prepareWhiskeyReviewer";
 import { prepareWhiskySagaSource } from "@peated/server/scraper/configured/prepareWhiskySaga";
 import { prepareWhiskyStudySource } from "@peated/server/scraper/configured/prepareWhiskyStudy";
+import { prepareWordsOfWhiskySource } from "@peated/server/scraper/configured/prepareWordsOfWhisky";
 import {
   ScrapeSourceConflictError,
   ScrapeSourceNotFoundError,
@@ -31,7 +32,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, compassbox, kilchoman, whiskeyreviewer, whiskysaga, and whiskystudy.",
+          "The existing site's key. Currently supports bourbonculture, compassbox, kilchoman, whiskeyreviewer, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -68,6 +69,7 @@ export default procedure
       whiskeyreviewer: prepareWhiskeyReviewerSource,
       whiskysaga: prepareWhiskySagaSource,
       whiskystudy: prepareWhiskyStudySource,
+      wordsofwhisky: prepareWordsOfWhiskySource,
     }[input.site];
     if (!prepareSource) {
       throw errors.BAD_REQUEST({

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -82,7 +82,7 @@ product database. Only a revision that passes its preview can become active. An
 admin can return to any older revision that passed. Pausing a source stops
 collection but keeps its revisions and run history.
 
-Rules formats 1 through 3 support same-origin HTML list and detail pages, an item
+Rules formats 1 through 4 support same-origin HTML list and detail pages, an item
 limit, an optional next-page link, CSS selectors, and fixed date, number, price,
 and volume conversions. Version 2 also supports bounded value cleanup, fixed
 values, joined labeled text, and list-card exclusion. An `item` selector scopes
@@ -91,6 +91,9 @@ optionally beginning with one of the configured literal labels. Code follows at
 most five list pages. Version 3 also lets review sources select and clean their
 canonical URL, read a publication date from a URL path with bounded `yyyy`, `yy`,
 `MM`, `dd`, and `*` tokens, and map up to 25 finite text grades to numeric values.
+Version 4 also lets a review heading start a section made from its following
+sibling blocks. A section stops before the next selected heading or an explicit
+ending selector. When only one heading matches, its parent is the review body.
 Rules do not support
 scripts, custom code, arbitrary request headers, browser automation, numbered
 page templates, infinite scrolling, or cross-origin discovery. Add a code-owned
@@ -157,12 +160,12 @@ pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 
 ```
 
 The input has the same `listUrl` and `rules` fields accepted by the revision
-API. Set `rulesVersion` to `3` when testing current operations. An omitted
+API. Set `rulesVersion` to `4` when testing current operations. An omitted
 version means version 1 so existing preview files keep their original behavior:
 
 ```json
 {
-  "rulesVersion": 3,
+  "rulesVersion": 4,
   "listUrl": "https://example.com/reviews",
   "rules": {}
 }

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -12,6 +12,10 @@ import {
 } from "../adapters/whiskeyReviewer";
 import { parseWhiskySagaArticle } from "../adapters/whiskySaga";
 import { parseWhiskyStudyArticle } from "../adapters/whiskyStudy";
+import {
+  discoverWordsOfWhiskyArticles,
+  parseWordsOfWhiskyArticle,
+} from "../adapters/wordsOfWhisky";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
 import { parseScrapeRules, type ScrapeRules } from "./rules";
 
@@ -250,6 +254,44 @@ const whiskeyReviewerRules = {
   },
 } satisfies ScrapeRules;
 
+const wordsOfWhiskyRules = {
+  kind: "review",
+  list: {
+    item: "article.category-tastingnotes",
+    detailLink: { selector: "a[href]", attribute: "href" },
+    maxItems: 20,
+  },
+  detail: {
+    canonicalUrl: {
+      selector: 'link[rel="canonical"]',
+      attribute: "href",
+      removeSuffixes: ["/"],
+    },
+    title: { selector: ".post-wrap .entry-title" },
+    publishedAt: {
+      selector: ".post-wrap time.entry-date",
+      attribute: "datetime",
+    },
+    reviewItem: { start: ".entry-content > h2" },
+    name: { selector: "h2" },
+    reviewerName: {
+      selector: ".side-author__wrap .side-meta .title",
+    },
+    reviewText: {
+      selector: "p",
+      startsWith: ["Nose:", "Palate:", "Taste:", "Finish:"],
+      all: true,
+    },
+    score: {
+      value: {
+        selector: ".lets-review-block__final-score",
+        suffix: "/10",
+      },
+      scale: 10,
+    },
+  },
+} satisfies ScrapeRules;
+
 function expectReviewFactsAndEvidenceToMatch(
   configured: ReturnType<typeof parseScrapeDetail>,
   legacy: NonNullable<ReturnType<typeof parseWhiskyStudyArticle>>,
@@ -397,6 +439,20 @@ describe("scrape source parser", () => {
     ).toEqual(legacyLinks);
   });
 
+  it("matches the current Words of Whisky article links", async () => {
+    const pageUrl = new URL("https://wordsofwhisky.com/");
+    const html = await loadFixture("wordsofwhisky", "index.html");
+    const legacyLinks = discoverWordsOfWhiskyArticles(html).map(
+      (url) => url.href,
+    );
+
+    expect(
+      parseScrapeList(wordsOfWhiskyRules, html, pageUrl).links.map((url) =>
+        url.replace(/\/$/u, ""),
+      ),
+    ).toEqual(legacyLinks);
+  });
+
   it("rejects a next page on another website", () => {
     const result = parseScrapeList(
       {
@@ -507,6 +563,44 @@ describe("scrape source parser", () => {
       Object.values(legacy.externalReviewBodies),
     );
   });
+
+  it.each(["single-review.html", "multi-review.html"])(
+    "matches the current Words of Whisky parser for %s",
+    async (fixture) => {
+      const url = new URL(
+        fixture === "single-review.html"
+          ? "https://wordsofwhisky.com/bruichladdich-greener-still-review"
+          : "https://wordsofwhisky.com/kanosuke-dingle-meikle-toir-the-whisky-exchange",
+      );
+      const html = await loadFixture("wordsofwhisky", fixture);
+      const legacy = parseWordsOfWhiskyArticle(html, url);
+      const configured = parseScrapeDetail(wordsOfWhiskyRules, html, url);
+
+      expect(configured.kind).toBe("review");
+      expect(configured.issues).toEqual([]);
+      if (configured.kind !== "review" || !configured.value) {
+        throw new Error("Expected configured review output.");
+      }
+      expect(configured.value.article).toMatchObject({
+        canonicalUrl: legacy.article.canonicalUrl,
+        title: legacy.article.title,
+        publishedAt: legacy.article.publishedAt,
+      });
+      expect(configured.value.article.externalReviews).toMatchObject(
+        legacy.article.externalReviews.map((review) => ({
+          name: review.name,
+          reviewerName: review.reviewerName,
+          nativeScore: review.nativeScore,
+        })),
+      );
+      expect(Object.values(configured.value.externalReviewTexts)).toEqual(
+        Object.values(legacy.externalReviewTexts),
+      );
+      expect(Object.values(configured.value.externalReviewBodies)).toEqual(
+        Object.values(legacy.externalReviewBodies),
+      );
+    },
+  );
 
   it("rejects conflicting URL dates and unmapped scores", async () => {
     const html = (await loadFixture("whiskeyreviewer", "review.html"))
@@ -786,6 +880,41 @@ describe("scrape source parser", () => {
     expect(result.value.externalReviewTexts).toEqual({
       [first.sourceKey]: "Nose: vanilla.",
       [second.sourceKey]: "Palate: smoke.",
+    });
+  });
+
+  it("stops sibling review sections at the next heading or ending selector", () => {
+    const result = parseScrapeDetail(
+      {
+        ...reviewConfig,
+        detail: {
+          ...reviewConfig.detail,
+          reviewItem: {
+            start: ".reviews > h2.review",
+            endBefore: ".reviews > .related",
+          },
+          name: { selector: "h2.review" },
+          reviewText: { selector: "p.notes" },
+          score: undefined,
+        },
+      },
+      `<h1>Two reviews</h1><time datetime="2026-09-01"></time>
+      <div class="reviews">
+        <h2 class="review">First Bottle</h2><p class="notes">Nose: fruit.</p>
+        <h2 class="review">Second Bottle</h2><p class="notes">Palate: smoke.</p>
+        <div class="related">Related reviews</div>
+      </div>`,
+      new URL("https://reviews.test/sections"),
+    );
+
+    expect(result.issues).toEqual([]);
+    if (result.kind !== "review" || !result.value) {
+      throw new Error("Expected reviews");
+    }
+    const [first, second] = result.value.article.externalReviews;
+    expect(result.value.externalReviewBodies).toEqual({
+      [first.sourceKey]: "First Bottle\n\nNose: fruit.",
+      [second.sourceKey]: "Second Bottle\n\nPalate: smoke.",
     });
   });
 

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -7,10 +7,12 @@ import type { z } from "zod";
 import { readReviewBody } from "../adapters/reviewBody";
 import type { ScrapeIssue } from "./preview";
 import type {
+  ScrapeReviewSection,
   ScrapeValue,
   ScrapeValueSelectorV1,
   StoredScrapeRules,
 } from "./rules";
+import { normalizeScrapeReviewItem } from "./rules";
 
 export type ScrapeListResult = {
   links: string[];
@@ -31,6 +33,7 @@ export type ScrapeDetailResult =
     };
 
 type ScrapeReadableValue = ScrapeValue | ScrapeValueSelectorV1;
+type ScrapeNode = { parent?: ScrapeNode | null };
 
 function normalizeValue(value: string | undefined) {
   return value?.replaceAll(/\s+/g, " ").trim() || null;
@@ -301,6 +304,49 @@ function priceField(path: PropertyKey[]) {
   return PRICE_FIELDS.has(field) ? `detail.${field}` : "detail";
 }
 
+function selectReviewItems(
+  $: ReturnType<typeof load>,
+  rule: string | ScrapeReviewSection,
+) {
+  const itemRule = normalizeScrapeReviewItem(rule);
+  if (itemRule.kind === "element") {
+    return $(itemRule.selector)
+      .toArray()
+      .map((element) => ({
+        body: $(element),
+        item: load($.html(element)),
+        nodes: [element],
+      }));
+  }
+
+  const starts = $(itemRule.start).toArray();
+  return starts.map((start) => {
+    if (starts.length === 1) {
+      const body = $(start).parent();
+      return {
+        body,
+        item: load(body.html() ?? ""),
+        nodes: body.toArray(),
+      };
+    }
+
+    const stopSelector = [itemRule.start, itemRule.endBefore]
+      .filter(Boolean)
+      .join(", ");
+    const body = $(start).add($(start).nextUntil(stopSelector));
+    return {
+      body,
+      item: load(
+        body
+          .toArray()
+          .map((element) => $.html(element))
+          .join(""),
+      ),
+      nodes: body.toArray(),
+    };
+  });
+}
+
 function parseReviewDetail(
   rules: Extract<StoredScrapeRules, { kind: "review" }>,
   html: string,
@@ -371,7 +417,18 @@ function parseReviewDetail(
   }> = [];
   const externalReviewTexts: Record<string, string> = {};
   const externalReviewBodies: Record<string, string> = {};
-  const reviewItems = $(rules.detail.reviewItem).toArray();
+  const reviewItems = selectReviewItems($, rules.detail.reviewItem);
+  const reviewItemNodes = new Set<ScrapeNode>(
+    reviewItems.flatMap(({ nodes }) => nodes),
+  );
+  const isWithinReviewItem = (element: ScrapeNode) => {
+    let current: ScrapeNode | null = element;
+    while (current) {
+      if (reviewItemNodes.has(current)) return true;
+      current = current.parent ?? null;
+    }
+    return false;
+  };
   const readReviewValue = (
     item: ReturnType<typeof load>,
     selector: ScrapeReadableValue,
@@ -384,8 +441,7 @@ function parseReviewDetail(
     const pageBylines =
       reviewerSelector && !("value" in reviewerSelector)
         ? $(reviewerSelector.selector).filter(
-            (_, element) =>
-              $(element).closest(rules.detail.reviewItem).length === 0,
+            (_, element) => !isWithinReviewItem(element),
           )
         : null;
     // Scraper parsing shares only one explicit page byline; a review's writer stays local.
@@ -402,8 +458,7 @@ function parseReviewDetail(
               reviewerSelector,
             )
           : null;
-    reviewItems.forEach((element, index) => {
-      const item = load($.html(element));
+    reviewItems.forEach(({ body, item }, index) => {
       const name = readReviewValue(item, rules.detail.name);
       if (!name) {
         issues.push({
@@ -413,8 +468,8 @@ function parseReviewDetail(
         return;
       }
       const sourceKey = `${canonicalUrl?.toString() ?? pageUrl.toString()}#review-${index + 1}`;
-      const body = readReviewBody($(element));
-      if (body) externalReviewBodies[sourceKey] = body;
+      const reviewBody = readReviewBody(body);
+      if (reviewBody) externalReviewBodies[sourceKey] = reviewBody;
       const reviewerName = reviewerSelector
         ? (readValue(item, reviewerSelector) ?? pageReviewerName)
         : null;

--- a/apps/server/src/scraper/configured/prepareMultiReviewSource.ts
+++ b/apps/server/src/scraper/configured/prepareMultiReviewSource.ts
@@ -1,0 +1,129 @@
+import { db } from "@peated/server/db";
+import {
+  externalReviewArticles,
+  externalReviews,
+} from "@peated/server/db/schema";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import {
+  createPreparedSource,
+  inspectExistingSource,
+  type ExistingSourceDefinition,
+} from "./prepareExistingSource";
+import type { PrepareReviewSourceInput } from "./prepareReviewSource";
+import { ScrapeSourceValidationError } from "./service";
+
+const InputSchema = z
+  .object({
+    apply: z.boolean().default(false),
+    createdById: z.number().int().positive(),
+  })
+  .strict();
+
+type MultiReviewSourceDefinition = ExistingSourceDefinition & {
+  listUrl: string;
+  isCanonicalArticleUrl: (url: string) => boolean;
+  legacyReviewKey: (review: {
+    articleUrl: string;
+    name: string;
+    reviewerName: string | null;
+  }) => string;
+};
+
+/** Checks every review identity before assigning configured-parser positions. */
+export async function prepareMultiReviewSource(
+  input: PrepareReviewSourceInput,
+  definition: MultiReviewSourceDefinition,
+) {
+  const { apply, createdById } = InputSchema.parse(input);
+  return db.transaction(async (tx) => {
+    const site = await inspectExistingSource(tx, definition);
+    const articles = await tx
+      .select({
+        id: externalReviewArticles.id,
+        url: externalReviewArticles.canonicalUrl,
+      })
+      .from(externalReviewArticles)
+      .where(eq(externalReviewArticles.externalSiteId, site.id))
+      .for("update");
+    const reviews = await tx
+      .select({
+        id: externalReviews.id,
+        articleId: externalReviews.articleId,
+        sourceKey: externalReviews.sourceKey,
+        name: externalReviews.name,
+        reviewerName: externalReviews.reviewerName,
+      })
+      .from(externalReviews)
+      .innerJoin(
+        externalReviewArticles,
+        eq(externalReviewArticles.id, externalReviews.articleId),
+      )
+      .where(eq(externalReviewArticles.externalSiteId, site.id))
+      .for("update");
+    const reviewsByArticle = new Map<number, typeof reviews>();
+    for (const review of reviews) {
+      const group = reviewsByArticle.get(review.articleId) ?? [];
+      group.push(review);
+      reviewsByArticle.set(review.articleId, group);
+    }
+
+    const changes = articles.flatMap((article) => {
+      const articleReviews = reviewsByArticle.get(article.id) ?? [];
+      if (
+        !definition.isCanonicalArticleUrl(article.url) ||
+        articleReviews.length === 0
+      ) {
+        throw new ScrapeSourceValidationError(
+          `Check the URL and review records for ${definition.siteName} article ${article.id} before continuing.`,
+        );
+      }
+      // The review store inserts an article's emitted reviews in order and never
+      // replaces their IDs. That stored order owns configured review positions.
+      return articleReviews
+        .toSorted((left, right) => left.id - right.id)
+        .map((review, index) => {
+          const expectedKey = definition.legacyReviewKey({
+            articleUrl: article.url,
+            name: review.name,
+            reviewerName: review.reviewerName,
+          });
+          if (review.sourceKey !== expectedKey) {
+            throw new ScrapeSourceValidationError(
+              `Check the URL and review records for ${definition.siteName} article ${article.id} before continuing.`,
+            );
+          }
+          return {
+            id: review.id,
+            sourceKey: `${article.url}#review-${index + 1}`,
+          };
+        });
+    });
+
+    let scrapeSourceId: number | null = null;
+    if (apply) {
+      for (const change of changes) {
+        await tx
+          .update(externalReviews)
+          .set({ sourceKey: change.sourceKey })
+          .where(eq(externalReviews.id, change.id));
+      }
+      scrapeSourceId = await createPreparedSource(
+        tx,
+        {
+          externalSiteId: site.id,
+          kind: "review",
+          listUrl: definition.listUrl,
+          createdById,
+        },
+        definition,
+      );
+    }
+    return {
+      siteId: site.id,
+      scrapeSourceId,
+      reviewCount: changes.length,
+      applied: apply,
+    };
+  });
+}

--- a/apps/server/src/scraper/configured/prepareWordsOfWhisky.ts
+++ b/apps/server/src/scraper/configured/prepareWordsOfWhisky.ts
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import { prepareMultiReviewSource } from "./prepareMultiReviewSource";
+import type { PrepareReviewSourceInput } from "./prepareReviewSource";
+
+function normalizeKeyPart(value: string) {
+  return value.replaceAll(/\s+/g, " ").trim().toLocaleLowerCase("en");
+}
+
+/** Checks one source by default; applying keeps record IDs and leaves collection paused. */
+export async function prepareWordsOfWhiskySource(
+  input: PrepareReviewSourceInput,
+) {
+  return prepareMultiReviewSource(input, {
+    siteKey: "wordsofwhisky",
+    siteName: "Words of Whisky",
+    targetKey: "wordsofwhisky",
+    origin: "https://wordsofwhisky.com",
+    listUrl: "https://wordsofwhisky.com/",
+    isCanonicalArticleUrl: (url) =>
+      /^https:\/\/wordsofwhisky\.com\/[a-z0-9][a-z0-9-]*$/.test(url),
+    legacyReviewKey: ({ articleUrl, name, reviewerName }) => {
+      const digest = createHash("sha256")
+        .update(
+          [articleUrl, name, reviewerName ?? ""]
+            .map(normalizeKeyPart)
+            .join("\n"),
+        )
+        .digest("hex");
+      return `wordsofwhisky:${digest}`;
+    },
+  });
+}

--- a/apps/server/src/scraper/configured/rules.test.ts
+++ b/apps/server/src/scraper/configured/rules.test.ts
@@ -7,6 +7,7 @@ import {
   ScrapeRulesSchema,
   ScrapeRulesV1Schema,
   ScrapeRulesV2Schema,
+  ScrapeRulesV3Schema,
   ScrapeValueSchema,
 } from "./rules";
 
@@ -38,8 +39,8 @@ test("bounds list and detail pages", () => {
 
 test("rejects rules for an unsupported stored format", () => {
   const rules = ScrapeRulesSchema.parse(reviewConfig(25));
-  expect(() => parseScrapeRules(4, rules)).toThrow(
-    "Unsupported scrape rules version: 4.",
+  expect(() => parseScrapeRules(5, rules)).toThrow(
+    "Unsupported scrape rules version: 5.",
   );
 });
 
@@ -52,7 +53,7 @@ test("loads old rules only through the version 1 contract", () => {
       list: { ...rules.list, item: ".card" },
     }),
   ).toThrow();
-  expect(SCRAPE_RULES_VERSION).toBe(3);
+  expect(SCRAPE_RULES_VERSION).toBe(4);
 });
 
 test("loads version 2 rules only through their original contract", () => {
@@ -94,7 +95,45 @@ test("accepts bounded canonical URLs, URL dates, and score maps", () => {
     },
   });
 
+  expect(parseScrapeRules(4, rules)).toEqual(rules);
+});
+
+test("loads version 3 rules only through their original contract", () => {
+  const rules = ScrapeRulesV3Schema.parse(reviewConfig(25));
   expect(parseScrapeRules(3, rules)).toEqual(rules);
+  expect(() =>
+    parseScrapeRules(3, {
+      ...rules,
+      detail: {
+        ...rules.detail,
+        reviewItem: { start: "h2.review" },
+      },
+    }),
+  ).toThrow();
+});
+
+test("accepts bounded sibling review sections", () => {
+  const config = reviewConfig(25);
+  const rules = ScrapeRulesSchema.parse({
+    ...config,
+    detail: {
+      ...config.detail,
+      reviewItem: {
+        start: ".entry-content > h2.review",
+        endBefore: ".entry-content > .related-posts",
+      },
+    },
+  });
+
+  expect(parseScrapeRules(4, rules)).toMatchObject({
+    kind: "review",
+    detail: {
+      reviewItem: {
+        start: ".entry-content > h2.review",
+        endBefore: ".entry-content > .related-posts",
+      },
+    },
+  });
 });
 
 test.each([

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -4,7 +4,8 @@ import { z } from "zod";
 
 export const SCRAPE_RULES_VERSION_1 = 1;
 export const SCRAPE_RULES_VERSION_2 = 2;
-export const SCRAPE_RULES_VERSION = 3;
+export const SCRAPE_RULES_VERSION_3 = 3;
+export const SCRAPE_RULES_VERSION = 4;
 // TODO(scraper-platform): Add event after scraped-event match and update rules are defined.
 export const SCRAPE_SOURCE_KIND_LIST = ["review", "price"] as const;
 export type ScrapeSourceKind = (typeof SCRAPE_SOURCE_KIND_LIST)[number];
@@ -217,26 +218,35 @@ const ScrapeScoreSchema = z
     }
   });
 
-const ReviewRulesSchema = z
+export const ScrapeReviewSectionSchema = z
   .object({
-    kind: z.literal("review"),
-    list: ListRulesSchema,
-    detail: z
-      .object({
-        canonicalUrl: ScrapeValueSchema.optional(),
-        title: ScrapeValueSchema,
-        publishedAt: z
-          .union([ScrapeValueSchema, ScrapeUrlDateSchema])
-          .optional(),
-        reviewItem: ScrapeSelectorSchema,
-        name: ScrapeValueSchema,
-        reviewerName: ScrapeValueSchema.optional(),
-        reviewText: ScrapeValueSchema.optional(),
-        score: ScrapeScoreSchema.optional(),
-      })
-      .strict(),
+    start: ScrapeSelectorSchema,
+    endBefore: ScrapeSelectorSchema.optional(),
   })
   .strict();
+
+function currentReviewRulesSchema<T extends z.ZodType>(reviewItemSchema: T) {
+  return z
+    .object({
+      kind: z.literal("review"),
+      list: ListRulesSchema,
+      detail: z
+        .object({
+          canonicalUrl: ScrapeValueSchema.optional(),
+          title: ScrapeValueSchema,
+          publishedAt: z
+            .union([ScrapeValueSchema, ScrapeUrlDateSchema])
+            .optional(),
+          reviewItem: reviewItemSchema,
+          name: ScrapeValueSchema,
+          reviewerName: ScrapeValueSchema.optional(),
+          reviewText: ScrapeValueSchema.optional(),
+          score: ScrapeScoreSchema.optional(),
+        })
+        .strict(),
+    })
+    .strict();
+}
 
 function priceRulesSchema<T extends z.ZodType, U extends z.ZodType>(
   valueSchema: T,
@@ -272,14 +282,22 @@ export const ScrapeRulesV2Schema = z.discriminatedUnion("kind", [
   priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
 ]);
 
+export const ScrapeRulesV3Schema = z.discriminatedUnion("kind", [
+  currentReviewRulesSchema(ScrapeSelectorSchema),
+  priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
+]);
+
 export const ScrapeRulesSchema = z.discriminatedUnion("kind", [
-  ReviewRulesSchema,
+  currentReviewRulesSchema(
+    z.union([ScrapeSelectorSchema, ScrapeReviewSectionSchema]),
+  ),
   priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
 ]);
 
 export const StoredScrapeRulesSchema = z.union([
   ScrapeRulesV1Schema,
   ScrapeRulesV2Schema,
+  ScrapeRulesV3Schema,
   ScrapeRulesSchema,
 ]);
 
@@ -289,6 +307,17 @@ export type StoredScrapeRules = z.infer<typeof StoredScrapeRulesSchema>;
 export type ScrapeValueSelectorV1 = z.infer<typeof ScrapeValueSelectorV1Schema>;
 export type ScrapeValue = z.infer<typeof ScrapeValueSchema>;
 export type ScrapeListExclusion = z.infer<typeof ScrapeListExclusionSchema>;
+export type ScrapeReviewSection = z.infer<typeof ScrapeReviewSectionSchema>;
+
+export function normalizeScrapeReviewItem(value: string | ScrapeReviewSection) {
+  const section = ScrapeReviewSectionSchema.safeParse(value);
+  return section.success
+    ? ({ kind: "section", ...section.data } as const)
+    : ({
+        kind: "element",
+        selector: ScrapeSelectorSchema.parse(value),
+      } as const);
+}
 
 /** Parses rules only with the interpreter contract that owns their stored version. */
 export function parseScrapeRules(
@@ -300,6 +329,9 @@ export function parseScrapeRules(
   }
   if (rulesVersion === SCRAPE_RULES_VERSION_2) {
     return ScrapeRulesV2Schema.parse(rules);
+  }
+  if (rulesVersion === SCRAPE_RULES_VERSION_3) {
+    return ScrapeRulesV3Schema.parse(rules);
   }
   if (rulesVersion === SCRAPE_RULES_VERSION) {
     return ScrapeRulesSchema.parse(rules);

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -185,7 +185,7 @@ test("database constraints keep source and revision identity valid", async () =>
     createdById: user.id,
   });
   expect(first.revision).toBe(1);
-  expect(first.rulesVersion).toBe(3);
+  expect(first.rulesVersion).toBe(4);
 
   await expect(
     db.insert(scrapeSources).values({

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -59,7 +59,11 @@ function reviewCandidate(
           attribute: "datetime",
           urlDateFormat: null,
         },
-        reviewItem: "article.review",
+        reviewItem: {
+          selector: "article.review",
+          includeFollowingSiblings: false,
+          endBefore: null,
+        },
         name: suggestedValue(nameSelector, null, {
           removeSuffixes: ["Review"],
         }),
@@ -303,6 +307,53 @@ test("accepts canonical cleanup, URL dates, and finite score maps", async () => 
     },
   });
   expect(checkRules).toHaveBeenCalledOnce();
+});
+
+test("turns review headings into bounded sibling sections", async () => {
+  const base = reviewCandidate("h2");
+  const candidate = {
+    ...base,
+    rules: {
+      ...base.rules,
+      detail: {
+        ...base.rules.detail,
+        reviewItem: {
+          selector: ".entry-content > h2.review",
+          includeFollowingSiblings: true,
+          endBefore: ".entry-content > .related-posts",
+        },
+      },
+    },
+  };
+
+  const result = await runScrapeSourceSetupAgent({
+    conversationId: "scrape_source:1",
+    externalSiteRunId: 10,
+    kind: "review",
+    scrapeSourceId: 1,
+    listPages: [
+      {
+        url: "https://example.test/reviews",
+        html: '<a class="review" href="/reviews/one">Review</a>',
+      },
+    ],
+    detailPages: [],
+    request: vi.fn().mockResolvedValue(toolCallResponse("sections", candidate)),
+    checkRules: vi.fn(async () => ({
+      status: "passed" as const,
+      checked: "parsed sections",
+    })),
+  });
+
+  expect(result.rules).toMatchObject({
+    kind: "review",
+    detail: {
+      reviewItem: {
+        start: ".entry-content > h2.review",
+        endBefore: ".entry-content > .related-posts",
+      },
+    },
+  });
 });
 
 test("stops after the rule-check limit", async () => {

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -178,7 +178,13 @@ const SuggestedReviewRulesSchema = z
         canonicalUrl: SuggestedValueSelectorSchema.nullable(),
         title: SuggestedValueSelectorSchema,
         publishedAt: SuggestedPublishedAtSchema,
-        reviewItem: ScrapeSelectorSchema,
+        reviewItem: z
+          .object({
+            selector: ScrapeSelectorSchema,
+            includeFollowingSiblings: z.boolean(),
+            endBefore: ScrapeSelectorSchema.nullable(),
+          })
+          .strict(),
         name: SuggestedValueSelectorSchema,
         reviewerName: SuggestedValueSelectorSchema.nullable(),
         reviewText: SuggestedValueSelectorSchema.nullable(),
@@ -282,7 +288,8 @@ const RULE_INSTRUCTIONS = [
   "Review rules must read the publisher's publication date.",
   "When a review date exists only in the canonical URL path, use url_date with a format made from yyyy, yy, MM, dd, and * tokens. Literal characters must match the path. Repeated date tokens must agree.",
   "Set canonicalUrl only when the article's stored canonical URL needs to come from page markup or bounded cleanup such as removing a trailing slash. Otherwise set it to null.",
-  "For reviews, reviewItem must select the complete content container for each reviewed bottle, including its introduction, tasting notes, and conclusion. Its text is retained internally for later parsing. Exclude navigation, comments, related articles, and other bottles' reviews.",
+  "For reviews, reviewItem selector must identify either each complete review container or each sibling heading that starts a review. Its text is retained internally for later parsing. Exclude navigation, comments, related articles, and other bottles' reviews.",
+  "Set reviewItem includeFollowingSiblings to true only when each selected heading starts a review whose content continues through following siblings. With one selected heading, its parent is the complete review. With several, parsing stops before the next selected heading. Set endBefore to a sibling selector only when another element must end a section; otherwise set it to null. Use selectors local to each resulting review section for name, reviewText, writer, and score.",
   "Use reviewText for a narrower tasting-notes container when available; otherwise select the review body. This text is used for flavor matching and short clips.",
   "Include an optional field when the supplied pages clearly and consistently provide it.",
   "Pagination must add new detail-page links when the website has a next page.",
@@ -381,10 +388,18 @@ function toScrapeList(input: SuggestedListRules): ReviewRules["list"] {
 }
 
 function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
+  let reviewItem: ReviewRules["detail"]["reviewItem"] =
+    input.detail.reviewItem.selector;
+  if (input.detail.reviewItem.includeFollowingSiblings) {
+    reviewItem = { start: input.detail.reviewItem.selector };
+    if (input.detail.reviewItem.endBefore) {
+      reviewItem.endBefore = input.detail.reviewItem.endBefore;
+    }
+  }
   const detail: ReviewRules["detail"] = {
     title: toScrapeValue(input.detail.title),
     publishedAt: toPublishedAt(input.detail.publishedAt),
-    reviewItem: input.detail.reviewItem,
+    reviewItem,
     name: toScrapeValue(input.detail.name),
   };
   const list = toScrapeList(input.list);

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -130,6 +130,34 @@ exact output, trigger one manual collection, and confirm that it updates the
 same article and review IDs without adding trailing-slash duplicates. Check
 Bottle matches, the run, and Sentry before restoring the saved schedule.
 
+## Words of Whisky
+
+Use the preparation endpoint with `{"site": "wordsofwhisky"}`. The check-only
+request locks and verifies every stored article and review. It accepts only the
+publisher's canonical article URLs without a trailing slash, requires at least
+one review per article, and verifies each legacy review key from its stored
+article URL, Bottle name, and writer. Applying changes only those keys to the
+version 4 positional form and adds a paused source whose list page is
+`https://wordsofwhisky.com/`.
+
+Before applying, save article URLs, review IDs and order, Bottle matches,
+visibility, scores, writers, publication settings, stored-body counts, and the
+current schedule. Stop the schedule and wait for active runs. Compare every
+record after applying; multi-Bottle articles must keep the same review order
+and IDs.
+
+Version 4 rules must select only tasting-note articles from the homepage. On
+detail pages, use each direct `h2` Bottle heading to start a sibling review
+section. Select the canonical URL without its trailing slash, exact publication
+time, writer, Bottle name, tasting paragraphs, and score out of 10. Run the
+rules through a full local no-write preview and compare single- and multi-Bottle
+articles with the code parser before applying.
+
+Activate only a production preview with exact output. Trigger one manual
+collection and confirm it updates the same review IDs without adding articles
+or reviews. Check Bottle matches, review bodies, the run, and Sentry before
+restoring the saved daily schedule. Preparation must not change publication.
+
 ## Compass Box
 
 Use the same preparation endpoint with `{"site": "compassbox"}`. The check-only
@@ -186,9 +214,9 @@ handles reviews added after the switch. Do not delete source or run history.
 ## Other sources
 
 The preparation API is shared. It currently supports Bourbon Culture, Compass
-Box, Kilchoman, The Whiskey Reviewer, Whisky Saga, and The Whisky Study. Other
-sites are rejected without changing records. Add each site's conversion behind
-this route as its existing records are reviewed.
+Box, Kilchoman, The Whiskey Reviewer, Whisky Saga, The Whisky Study, and Words
+of Whisky. Other sites are rejected without changing records. Add each site's
+conversion behind this route as its existing records are reviewed.
 
 Prepare each source using its own rules for recognizing existing records.
 Articles with several reviews need a verified match for each review. Store


### PR DESCRIPTION
Words of Whisky can now be prepared for database-managed scraper rules without replacing its existing articles, reviews, Bottle matches, bodies, publication state, or run history. The check-only path validates every canonical article URL and reconstructs every legacy review key from stored article, Bottle-name, and writer evidence before any change is allowed.

Applying the preparation keeps each review ID and assigns positional keys in the original stored insertion order, transfers only the source's request settings to administrator ownership, creates a paused review source, and leaves activation for the normal preview workflow. The operation guide records the inventory, full local preview, activation, and post-run checks required for multi-Bottle articles.

This is stacked on #1055, which adds the version 4 sibling-section rules needed to parse Words of Whisky's multi-Bottle articles.
