### PR TITLE
fix(server): repair bottle group counts safely

### DIFF
--- a/apps/server/src/lib/recomputeBottleGroupStats.test.ts
+++ b/apps/server/src/lib/recomputeBottleGroupStats.test.ts
@@ -1,5 +1,6 @@
 import type { RatingBandId } from "@peated/server/constants";
 import { db } from "@peated/server/db";
+import { getPostgresConnectionConfig } from "@peated/server/db/connection";
 import type { Bottle } from "@peated/server/db/schema";
 import {
   bottleGroups,
@@ -10,11 +11,36 @@ import {
 } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { eq } from "drizzle-orm";
+import pg from "pg";
 import {
   BottleGroupStatsIntegrityError,
+  checkBottleGroupBottleCounts,
   recomputeBottleGroupStats,
   recomputeBottleGroupStatsInTransaction,
+  repairBottleGroupBottleCount,
 } from "./recomputeBottleGroupStats";
+
+const { Client } = pg;
+type NodePgClient = InstanceType<typeof Client>;
+
+async function waitForSessionBlockedBy(
+  observer: NodePgClient,
+  blockerPid: number,
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const result = await observer.query<{ pid: number }>(
+      `SELECT pid
+       FROM pg_stat_activity
+       WHERE $1 = ANY(pg_blocking_pids(pid))
+       LIMIT 1`,
+      [blockerPid],
+    );
+    if (result.rows.length) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for the BottleGroup repair lock.");
+}
 
 function requireGroupId(groupId: number | null): number {
   if (groupId === null) throw new Error("Missing BottleGroup fixture");
@@ -157,5 +183,118 @@ describe("BottleGroup statistics recomputation", () => {
         where: eq(bottleGroups.id, requireGroupId(onlyMember.groupId)),
       }),
     ).resolves.toEqual(before);
+  });
+
+  test("finds and repairs wrong Bottle totals", async ({ fixtures }) => {
+    const wrong = await fixtures.Bottle();
+    const correct = await fixtures.Bottle();
+    const [emptyGroup] = await db
+      .insert(bottleGroups)
+      .values({
+        name: "Empty Group",
+        fullName: "Empty Group",
+        brandId: wrong.brandId,
+        createdByActorId: wrong.createdByActorId,
+        totalBottles: 4,
+      })
+      .returning();
+    if (!emptyGroup) throw new Error("Unable to create empty BottleGroup");
+    await db
+      .update(bottleGroups)
+      .set({ totalBottles: 9 })
+      .where(eq(bottleGroups.id, wrong.groupId));
+
+    const groupIds = [wrong.groupId, correct.groupId, emptyGroup.id];
+    await expect(checkBottleGroupBottleCounts(groupIds)).resolves.toEqual([
+      {
+        groupId: wrong.groupId,
+        savedCount: 9,
+        actualCount: 1,
+      },
+      {
+        groupId: emptyGroup.id,
+        savedCount: 4,
+        actualCount: 0,
+      },
+    ]);
+    await expect(checkBottleGroupBottleCounts([])).resolves.toEqual([]);
+
+    await expect(repairBottleGroupBottleCount(wrong.groupId)).resolves.toEqual({
+      groupId: wrong.groupId,
+      savedCount: 9,
+      actualCount: 1,
+    });
+    await expect(repairBottleGroupBottleCount(emptyGroup.id)).resolves.toEqual({
+      groupId: emptyGroup.id,
+      savedCount: 4,
+      actualCount: 0,
+    });
+    await expect(
+      repairBottleGroupBottleCount(wrong.groupId),
+    ).resolves.toBeNull();
+    await expect(repairBottleGroupBottleCount(999_999)).resolves.toBeNull();
+    await expect(checkBottleGroupBottleCounts(groupIds)).resolves.toEqual([]);
+  });
+
+  test("recounts after an earlier member change commits", async ({
+    fixtures,
+  }) => {
+    const first = await fixtures.Bottle();
+    const retired = await fixtures.BottleGroupMember({
+      groupId: first.groupId,
+    });
+    const writer = new Client(getPostgresConnectionConfig());
+    const observer = new Client(getPostgresConnectionConfig());
+    let writerCommitted = false;
+    let repair: ReturnType<typeof repairBottleGroupBottleCount> | null = null;
+
+    await writer.connect();
+    await observer.connect();
+    try {
+      await writer.query("BEGIN");
+      const writerPid = (
+        await writer.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")
+      ).rows[0]?.pid;
+      if (!writerPid) throw new Error("Unable to load Bottle writer pid.");
+
+      await writer.query(
+        "SELECT id FROM bottle_group WHERE id = $1 FOR UPDATE",
+        [first.groupId],
+      );
+      await writer.query(
+        "INSERT INTO bottle_tombstone (bottle_id) VALUES ($1)",
+        [retired.id],
+      );
+      await writer.query(
+        "UPDATE bottle_group SET total_bottles = 7 WHERE id = $1",
+        [first.groupId],
+      );
+
+      repair = repairBottleGroupBottleCount(first.groupId);
+      void repair.catch(() => undefined);
+      await waitForSessionBlockedBy(observer, writerPid);
+
+      await writer.query("COMMIT");
+      writerCommitted = true;
+
+      await expect(repair).resolves.toEqual({
+        groupId: first.groupId,
+        savedCount: 7,
+        actualCount: 1,
+      });
+    } finally {
+      if (!writerCommitted) {
+        await writer.query("ROLLBACK").catch(() => undefined);
+      }
+      if (repair) await repair.catch(() => undefined);
+      await writer.end();
+      await observer.end();
+    }
+
+    await expect(
+      db.query.bottleGroups.findFirst({
+        where: eq(bottleGroups.id, first.groupId),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
   });
 });

--- a/apps/server/src/lib/recomputeBottleGroupStats.ts
+++ b/apps/server/src/lib/recomputeBottleGroupStats.ts
@@ -1,4 +1,4 @@
-import { db, type AnyTransaction } from "@peated/server/db";
+import { db, type AnyDatabase, type AnyTransaction } from "@peated/server/db";
 import type { BottleGroup } from "@peated/server/db/schema";
 import {
   bottleGroups,
@@ -6,7 +6,7 @@ import {
   bottleTombstones,
 } from "@peated/server/db/schema";
 import { aggregateBottleActivityStatsInTransaction } from "@peated/server/lib/recomputeBottleActivityStats";
-import { asc, eq, inArray } from "drizzle-orm";
+import { asc, eq, inArray, sql } from "drizzle-orm";
 
 export type BottleGroupStatsIntegrityErrorCode =
   | "not_found"
@@ -36,6 +36,75 @@ export type BottleGroupStatsResult = Pick<
   | "tastingBandCounts"
   | "updatedAt"
 >;
+
+export type WrongBottleGroupBottleCount = {
+  groupId: number;
+  savedCount: number;
+  actualCount: number;
+};
+
+type BottleCountQueryRow = {
+  groupId: number | string;
+  savedCount: number | string;
+  actualCount: number | string;
+};
+
+function uniqueSorted(values: readonly number[]): number[] {
+  return Array.from(new Set(values)).sort((left, right) => left - right);
+}
+
+async function findWrongBottleCounts(
+  database: AnyDatabase,
+  groupIds?: readonly number[],
+): Promise<WrongBottleGroupBottleCount[]> {
+  const ids = groupIds === undefined ? undefined : uniqueSorted(groupIds);
+  if (ids?.length === 0) return [];
+  const groupFilter = ids ? inArray(bottleGroups.id, ids) : sql`TRUE`;
+  const bottleFilter = ids ? inArray(bottles.groupId, ids) : sql`TRUE`;
+
+  const result = await database.execute<BottleCountQueryRow>(sql`
+    WITH active_counts AS (
+      SELECT ${bottles.groupId} AS group_id, COUNT(*) AS total
+      FROM ${bottles}
+      WHERE ${bottles.groupId} IS NOT NULL
+        AND ${bottleFilter}
+        AND NOT EXISTS (
+          SELECT 1 FROM ${bottleTombstones}
+          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
+        )
+      GROUP BY ${bottles.groupId}
+    )
+    SELECT
+      ${bottleGroups.id} AS "groupId",
+      ${bottleGroups.totalBottles} AS "savedCount",
+      COALESCE(active_counts.total, 0) AS "actualCount"
+    FROM ${bottleGroups}
+    LEFT JOIN active_counts ON active_counts.group_id = ${bottleGroups.id}
+    WHERE ${groupFilter}
+      AND ${bottleGroups.totalBottles} <> COALESCE(active_counts.total, 0)
+    ORDER BY ${bottleGroups.id}
+  `);
+
+  return result.rows.map((row) => ({
+    groupId: Number(row.groupId),
+    savedCount: Number(row.savedCount),
+    actualCount: Number(row.actualCount),
+  }));
+}
+
+async function repairExistingBottleCount(
+  tx: AnyTransaction,
+  groupId: number,
+): Promise<WrongBottleGroupBottleCount | null> {
+  const [difference] = await findWrongBottleCounts(tx, [groupId]);
+  if (!difference) return null;
+
+  await tx
+    .update(bottleGroups)
+    .set({ totalBottles: difference.actualCount })
+    .where(eq(bottleGroups.id, groupId));
+  return difference;
+}
 
 /** Recomputes one active group from direct activity on its member Bottles. */
 export async function recomputeBottleGroupStatsInTransaction(
@@ -116,4 +185,27 @@ export async function recomputeBottleGroupStats(
   return await db.transaction((tx) =>
     recomputeBottleGroupStatsInTransaction(tx, groupId),
   );
+}
+
+/** Checks saved BottleGroup totals against their active member Bottles. */
+export async function checkBottleGroupBottleCounts(
+  groupIds?: readonly number[],
+): Promise<WrongBottleGroupBottleCount[]> {
+  return findWrongBottleCounts(db, groupIds);
+}
+
+/** Locks and rechecks one BottleGroup before repairing only its Bottle total. */
+export async function repairBottleGroupBottleCount(
+  groupId: number,
+): Promise<WrongBottleGroupBottleCount | null> {
+  return db.transaction(async (tx) => {
+    const [group] = await tx
+      .select({ id: bottleGroups.id })
+      .from(bottleGroups)
+      .where(eq(bottleGroups.id, groupId))
+      .for("update");
+    if (!group) return null;
+
+    return repairExistingBottleCount(tx, groupId);
+  });
 }

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
@@ -15,7 +15,7 @@ describe("POST /admin/catalog/repair-bottle-counts", () => {
     await expect(
       routerClient.admin.repairBottleCounts({}, { context: { user: admin } }),
     ).resolves.toEqual({ status: "queued" });
-    expect(pushUniqueJob).toHaveBeenCalledTimes(2);
+    expect(pushUniqueJob).toHaveBeenCalledTimes(3);
     expect(pushUniqueJob).toHaveBeenNthCalledWith(
       1,
       "RepairEntityBottleCounts",
@@ -27,6 +27,14 @@ describe("POST /admin/catalog/repair-bottle-counts", () => {
     expect(pushUniqueJob).toHaveBeenNthCalledWith(
       2,
       "RepairLocationBottleCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
+    expect(pushUniqueJob).toHaveBeenNthCalledWith(
+      3,
+      "RepairBottleGroupBottleCounts",
       {},
       {
         delay: 0,

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
@@ -10,7 +10,7 @@ export default procedure
     path: "/admin/catalog/repair-bottle-counts",
     summary: "Repair saved bottle counts",
     description:
-      "Check saved bottle totals for brands, producers, countries, and regions, and fix any that are wrong. Requires administrator privileges.",
+      "Check saved bottle totals and fix any that are wrong. Requires administrator privileges.",
     operationId: "repairEntityBottleCounts",
   })
   .input(z.object({}).strict().default({}))
@@ -25,6 +25,13 @@ export default procedure
     );
     await pushUniqueJob(
       "RepairLocationBottleCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
+    await pushUniqueJob(
+      "RepairBottleGroupBottleCounts",
       {},
       {
         delay: 0,

--- a/apps/server/src/orpc/routes/bottles/delete.test.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.test.ts
@@ -1,4 +1,5 @@
 import { db } from "@peated/server/db";
+import { getPostgresConnectionConfig } from "@peated/server/db/connection";
 import {
   bottleBarcodes,
   bottleFlavorProfiles,
@@ -21,7 +22,30 @@ import { getUserActor } from "@peated/server/lib/actors";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
+import pg from "pg";
 import { describe, expect, test } from "vitest";
+
+const { Client } = pg;
+type NodePgClient = InstanceType<typeof Client>;
+
+async function waitForSessionBlockedBy(
+  observer: NodePgClient,
+  blockerPid: number,
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const result = await observer.query<{ pid: number }>(
+      `SELECT pid
+       FROM pg_stat_activity
+       WHERE $1 = ANY(pg_blocking_pids(pid))
+       LIMIT 1`,
+      [blockerPid],
+    );
+    if (result.rows.length) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for Bottle deletion.");
+}
 
 async function loadGroupedBottleGraph(groupId: number) {
   const members = await db
@@ -118,6 +142,10 @@ describe("DELETE /bottles/:bottle", () => {
     const before = await loadGroupedBottleGraph(groupId);
     expect(before.group[0]?.representativeBottleId).toBe(representative.id);
     expect(before.members).toHaveLength(2);
+    await db
+      .update(bottleGroups)
+      .set({ totalBottles: 99 })
+      .where(eq(bottleGroups.id, groupId));
 
     await routerClient.bottles.delete(
       { bottle: representative.id },
@@ -140,6 +168,64 @@ describe("DELETE /bottles/:bottle", () => {
         where: eq(entities.id, representative.brandId),
       }),
     ).toMatchObject({ totalBottles: 1 });
+  });
+
+  test("waits for group statistics before locking member Bottles", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ admin: true });
+    const bottle = await fixtures.Bottle();
+    await fixtures.BottleGroupMember({ groupId: bottle.groupId });
+    const statistics = new Client(getPostgresConnectionConfig());
+    const observer = new Client(getPostgresConnectionConfig());
+    let statisticsCommitted = false;
+    let deletion: ReturnType<typeof routerClient.bottles.delete> | null = null;
+
+    await statistics.connect();
+    await observer.connect();
+    try {
+      await statistics.query("BEGIN");
+      const statisticsPid = (
+        await statistics.query<{ pid: number }>(
+          "SELECT pg_backend_pid() AS pid",
+        )
+      ).rows[0]?.pid;
+      if (!statisticsPid) {
+        throw new Error("Unable to load BottleGroup statistics pid.");
+      }
+      await statistics.query(
+        "SELECT id FROM bottle_group WHERE id = $1 FOR UPDATE",
+        [bottle.groupId],
+      );
+
+      deletion = routerClient.bottles.delete(
+        { bottle: bottle.id },
+        { context: { user } },
+      );
+      void deletion.catch(() => undefined);
+      await waitForSessionBlockedBy(observer, statisticsPid);
+
+      await statistics.query(
+        "SELECT id FROM bottle WHERE group_id = $1 ORDER BY id FOR SHARE NOWAIT",
+        [bottle.groupId],
+      );
+      await statistics.query("COMMIT");
+      statisticsCommitted = true;
+      await expect(deletion).resolves.toEqual({});
+    } finally {
+      if (!statisticsCommitted) {
+        await statistics.query("ROLLBACK").catch(() => undefined);
+      }
+      if (deletion) await deletion.catch(() => undefined);
+      await statistics.end();
+      await observer.end();
+    }
+
+    await expect(
+      db.query.bottleGroups.findFirst({
+        where: eq(bottleGroups.id, bottle.groupId),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
   });
 
   test("deletes a Bottle when its Entity count is too low", async ({

--- a/apps/server/src/orpc/routes/bottles/delete.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.ts
@@ -65,18 +65,85 @@ export default procedure
   .handler(async function ({ input, context, errors }) {
     const { bottle: bottleId } = input;
     await db.transaction(async (tx) => {
-      // Bottle deletion owns this row lock so new records cannot link to the
-      // Bottle after the checks below pass.
-      const [bottle] = await tx
-        .select()
+      const [discoveredBottle] = await tx
+        .select({ id: bottles.id, groupId: bottles.groupId })
         .from(bottles)
         .where(eq(bottles.id, bottleId))
-        .limit(1)
-        .for("update");
-      if (!bottle) {
+        .limit(1);
+      if (!discoveredBottle) {
         throw errors.NOT_FOUND({
           message: "Bottle not found.",
         });
+      }
+
+      let bottle: typeof bottles.$inferSelect | undefined;
+      let remainingGroupMemberIds: number[] = [];
+      let groupRepresentativeBottleId: number | null = null;
+      if (discoveredBottle.groupId === null) {
+        [bottle] = await tx
+          .select()
+          .from(bottles)
+          .where(eq(bottles.id, bottleId))
+          .limit(1)
+          .for("update");
+        if (!bottle) {
+          throw errors.NOT_FOUND({
+            message: "Bottle not found.",
+          });
+        }
+        if (bottle.groupId !== null) {
+          throw errors.CONFLICT({
+            message: `Bottle ${bottle.id} changed groups before deletion.`,
+          });
+        }
+      } else {
+        // BottleGroup writes own this order: lock the group, then all members
+        // by ID. Statistics and repair use the same order.
+        const [group] = await tx
+          .select({
+            id: bottleGroups.id,
+            representativeBottleId: bottleGroups.representativeBottleId,
+          })
+          .from(bottleGroups)
+          .where(eq(bottleGroups.id, discoveredBottle.groupId))
+          .limit(1)
+          .for("update");
+        if (!group) {
+          const currentBottle = await tx.query.bottles.findFirst({
+            columns: { id: true },
+            where: eq(bottles.id, bottleId),
+          });
+          if (!currentBottle) {
+            throw errors.NOT_FOUND({ message: "Bottle not found." });
+          }
+          throw errors.CONFLICT({
+            message: `Bottle ${bottleId} belongs to a missing BottleGroup.`,
+          });
+        }
+
+        const groupMembers = await tx
+          .select()
+          .from(bottles)
+          .where(eq(bottles.groupId, group.id))
+          .orderBy(asc(bottles.id))
+          .for("update");
+        bottle = groupMembers.find(({ id }) => id === bottleId);
+        if (!bottle) {
+          const currentBottle = await tx.query.bottles.findFirst({
+            columns: { groupId: true },
+            where: eq(bottles.id, bottleId),
+          });
+          if (!currentBottle) {
+            throw errors.NOT_FOUND({ message: "Bottle not found." });
+          }
+          throw errors.CONFLICT({
+            message: `Bottle ${bottleId} changed groups before deletion.`,
+          });
+        }
+        remainingGroupMemberIds = groupMembers
+          .map(({ id }) => id)
+          .filter((id) => id !== bottleId);
+        groupRepresentativeBottleId = group.representativeBottleId;
       }
 
       const entityLinksBefore = await getBottleEntityLinks(tx, [bottle.id]);
@@ -119,36 +186,6 @@ export default procedure
         throw errors.BAD_REQUEST({
           message: `Cannot delete bottle while it is used in ${formatReferenceTypes(blockingReferences)}.`,
         });
-      }
-
-      let remainingGroupMemberIds: number[] = [];
-      let groupRepresentativeBottleId: number | null = null;
-      if (bottle.groupId !== null) {
-        const [group] = await tx
-          .select({
-            id: bottleGroups.id,
-            representativeBottleId: bottleGroups.representativeBottleId,
-          })
-          .from(bottleGroups)
-          .where(eq(bottleGroups.id, bottle.groupId))
-          .limit(1)
-          .for("update");
-        if (!group) {
-          throw errors.CONFLICT({
-            message: `Bottle ${bottle.id} belongs to a missing BottleGroup.`,
-          });
-        }
-
-        const groupMembers = await tx
-          .select({ id: bottles.id })
-          .from(bottles)
-          .where(eq(bottles.groupId, group.id))
-          .orderBy(asc(bottles.id))
-          .for("update");
-        remainingGroupMemberIds = groupMembers
-          .map(({ id }) => id)
-          .filter((id) => id !== bottle.id);
-        groupRepresentativeBottleId = group.representativeBottleId;
       }
 
       const actorId = (await getUserActorForDatabase(tx, context.user)).id;

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -21,6 +21,7 @@ import onEntityChange from "./onEntityChange";
 import processNotification from "./processNotification";
 import processStorePriceMatchRetryRun from "./processStorePriceMatchRetryRun";
 import reconcileStorePriceMatchProposals from "./reconcileStorePriceMatchProposals";
+import repairBottleGroupBottleCounts from "./repairBottleGroupBottleCounts";
 import repairEntityBottleCounts from "./repairEntityBottleCounts";
 import repairLocationBottleCounts from "./repairLocationBottleCounts";
 import resolveStorePriceBottle from "./resolveStorePriceBottle";
@@ -53,6 +54,7 @@ registry.add("OnBottleChange", onBottleChange);
 registry.add("OnEntityChange", onEntityChange);
 registry.add("ProcessNotification", processNotification);
 registry.add("ProcessStorePriceMatchRetryRun", processStorePriceMatchRetryRun);
+registry.add("RepairBottleGroupBottleCounts", repairBottleGroupBottleCounts);
 registry.add("RepairEntityBottleCounts", repairEntityBottleCounts);
 registry.add("RepairLocationBottleCounts", repairLocationBottleCounts);
 registry.add(

--- a/apps/server/src/worker/jobs/repairBottleGroupBottleCounts.test.ts
+++ b/apps/server/src/worker/jobs/repairBottleGroupBottleCounts.test.ts
@@ -1,0 +1,35 @@
+import { db } from "@peated/server/db";
+import { bottleGroups } from "@peated/server/db/schema";
+import { checkBottleGroupBottleCounts } from "@peated/server/lib/recomputeBottleGroupStats";
+import { eq } from "drizzle-orm";
+import repairBottleGroupBottleCountsJob from "./repairBottleGroupBottleCounts";
+
+test("repairs wrong counts and is safe to run again", async ({ fixtures }) => {
+  const bottle = await fixtures.Bottle();
+  await fixtures.BottleGroupMember({ groupId: bottle.groupId });
+  await db
+    .update(bottleGroups)
+    .set({ totalBottles: 9 })
+    .where(eq(bottleGroups.id, bottle.groupId));
+
+  await expect(repairBottleGroupBottleCountsJob({})).resolves.toEqual({
+    wrongCount: 1,
+    repairedCount: 1,
+  });
+  await expect(checkBottleGroupBottleCounts()).resolves.toEqual([]);
+
+  await expect(repairBottleGroupBottleCountsJob({})).resolves.toEqual({
+    wrongCount: 0,
+    repairedCount: 0,
+  });
+});
+
+test.each([undefined, null, [], { unexpected: true }])(
+  "rejects malformed input %#",
+  async (input) => {
+    // SAFETY: This test bypasses the type so the job can reject invalid queue input.
+    await expect(
+      repairBottleGroupBottleCountsJob(input as never),
+    ).rejects.toThrow();
+  },
+);

--- a/apps/server/src/worker/jobs/repairBottleGroupBottleCounts.ts
+++ b/apps/server/src/worker/jobs/repairBottleGroupBottleCounts.ts
@@ -22,7 +22,7 @@ export default async function repairBottleGroupBottleCountsJob(
     }
   }
 
-  logInfo("Finished Bottle group count repair", {
+  logInfo("Finished BottleGroup count repair", {
     extra: {
       wrongCount: wrongCounts.length,
       repairedCount,

--- a/apps/server/src/worker/jobs/repairBottleGroupBottleCounts.ts
+++ b/apps/server/src/worker/jobs/repairBottleGroupBottleCounts.ts
@@ -1,0 +1,36 @@
+import { logInfo } from "@peated/server/lib/log";
+import {
+  checkBottleGroupBottleCounts,
+  repairBottleGroupBottleCount,
+} from "@peated/server/lib/recomputeBottleGroupStats";
+import { z } from "zod";
+import type { JobPayload } from "../types";
+
+export const RepairBottleGroupBottleCountsJobArgsSchema = z.object({}).strict();
+
+export default async function repairBottleGroupBottleCountsJob(
+  input: JobPayload,
+) {
+  RepairBottleGroupBottleCountsJobArgsSchema.parse(input);
+
+  const wrongCounts = await checkBottleGroupBottleCounts();
+  let repairedCount = 0;
+
+  for (const wrongCount of wrongCounts) {
+    if (await repairBottleGroupBottleCount(wrongCount.groupId)) {
+      repairedCount += 1;
+    }
+  }
+
+  logInfo("Finished Bottle group count repair", {
+    extra: {
+      wrongCount: wrongCounts.length,
+      repairedCount,
+    },
+  });
+
+  return {
+    wrongCount: wrongCounts.length,
+    repairedCount,
+  };
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -22,6 +22,7 @@ export type JobName =
   | "OnEntityChange"
   | "ProcessStorePriceMatchRetryRun"
   | "ProcessNotification"
+  | "RepairBottleGroupBottleCounts"
   | "RepairEntityBottleCounts"
   | "RepairLocationBottleCounts"
   | "ReconcileStorePriceMatchProposals"

--- a/apps/web/src/app/(admin)/admin/(default)/maintenance/maintenancePage.stylex.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/maintenance/maintenancePage.stylex.tsx
@@ -122,7 +122,7 @@ export default function MaintenancePage() {
 
         <AdminSection
           title="Bottle counts"
-          description="Check Bottle counts for brands, producers, countries, and regions, and fix any that are wrong. Bottle editing can continue while this runs."
+          description="Check saved Bottle counts and fix any that are wrong. Bottle editing can continue while this runs."
         >
           <div {...stylex.props(styles.sectionContent)}>
             <div {...stylex.props(styles.actionRow)}>

--- a/openspec/changes/repair-bottle-group-counts/.openspec.yaml
+++ b/openspec/changes/repair-bottle-group-counts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/repair-bottle-group-counts/design.md
+++ b/openspec/changes/repair-bottle-group-counts/design.md
@@ -1,0 +1,65 @@
+## Context
+
+`BottleGroup.totalBottles` counts active Bottle rows assigned to that group. A new Bottle and group are created together with a total of one. Bottle deletion and Bottle merge already recount affected groups in their catalog transactions. Shared Bottle edits do not change group membership.
+
+The existing BottleGroup statistics module also recalculates the total when rating work runs. It locks the BottleGroup before reading member Bottles. Bottle deletion currently takes those locks in the opposite order, which can deadlock with a queued statistics run. There is also no admin repair for old wrong BottleGroup totals.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep normal BottleGroup totals correct without depending on a queued job.
+- Give old wrong totals a repair that is safe while Bottle work continues.
+- Use one module for the BottleGroup count rule and independent check.
+- Make group and member lock order consistent.
+
+**Non-Goals:**
+
+- Changing Bottle grouping or adding a group merge or split feature.
+- Changing rating aggregates stored on BottleGroup.
+- Deleting empty legacy BottleGroups during count repair.
+- Adding a general counter framework, CLI command, new admin control, schema change, or public API change.
+
+## Decisions
+
+### Keep active member Bottles as the source of truth
+
+The total is the number of Bottle rows assigned to a BottleGroup that do not have a tombstone. This matches the existing BottleGroup statistics calculation.
+
+Normal creation continues to save one for a new singleton group. Deletion and merge continue to recount only the affected groups before commit. Bottle field and relationship updates do not touch the total because they cannot change group membership.
+
+Replacing these bounded recounts with a new before-and-after change system was considered, but it would add another concept without reducing meaningful work. BottleGroups are small, and the existing exact recount also updates required rating aggregates after deletion and merge.
+
+### Add the check and repair to the BottleGroup statistics owner
+
+The existing BottleGroup statistics module gains an independent query that compares every saved total with active Bottle rows. Repair locks one BottleGroup, runs the filtered check again, and updates only `totalBottles`. Rechecking after the lock prevents a scan result from overwriting a newer catalog change.
+
+Repairing only the total avoids recalculating or changing unrelated rating data. If an old BottleGroup has no active members, repair saves zero but does not delete the group or change links. Removing invalid groups requires a separate reviewed catalog operation.
+
+### Lock BottleGroups before member Bottles
+
+Bottle update, merge, and group statistics work already lock a BottleGroup before its member Bottles. Bottle deletion will discover the group without a lock, then lock the group and all member Bottles by ID before checking and changing the graph. It verifies the discovered Bottle still belongs to the locked group.
+
+This order lets a repair or queued statistics run wait for a normal write without the two transactions holding one another's needed rows.
+
+### Extend the existing admin repair action
+
+A strict, unique worker job checks all BottleGroups once and repairs each wrong group in a separate transaction. The existing admin Bottle-count action starts it after the Entity and location repair jobs. The Maintenance page uses general wording so another saved Bottle count does not require another control or a list of internal data types.
+
+## Risks / Trade-offs
+
+- [A catalog write bypasses the group lock] → Keep group membership changes in the existing create, delete, and merge owners and test each path.
+- [A scan result becomes stale] → Lock and recheck one BottleGroup before saving its total.
+- [An old group has no active Bottles] → Save the accurate zero total without deleting catalog history or links.
+- [A group has many releases] → Count only that group's indexed member rows during repair; the broad comparison runs only when an administrator starts it.
+
+## Migration Plan
+
+1. Deploy the check, repair job, and consistent deletion lock order.
+2. Run the existing Bottle-count repair once from Maintenance.
+
+Rollback removes the new repair job and restores the earlier deletion code. No stored format or schema rollback is needed.
+
+## Open Questions
+
+None.

--- a/openspec/changes/repair-bottle-group-counts/proposal.md
+++ b/openspec/changes/repair-bottle-group-counts/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`BottleGroup.totalBottles` is saved because Bottle lists use it to show and sort related releases. Normal creation, deletion, and merge paths update it today, but there is no production repair for old wrong totals, and Bottle deletion takes group and Bottle locks in the opposite order from the shared group statistics code.
+
+## What Changes
+
+- Make active Bottle rows in a BottleGroup the documented source of truth for its Bottle total.
+- Keep the total correct in the existing creation, deletion, and merge transactions; ordinary Bottle field updates do not change group membership.
+- Make Bottle deletion lock its BottleGroup before its member Bottles, matching the other group write paths.
+- Add an independent check and one-group-at-a-time repair to the existing admin Bottle-count action.
+- Cover creation, updates, deletion, merges, concurrent repair, and invalid groups with integration tests.
+
+## Capabilities
+
+### New Capabilities
+
+- `bottle-group-bottle-counts`: Correct, repairable BottleGroup Bottle totals derived from active member Bottles.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- BottleGroup statistics ownership and tests.
+- Bottle deletion lock order and tests.
+- The existing admin Bottle-count repair route and Maintenance page copy.
+- Worker registration and tests for the BottleGroup repair job.
+- No schema migration, CLI command, new admin control, public API change, or runtime dependency.

--- a/openspec/changes/repair-bottle-group-counts/specs/bottle-group-bottle-counts/spec.md
+++ b/openspec/changes/repair-bottle-group-counts/specs/bottle-group-bottle-counts/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Correct BottleGroup Bottle totals
+
+The system SHALL store the number of active member Bottles on each BottleGroup without depending on queued work.
+
+#### Scenario: Create a Bottle
+
+- **WHEN** the system creates a Bottle and its singleton BottleGroup
+- **THEN** the BottleGroup total is one in the creation transaction
+
+#### Scenario: Update Bottle fields or relationships
+
+- **WHEN** a Bottle update changes fields or relationships without changing BottleGroup membership
+- **THEN** the BottleGroup total remains unchanged
+
+#### Scenario: Delete a Bottle
+
+- **WHEN** the system deletes a Bottle from a group that retains active members
+- **THEN** the BottleGroup total equals the remaining active members before the deletion commits
+
+#### Scenario: Merge Bottles
+
+- **WHEN** the system merges an exact duplicate within one group or across two groups
+- **THEN** every retained BottleGroup total equals its remaining active members before the merge commits
+
+### Requirement: Consistent BottleGroup locks
+
+The system SHALL lock a BottleGroup before its member Bottles when an operation needs both.
+
+#### Scenario: Statistics overlap deletion
+
+- **WHEN** BottleGroup statistics or repair overlaps deletion of a member Bottle
+- **THEN** the operations wait in the same lock order and each committed result reflects the active members at that point
+
+### Requirement: Bounded BottleGroup count repair
+
+The system SHALL compare BottleGroup totals with an independent active-member count and SHALL repair each wrong group in a separate transaction while catalog work continues.
+
+#### Scenario: Check correct totals
+
+- **WHEN** saved BottleGroup totals match their active member Bottles
+- **THEN** the check reports no differences and changes no data
+
+#### Scenario: Repair a wrong total
+
+- **WHEN** a saved BottleGroup total is wrong
+- **THEN** repair locks that group, checks it again, and saves its current active-member count
+
+#### Scenario: Repair overlaps a catalog change
+
+- **WHEN** repair waits for a Bottle deletion or merge on the same BottleGroup
+- **THEN** repair recounts after that catalog transaction commits and does not restore its older total
+
+#### Scenario: Repair an empty old group
+
+- **WHEN** an existing BottleGroup has no active member Bottles
+- **THEN** repair saves a total of zero without deleting the group or changing catalog links
+
+#### Scenario: Start repair more than once
+
+- **WHEN** an administrator starts Bottle-count repair while the BottleGroup repair is waiting or running
+- **THEN** the system keeps one active BottleGroup repair job

--- a/openspec/changes/repair-bottle-group-counts/tasks.md
+++ b/openspec/changes/repair-bottle-group-counts/tasks.md
@@ -1,0 +1,21 @@
+## 1. BottleGroup Count Owner
+
+- [x] 1.1 Add an independent BottleGroup Bottle-count check to the existing BottleGroup statistics module.
+- [x] 1.2 Add a one-group repair that locks and rechecks before saving only the Bottle total.
+- [x] 1.3 Cover correct, wrong, empty, missing, and repeated repairs with integration tests.
+
+## 2. Catalog Writes
+
+- [x] 2.1 Change Bottle deletion to lock the BottleGroup before its member Bottles and preserve its existing checks and results.
+- [x] 2.2 Verify creation, field updates, deletion, same-group merges, and cross-group merges keep totals correct.
+- [x] 2.3 Cover repair overlapping a normal group write without losing the committed total.
+
+## 3. Admin Repair
+
+- [x] 3.1 Add and register a strict, unique BottleGroup count repair job.
+- [x] 3.2 Start the job from the existing admin action and use general plain-language Maintenance copy.
+- [x] 3.3 Cover worker input, repeat-safe repair, administrator permission, and unique dispatch.
+
+## 4. Checks
+
+- [x] 4.1 Run focused tests, server and web typechecks, lint, formatting, and strict OpenSpec validation.


### PR DESCRIPTION
BottleGroup Bottle totals can now be checked independently and repaired one group at a time from the existing admin Bottle-count action. Each repair locks and rechecks the group before saving only its Bottle total, so an earlier scan cannot overwrite a newer catalog change. Empty legacy groups are corrected to zero without deleting groups or changing links or ratings.

Bottle deletion now locks the BottleGroup before its member Bottles, matching update, merge, statistics, and repair work. This removes the inverse lock order that could deadlock deletion against a queued group statistics run. Normal creation, updates, deletion, same-group merges, and cross-group merges remain synchronous and do not depend on the repair queue.

Integration coverage exercises wrong and empty totals, concurrent repair, lock overlap, all supported Bottle changes, strict worker input, permissions, and unique dispatch.

Refs #1042
