### PR TITLE
style(web): reduce compact bottle row emphasis

### DIFF
--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -75,7 +75,7 @@ const meta = {
 | standard (default) | Catalog, tastings, reviews, and selection | Name, provenance, and release facts; 48 × 64px thumbnail (42 × 58px on mobile). |
 | search | Typeahead results | Standard identity and thumbnail, 15px compact title, and 8px vertical padding. |
 | sidebar | Sidebar bottle lists | 15px title limited to two lines, 32 × 46px thumbnail, and trailing content below the identity. |
-| compact | Single or grouped library additions | One name line, 24 × 32px thumbnail, and a 44px hit area. |
+| compact | Single or grouped library additions | One regular-weight name line, 24 × 32px thumbnail, and a 44px hit area. |
 
 Sidebar omits membership status icons and keeps full accessible names when its two-line titles truncate. Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Use layout="cell" inside an existing control so its bottle link stays within the identity. Use linkArea="title" when the surrounding card is also clickable. The end slot holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
 

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -40,8 +40,9 @@ export type BottleIdentityRowProps = {
 /**
  * Bottle identity for lists and activity. Standard shows name, provenance, then
  * release facts; search tightens the title and spacing for typeahead results;
- * sidebar uses compact titles and small thumbnails; compact shows one name line
- * for library additions. Sidebar names use two lines with the full name in title.
+ * sidebar uses compact titles and small thumbnails; compact shows one regular-weight
+ * name line for dense lists of library additions. Sidebar names use two lines with
+ * the full name in title.
  * Search places trailing ratings or actions below the identity on narrow screens.
  * Use toBottleListItem for API Bottles or getBottleIdentityProps for partial reads.
  * All variants take the same full marketed name and own their thumbnail size.
@@ -259,6 +260,7 @@ const styles = stylex.create({
   compactName: {
     display: "block",
     overflow: "hidden",
+    fontWeight: 400,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },


### PR DESCRIPTION
Compact bottle rows now render bottle names at regular weight, reducing visual noise when several library additions are grouped together. The existing size, spacing, hit area, and truncation behavior remain unchanged, as do the standard, search, and sidebar row variants; Storybook guidance now records the compact treatment.
