### PR TITLE
feat(scrapers): support first-review score fallbacks

### DIFF
--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -82,7 +82,7 @@ product database. Only a revision that passes its preview can become active. An
 admin can return to any older revision that passed. Pausing a source stops
 collection but keeps its revisions and run history.
 
-Rules formats 1 through 4 support same-origin HTML list and detail pages, an item
+Rules formats 1 through 5 support same-origin HTML list and detail pages, an item
 limit, an optional next-page link, CSS selectors, and fixed date, number, price,
 and volume conversions. Version 2 also supports bounded value cleanup, fixed
 values, joined labeled text, and list-card exclusion. An `item` selector scopes
@@ -93,7 +93,10 @@ canonical URL, read a publication date from a URL path with bounded `yyyy`, `yy`
 `MM`, `dd`, and `*` tokens, and map up to 25 finite text grades to numeric values.
 Version 4 also lets a heading start a review that continues through the elements
 after it. The review stops before the next selected heading or an optional end
-selector. When only one heading matches, its parent is the review body.
+selector. When only one heading matches without an end selector, its parent is
+the review body.
+Version 5 also lets the first review use a score stored outside its section when
+the section itself has no score.
 Rules do not support
 scripts, custom code, arbitrary request headers, browser automation, numbered
 page templates, infinite scrolling, or cross-origin discovery. Add a code-owned
@@ -160,12 +163,12 @@ pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 
 ```
 
 The input has the same `listUrl` and `rules` fields accepted by the revision
-API. Set `rulesVersion` to `4` when testing current operations. An omitted
+API. Set `rulesVersion` to `5` when testing current operations. An omitted
 version means version 1 so existing preview files keep their original behavior:
 
 ```json
 {
-  "rulesVersion": 4,
+  "rulesVersion": 5,
   "listUrl": "https://example.com/reviews",
   "rules": {}
 }

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -10,6 +10,10 @@ import {
   discoverWhiskeyReviewerArticles,
   parseWhiskeyReviewerArticle,
 } from "../adapters/whiskeyReviewer";
+import {
+  discoverWhiskyNotesArticles,
+  parseWhiskyNotesArticle,
+} from "../adapters/whiskyNotes";
 import { parseWhiskySagaArticle } from "../adapters/whiskySaga";
 import { parseWhiskyStudyArticle } from "../adapters/whiskyStudy";
 import {
@@ -292,6 +296,48 @@ const wordsOfWhiskyRules = {
   },
 } satisfies ScrapeRules;
 
+const whiskyNotesRules = {
+  kind: "review",
+  list: {
+    item: "#featured article, #posts article",
+    detailLink: { selector: "a.entry-permalink", attribute: "href" },
+    excludeWhen: {
+      selector:
+        ".category-armagnac, .category-bars, .category-cognac, .category-distillery-visits, .category-other-spirits, .category-rum, .category-whisky-news",
+    },
+    nextPage: { selector: 'link[rel="next"]', attribute: "href" },
+    maxItems: 20,
+  },
+  detail: {
+    title: { selector: "#main article.post .entry-title" },
+    publishedAt: {
+      selector: "#main article.post time.entry-date.published",
+      attribute: "datetime",
+    },
+    reviewItem: {
+      start:
+        '.entry-content > h2:contains("%"), .entry-content > h2:contains("Proof"), .entry-content > h2:contains("proof")',
+      endBefore: ".entry-content > .yarpp",
+    },
+    name: { selector: "h2" },
+    reviewerName: { selector: ".author.vcard" },
+    reviewText: { selector: "h2, h2 ~ p", all: true },
+    score: {
+      value: {
+        selector:
+          'p:contains("Score:") > span:last-child strong, p:contains("Score:") > strong:last-child',
+        removeSuffixes: ["/100"],
+        suffix: "/100",
+      },
+      firstReviewFallback: {
+        selector: ".entry-score",
+        suffix: "/100",
+      },
+      scale: 100,
+    },
+  },
+} satisfies ScrapeRules;
+
 function expectReviewFactsAndEvidenceToMatch(
   configured: ReturnType<typeof parseScrapeDetail>,
   legacy: NonNullable<ReturnType<typeof parseWhiskyStudyArticle>>,
@@ -453,6 +499,20 @@ describe("scrape source parser", () => {
     ).toEqual(legacyLinks);
   });
 
+  it("matches the current WhiskyNotes article links", async () => {
+    const pageUrl = new URL("https://www.whiskynotes.be/");
+    const html = await loadFixture("whiskynotes", "archive.html");
+    const legacyLinks = discoverWhiskyNotesArticles(html).map(
+      (url) => url.href,
+    );
+
+    expect(parseScrapeList(whiskyNotesRules, html, pageUrl)).toEqual({
+      links: legacyLinks,
+      nextPageUrl: "https://www.whiskynotes.be/page/2/",
+      issues: [],
+    });
+  });
+
   it("rejects a next page on another website", () => {
     const result = parseScrapeList(
       {
@@ -601,6 +661,46 @@ describe("scrape source parser", () => {
       );
     },
   );
+
+  it.each([
+    [
+      "single-review.html",
+      "https://www.whiskynotes.be/2026/world/kanekou-okinawa-whisky/",
+    ],
+    [
+      "multi-review.html",
+      "https://www.whiskynotes.be/2026/bowmore/bowmore-2005-ben-nevis-1996-whisky-agency/",
+    ],
+  ])("matches the current WhiskyNotes parser for %s", async (fixture, url) => {
+    const html = await loadFixture("whiskynotes", fixture);
+    const pageUrl = new URL(url);
+    const legacy = parseWhiskyNotesArticle(html, pageUrl);
+    const configured = parseScrapeDetail(whiskyNotesRules, html, pageUrl);
+
+    expect(configured.kind).toBe("review");
+    expect(configured.issues).toEqual([]);
+    if (configured.kind !== "review" || !configured.value) {
+      throw new Error("Expected configured review output.");
+    }
+    expect(configured.value.article).toMatchObject({
+      canonicalUrl: legacy.article.canonicalUrl,
+      title: legacy.article.title,
+      publishedAt: legacy.article.publishedAt,
+    });
+    expect(configured.value.article.externalReviews).toMatchObject(
+      legacy.article.externalReviews.map((review) => ({
+        name: review.name,
+        reviewerName: review.reviewerName,
+        nativeScore: review.nativeScore,
+      })),
+    );
+    expect(Object.values(configured.value.externalReviewTexts)).toEqual(
+      Object.values(legacy.externalReviewTexts),
+    );
+    expect(Object.values(configured.value.externalReviewBodies)).toEqual(
+      Object.values(legacy.externalReviewBodies),
+    );
+  });
 
   it("rejects conflicting URL dates and unmapped scores", async () => {
     const html = (await loadFixture("whiskeyreviewer", "review.html"))

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -319,10 +319,24 @@ function selectReviewItems(
   const starts = $(section.data.start).toArray();
   return starts.map((start) => {
     if (starts.length === 1) {
-      const body = $(start).parent();
+      const parent = $(start).parent();
+      if (!section.data.endBefore) {
+        return {
+          body: parent,
+          item: load(parent.html() ?? ""),
+        };
+      }
+      const body = $($(start).prevAll().toArray().reverse())
+        .add(start)
+        .add($(start).nextUntil(section.data.endBefore));
       return {
         body,
-        item: load(body.html() ?? ""),
+        item: load(
+          body
+            .toArray()
+            .map((element) => $.html(element))
+            .join(""),
+        ),
       };
     }
 
@@ -459,8 +473,18 @@ function parseReviewDetail(
       const reviewerName = reviewerSelector
         ? (readValue(item, reviewerSelector) ?? pageReviewerName)
         : null;
-      const scoreText = rules.detail.score
-        ? readReviewValue(item, rules.detail.score.value)
+      const scoreRule = rules.detail.score;
+      const firstReviewFallback =
+        scoreRule &&
+        "firstReviewFallback" in scoreRule &&
+        scoreRule.firstReviewFallback;
+      const scoreText = scoreRule
+        ? (readValue(item, scoreRule.value) ??
+          (index === 0 && firstReviewFallback
+            ? readValue($, firstReviewFallback)
+            : reviewItems.length === 1
+              ? readValue($, scoreRule.value)
+              : null))
         : null;
       const scoreMap =
         rules.detail.score && "map" in rules.detail.score

--- a/apps/server/src/scraper/configured/rules.test.ts
+++ b/apps/server/src/scraper/configured/rules.test.ts
@@ -8,6 +8,7 @@ import {
   ScrapeRulesV1Schema,
   ScrapeRulesV2Schema,
   ScrapeRulesV3Schema,
+  ScrapeRulesV4Schema,
   ScrapeValueSchema,
 } from "./rules";
 
@@ -39,8 +40,8 @@ test("bounds list and detail pages", () => {
 
 test("rejects rules for an unsupported stored format", () => {
   const rules = ScrapeRulesSchema.parse(reviewConfig(25));
-  expect(() => parseScrapeRules(5, rules)).toThrow(
-    "Unsupported scrape rules version: 5.",
+  expect(() => parseScrapeRules(6, rules)).toThrow(
+    "Unsupported scrape rules version: 6.",
   );
 });
 
@@ -53,7 +54,7 @@ test("loads old rules only through the version 1 contract", () => {
       list: { ...rules.list, item: ".card" },
     }),
   ).toThrow();
-  expect(SCRAPE_RULES_VERSION).toBe(4);
+  expect(SCRAPE_RULES_VERSION).toBe(5);
 });
 
 test("loads version 2 rules only through their original contract", () => {
@@ -73,8 +74,8 @@ test("loads version 2 rules only through their original contract", () => {
   ).toThrow();
 });
 
-test("accepts bounded canonical URLs, URL dates, and score maps", () => {
-  const rules = ScrapeRulesSchema.parse({
+test("loads version 4 rules only through their original contract", () => {
+  const rules = ScrapeRulesV4Schema.parse({
     ...reviewConfig(25),
     detail: {
       ...reviewConfig(25).detail,
@@ -96,6 +97,23 @@ test("accepts bounded canonical URLs, URL dates, and score maps", () => {
   });
 
   expect(parseScrapeRules(4, rules)).toEqual(rules);
+  expect(() =>
+    parseScrapeRules(4, {
+      ...rules,
+      detail: {
+        ...rules.detail,
+        score: {
+          value: { selector: ".rating", removePrefixes: ["Rating:"] },
+          scale: 100,
+          map: [
+            { text: "A", value: 95 },
+            { text: "B+", value: 87 },
+          ],
+          firstReviewFallback: { selector: ".article-rating" },
+        },
+      },
+    }),
+  ).toThrow();
 });
 
 test("loads version 3 rules only through their original contract", () => {
@@ -125,7 +143,7 @@ test("accepts review sections with an end selector", () => {
     },
   });
 
-  expect(parseScrapeRules(4, rules)).toMatchObject({
+  expect(parseScrapeRules(5, rules)).toMatchObject({
     kind: "review",
     detail: {
       reviewItem: {
@@ -134,6 +152,23 @@ test("accepts review sections with an end selector", () => {
       },
     },
   });
+});
+
+test("accepts a separate first-review score", () => {
+  const config = reviewConfig(25);
+  const rules = ScrapeRulesSchema.parse({
+    ...config,
+    detail: {
+      ...config.detail,
+      score: {
+        value: { selector: ".review-score" },
+        firstReviewFallback: { selector: ".article-score" },
+        scale: 100,
+      },
+    },
+  });
+
+  expect(parseScrapeRules(5, rules)).toEqual(rules);
 });
 
 test.each([

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -5,7 +5,8 @@ import { z } from "zod";
 export const SCRAPE_RULES_VERSION_1 = 1;
 export const SCRAPE_RULES_VERSION_2 = 2;
 export const SCRAPE_RULES_VERSION_3 = 3;
-export const SCRAPE_RULES_VERSION = 4;
+export const SCRAPE_RULES_VERSION_4 = 4;
+export const SCRAPE_RULES_VERSION = 5;
 // TODO(scraper-platform): Add event after scraped-event match and update rules are defined.
 export const SCRAPE_SOURCE_KIND_LIST = ["review", "price"] as const;
 export type ScrapeSourceKind = (typeof SCRAPE_SOURCE_KIND_LIST)[number];
@@ -218,6 +219,10 @@ const ScrapeScoreSchema = z
     }
   });
 
+const ScrapeScoreWithFirstReviewSchema = ScrapeScoreSchema.safeExtend({
+  firstReviewFallback: ScrapeValueSchema.optional(),
+});
+
 export const ScrapeReviewSectionSchema = z
   .object({
     start: ScrapeSelectorSchema,
@@ -225,7 +230,10 @@ export const ScrapeReviewSectionSchema = z
   })
   .strict();
 
-function currentReviewRulesSchema<T extends z.ZodType>(reviewItemSchema: T) {
+function currentReviewRulesSchema<T extends z.ZodType, U extends z.ZodType>(
+  reviewItemSchema: T,
+  scoreSchema: U,
+) {
   return z
     .object({
       kind: z.literal("review"),
@@ -241,7 +249,7 @@ function currentReviewRulesSchema<T extends z.ZodType>(reviewItemSchema: T) {
           name: ScrapeValueSchema,
           reviewerName: ScrapeValueSchema.optional(),
           reviewText: ScrapeValueSchema.optional(),
-          score: ScrapeScoreSchema.optional(),
+          score: scoreSchema.optional(),
         })
         .strict(),
     })
@@ -283,13 +291,22 @@ export const ScrapeRulesV2Schema = z.discriminatedUnion("kind", [
 ]);
 
 export const ScrapeRulesV3Schema = z.discriminatedUnion("kind", [
-  currentReviewRulesSchema(ScrapeSelectorSchema),
+  currentReviewRulesSchema(ScrapeSelectorSchema, ScrapeScoreSchema),
+  priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
+]);
+
+export const ScrapeRulesV4Schema = z.discriminatedUnion("kind", [
+  currentReviewRulesSchema(
+    z.union([ScrapeSelectorSchema, ScrapeReviewSectionSchema]),
+    ScrapeScoreSchema,
+  ),
   priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
 ]);
 
 export const ScrapeRulesSchema = z.discriminatedUnion("kind", [
   currentReviewRulesSchema(
     z.union([ScrapeSelectorSchema, ScrapeReviewSectionSchema]),
+    ScrapeScoreWithFirstReviewSchema,
   ),
   priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
 ]);
@@ -298,6 +315,7 @@ export const StoredScrapeRulesSchema = z.union([
   ScrapeRulesV1Schema,
   ScrapeRulesV2Schema,
   ScrapeRulesV3Schema,
+  ScrapeRulesV4Schema,
   ScrapeRulesSchema,
 ]);
 
@@ -321,6 +339,9 @@ export function parseScrapeRules(
   }
   if (rulesVersion === SCRAPE_RULES_VERSION_3) {
     return ScrapeRulesV3Schema.parse(rules);
+  }
+  if (rulesVersion === SCRAPE_RULES_VERSION_4) {
+    return ScrapeRulesV4Schema.parse(rules);
   }
   if (rulesVersion === SCRAPE_RULES_VERSION) {
     return ScrapeRulesSchema.parse(rules);

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -185,7 +185,7 @@ test("database constraints keep source and revision identity valid", async () =>
     createdById: user.id,
   });
   expect(first.revision).toBe(1);
-  expect(first.rulesVersion).toBe(4);
+  expect(first.rulesVersion).toBe(5);
 
   await expect(
     db.insert(scrapeSources).values({

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -259,6 +259,7 @@ test("accepts canonical cleanup, URL dates, and finite score maps", async () => 
           value: suggestedValue(".rating", null, {
             removePrefixes: ["Rating:"],
           }),
+          firstReviewFallback: suggestedValue(".article-rating"),
           scale: 100,
           map: [
             { text: "A", value: 95 },
@@ -299,6 +300,7 @@ test("accepts canonical cleanup, URL dates, and finite score maps", async () => 
       publishedAt: { urlDateFormat: "/yyyy/MM/*-MMddyy" },
       score: {
         scale: 100,
+        firstReviewFallback: { selector: ".article-rating" },
         map: [
           { text: "A", value: 95 },
           { text: "B+", value: 87 },

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -27,7 +27,7 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v12";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v13";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_SUGGESTION_DETAIL_PAGES = 3;
 const MAX_RULE_CHECKS = 3;
@@ -191,6 +191,7 @@ const SuggestedReviewRulesSchema = z
         score: z
           .object({
             value: SuggestedValueSelectorSchema,
+            firstReviewFallback: SuggestedValueSelectorSchema.nullable(),
             scale: z.number().positive(),
             map: z.array(SuggestedScoreMapEntrySchema).max(25).nullable(),
           })
@@ -290,6 +291,7 @@ const RULE_INSTRUCTIONS = [
   "Set canonicalUrl only when the article's stored canonical URL needs to come from page markup or bounded cleanup such as removing a trailing slash. Otherwise set it to null.",
   "For reviews, reviewItem selector must identify either each complete review container or each heading that starts a review section. Its text is retained internally for later parsing. Exclude navigation, comments, related articles, and other bottles' reviews.",
   "Set reviewItem startsSection to true only when each selected heading starts a review and the elements after it contain the rest of that review. Parsing stops before the next selected heading. When only one heading matches, its parent is the review. Set sectionEndsBefore only when another element must end the last section; otherwise set it to null. Keep selectors for name, reviewText, writer, and score inside each review section.",
+  "Set score firstReviewFallback only when the page keeps the first review's score outside its review section. It is used only when that section has no score. Otherwise set it to null.",
   "Use reviewText for a narrower tasting-notes container when available; otherwise select the review body. This text is used for flavor matching and short clips.",
   "Include an optional field when the supplied pages clearly and consistently provide it.",
   "Pagination must add new detail-page links when the website has a next page.",
@@ -417,6 +419,11 @@ function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
       scale: input.detail.score.scale,
       value: toScrapeValue(input.detail.score.value),
     };
+    if (input.detail.score.firstReviewFallback !== null) {
+      detail.score.firstReviewFallback = toScrapeValue(
+        input.detail.score.firstReviewFallback,
+      );
+    }
     if (input.detail.score.map?.length) {
       detail.score.map = input.detail.score.map;
     }


### PR DESCRIPTION
Configured review sources can now bound a single heading-led review with an end selector while retaining the article introduction. They can also use an article-level score only when the first review section has no score; later reviews still require their own score. This supports WhiskyNotes without applying the article score to every review.

The stored rules format advances to version 5 while versions 1–4 retain their original contracts. The setup agent exposes the fallback explicitly, and regression coverage compares configured parsing with the existing WhiskyNotes adapter for its archive, single-review articles, and multi-review articles.
