### PR TITLE
fix(catalog): keep BottleSeries release counts correct

### DIFF
--- a/apps/server/src/lib/bottleHelpers.ts
+++ b/apps/server/src/lib/bottleHelpers.ts
@@ -67,7 +67,6 @@ export async function processSeries({
       description: seriesDraft.description,
       fullName,
       brandId: brand.id,
-      numReleases: 1,
       createdByActorId: actorId,
     })
     .returning();

--- a/apps/server/src/lib/bottleSeriesReleaseCounts.test.ts
+++ b/apps/server/src/lib/bottleSeriesReleaseCounts.test.ts
@@ -1,0 +1,232 @@
+import { db } from "@peated/server/db";
+import { getPostgresConnectionConfig } from "@peated/server/db/connection";
+import {
+  bottleSeries,
+  bottleTombstones,
+  bottles,
+} from "@peated/server/db/schema";
+import { eq } from "drizzle-orm";
+import pg from "pg";
+import {
+  checkBottleSeriesReleaseCounts,
+  getBottleSeriesMemberships,
+  repairBottleSeriesReleaseCount,
+  updateBottleSeriesReleaseCounts,
+} from "./bottleSeriesReleaseCounts";
+
+const { Client } = pg;
+type NodePgClient = InstanceType<typeof Client>;
+
+async function waitForSessionBlockedBy(
+  observer: NodePgClient,
+  blockerPid: number,
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const result = await observer.query<{ pid: number }>(
+      `SELECT pid
+       FROM pg_stat_activity
+       WHERE $1 = ANY(pg_blocking_pids(pid))
+       LIMIT 1`,
+      [blockerPid],
+    );
+    if (result.rows.length) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for the BottleSeries repair lock.");
+}
+
+describe("BottleSeries release counts", () => {
+  test("moves only the changed Bottle between series", async ({ fixtures }) => {
+    const oldSeries = await fixtures.BottleSeries({ numReleases: 1 });
+    const newSeries = await fixtures.BottleSeries({ numReleases: 0 });
+    const bottle = await fixtures.Bottle({ seriesId: oldSeries.id });
+
+    await db.transaction(async (tx) => {
+      const before = await getBottleSeriesMemberships(tx, [bottle.id]);
+      await tx
+        .update(bottles)
+        .set({ seriesId: newSeries.id })
+        .where(eq(bottles.id, bottle.id));
+      const after = await getBottleSeriesMemberships(tx, [bottle.id]);
+      await updateBottleSeriesReleaseCounts(tx, before, after);
+    });
+
+    await expect(
+      db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, oldSeries.id),
+      }),
+    ).resolves.toMatchObject({ numReleases: 0 });
+    await expect(
+      db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, newSeries.id),
+      }),
+    ).resolves.toMatchObject({ numReleases: 1 });
+  });
+
+  test("repairs an old undercount when removing a Bottle", async ({
+    fixtures,
+  }) => {
+    const series = await fixtures.BottleSeries({ numReleases: 0 });
+    const removedBottle = await fixtures.Bottle({ seriesId: series.id });
+    await fixtures.Bottle({ seriesId: series.id });
+
+    await db.transaction(async (tx) => {
+      const before = await getBottleSeriesMemberships(tx, [removedBottle.id]);
+      await tx.insert(bottleTombstones).values({
+        bottleId: removedBottle.id,
+      });
+      const after = await getBottleSeriesMemberships(tx, [removedBottle.id]);
+      await updateBottleSeriesReleaseCounts(tx, before, after);
+    });
+
+    await expect(
+      db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, series.id),
+      }),
+    ).resolves.toMatchObject({ numReleases: 1 });
+    await expect(checkBottleSeriesReleaseCounts([series.id])).resolves.toEqual(
+      [],
+    );
+  });
+
+  test("rolls back earlier changes when a BottleSeries is missing", async ({
+    fixtures,
+  }) => {
+    const series = await fixtures.BottleSeries({ numReleases: 0 });
+    const missingSeriesId = 2_147_483_647;
+
+    await expect(
+      db.transaction((tx) =>
+        updateBottleSeriesReleaseCounts(
+          tx,
+          [],
+          [
+            { bottleId: 10, seriesId: series.id },
+            { bottleId: 11, seriesId: missingSeriesId },
+          ],
+        ),
+      ),
+    ).rejects.toThrow(
+      `Cannot update release count: BottleSeries ${missingSeriesId} is missing.`,
+    );
+    await expect(
+      db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, series.id),
+      }),
+    ).resolves.toMatchObject({ numReleases: 0 });
+  });
+
+  test("counts concurrent Bottles without losing an update", async ({
+    fixtures,
+  }) => {
+    const series = await fixtures.BottleSeries({ numReleases: 0 });
+    const first = await fixtures.Bottle({ seriesId: series.id });
+    const second = await fixtures.Bottle({ seriesId: series.id });
+
+    await Promise.all(
+      [first.id, second.id].map((bottleId) =>
+        db.transaction(async (tx) => {
+          const after = await getBottleSeriesMemberships(tx, [bottleId]);
+          await updateBottleSeriesReleaseCounts(tx, [], after);
+        }),
+      ),
+    );
+
+    await expect(
+      db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, series.id),
+      }),
+    ).resolves.toMatchObject({ numReleases: 2 });
+  });
+
+  test("finds and repairs wrong saved counts", async ({ fixtures }) => {
+    const wrong = await fixtures.BottleSeries({ numReleases: 8 });
+    const correctEmpty = await fixtures.BottleSeries({ numReleases: 0 });
+    await fixtures.Bottle({ seriesId: wrong.id });
+    await db
+      .update(bottleSeries)
+      .set({ numReleases: 8 })
+      .where(eq(bottleSeries.id, wrong.id));
+
+    await expect(
+      checkBottleSeriesReleaseCounts([wrong.id, correctEmpty.id]),
+    ).resolves.toEqual([{ seriesId: wrong.id, savedCount: 8, actualCount: 1 }]);
+    await expect(checkBottleSeriesReleaseCounts([])).resolves.toEqual([]);
+
+    await expect(repairBottleSeriesReleaseCount(wrong.id)).resolves.toEqual({
+      seriesId: wrong.id,
+      savedCount: 8,
+      actualCount: 1,
+    });
+    await expect(
+      checkBottleSeriesReleaseCounts([wrong.id, correctEmpty.id]),
+    ).resolves.toEqual([]);
+    await expect(
+      repairBottleSeriesReleaseCount(2_147_483_647),
+    ).resolves.toBeNull();
+  });
+
+  test("recounts after an earlier Bottle change commits", async ({
+    fixtures,
+  }) => {
+    const target = await fixtures.BottleSeries({ numReleases: 0 });
+    const source = await fixtures.BottleSeries({ numReleases: 1 });
+    await fixtures.Bottle({ seriesId: target.id });
+    const movingBottle = await fixtures.Bottle({ seriesId: source.id });
+
+    const writer = new Client(getPostgresConnectionConfig());
+    const observer = new Client(getPostgresConnectionConfig());
+    let writerCommitted = false;
+    let repair: ReturnType<typeof repairBottleSeriesReleaseCount> | null = null;
+
+    await writer.connect();
+    await observer.connect();
+    try {
+      await writer.query("BEGIN");
+      const writerPid = (
+        await writer.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")
+      ).rows[0]?.pid;
+      if (!writerPid) throw new Error("Unable to load Bottle writer pid.");
+
+      await writer.query(
+        "SELECT id FROM bottle_series WHERE id = $1 FOR UPDATE",
+        [target.id],
+      );
+      await writer.query("UPDATE bottle SET series_id = $2 WHERE id = $1", [
+        movingBottle.id,
+        target.id,
+      ]);
+      await writer.query(
+        "UPDATE bottle_series SET num_releases = num_releases + 1 WHERE id = $1",
+        [target.id],
+      );
+
+      repair = repairBottleSeriesReleaseCount(target.id);
+      void repair.catch(() => undefined);
+      await waitForSessionBlockedBy(observer, writerPid);
+
+      await writer.query("COMMIT");
+      writerCommitted = true;
+
+      await expect(repair).resolves.toEqual({
+        seriesId: target.id,
+        savedCount: 1,
+        actualCount: 2,
+      });
+    } finally {
+      if (!writerCommitted) {
+        await writer.query("ROLLBACK").catch(() => undefined);
+      }
+      if (repair) await repair.catch(() => undefined);
+      await writer.end();
+      await observer.end();
+    }
+
+    await expect(
+      db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, target.id),
+      }),
+    ).resolves.toMatchObject({ numReleases: 2 });
+  });
+});

--- a/apps/server/src/lib/bottleSeriesReleaseCounts.ts
+++ b/apps/server/src/lib/bottleSeriesReleaseCounts.ts
@@ -1,0 +1,188 @@
+import { db, type AnyDatabase, type AnyTransaction } from "@peated/server/db";
+import {
+  bottleSeries,
+  bottleTombstones,
+  bottles,
+} from "@peated/server/db/schema";
+import { and, asc, eq, gte, inArray, isNotNull, sql } from "drizzle-orm";
+
+export type BottleSeriesMembership = {
+  bottleId: number;
+  seriesId: number;
+};
+
+export type WrongBottleSeriesReleaseCount = {
+  seriesId: number;
+  savedCount: number;
+  actualCount: number;
+};
+
+function uniqueSorted(values: readonly number[]): number[] {
+  return Array.from(new Set(values)).sort((left, right) => left - right);
+}
+
+/** Returns active Bottles that belong to a BottleSeries. */
+export async function getBottleSeriesMemberships(
+  tx: AnyTransaction,
+  bottleIds: readonly number[],
+): Promise<BottleSeriesMembership[]> {
+  const ids = uniqueSorted(bottleIds);
+  if (!ids.length) return [];
+
+  const rows = await tx
+    .select({ bottleId: bottles.id, seriesId: bottles.seriesId })
+    .from(bottles)
+    .where(
+      and(
+        inArray(bottles.id, ids),
+        isNotNull(bottles.seriesId),
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${bottleTombstones}
+          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
+        )`,
+      ),
+    )
+    .orderBy(asc(bottles.id));
+
+  return rows.flatMap(({ bottleId, seriesId }) =>
+    seriesId === null ? [] : [{ bottleId, seriesId }],
+  );
+}
+
+function addMembershipChanges(
+  changes: Map<number, number>,
+  memberships: readonly BottleSeriesMembership[],
+  change: number,
+) {
+  for (const membership of memberships) {
+    changes.set(
+      membership.seriesId,
+      (changes.get(membership.seriesId) ?? 0) + change,
+    );
+  }
+}
+
+type CountQueryRow = {
+  seriesId: number | string;
+  savedCount: number | string;
+  actualCount: number | string;
+};
+
+async function findWrongBottleSeriesReleaseCounts(
+  database: AnyDatabase,
+  seriesIds?: readonly number[],
+): Promise<WrongBottleSeriesReleaseCount[]> {
+  const ids = seriesIds === undefined ? undefined : uniqueSorted(seriesIds);
+  if (ids?.length === 0) return [];
+  const seriesFilter = ids ? inArray(bottleSeries.id, ids) : sql`TRUE`;
+  const bottleFilter = ids ? inArray(bottles.seriesId, ids) : sql`TRUE`;
+
+  const result = await database.execute<CountQueryRow>(sql`
+    WITH actual_counts AS (
+      SELECT ${bottles.seriesId} AS series_id, COUNT(*) AS total
+      FROM ${bottles}
+      WHERE ${bottles.seriesId} IS NOT NULL
+        AND ${bottleFilter}
+        AND NOT EXISTS (
+          SELECT 1 FROM ${bottleTombstones}
+          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
+        )
+      GROUP BY ${bottles.seriesId}
+    )
+    SELECT
+      ${bottleSeries.id} AS "seriesId",
+      ${bottleSeries.numReleases} AS "savedCount",
+      COALESCE(actual_counts.total, 0) AS "actualCount"
+    FROM ${bottleSeries}
+    LEFT JOIN actual_counts ON actual_counts.series_id = ${bottleSeries.id}
+    WHERE ${seriesFilter}
+      AND ${bottleSeries.numReleases} <> COALESCE(actual_counts.total, 0)
+    ORDER BY ${bottleSeries.id}
+  `);
+
+  return result.rows.map((row) => ({
+    seriesId: Number(row.seriesId),
+    savedCount: Number(row.savedCount),
+    actualCount: Number(row.actualCount),
+  }));
+}
+
+async function repairExistingBottleSeriesReleaseCount(
+  tx: AnyTransaction,
+  seriesId: number,
+): Promise<WrongBottleSeriesReleaseCount | null> {
+  const [difference] = await findWrongBottleSeriesReleaseCounts(tx, [seriesId]);
+  if (!difference) return null;
+
+  await tx
+    .update(bottleSeries)
+    .set({ numReleases: difference.actualCount })
+    .where(eq(bottleSeries.id, seriesId));
+  return difference;
+}
+
+/** Saves BottleSeries membership changes in the caller's Bottle transaction. */
+export async function updateBottleSeriesReleaseCounts(
+  tx: AnyTransaction,
+  membershipsBefore: readonly BottleSeriesMembership[],
+  membershipsAfter: readonly BottleSeriesMembership[],
+): Promise<void> {
+  const changes = new Map<number, number>();
+  addMembershipChanges(changes, membershipsBefore, -1);
+  addMembershipChanges(changes, membershipsAfter, 1);
+
+  for (const [seriesId, change] of Array.from(changes)
+    .filter(([, change]) => change !== 0)
+    .sort(([left], [right]) => left - right)) {
+    // Bottle writes own this total. Repair an old undercount before it can
+    // make a valid Bottle deletion or merge fail.
+    const [updatedSeries] = await tx
+      .update(bottleSeries)
+      .set({ numReleases: sql`${bottleSeries.numReleases} + ${change}` })
+      .where(
+        and(
+          eq(bottleSeries.id, seriesId),
+          change < 0 ? gte(bottleSeries.numReleases, -change) : undefined,
+        ),
+      )
+      .returning({ id: bottleSeries.id });
+    if (updatedSeries) continue;
+
+    const [series] = await tx
+      .select({ id: bottleSeries.id })
+      .from(bottleSeries)
+      .where(eq(bottleSeries.id, seriesId))
+      .limit(1)
+      .for("update");
+    if (!series) {
+      throw new Error(
+        `Cannot update release count: BottleSeries ${seriesId} is missing.`,
+      );
+    }
+
+    await repairExistingBottleSeriesReleaseCount(tx, seriesId);
+  }
+}
+
+/** Checks saved release totals against active Bottle membership. */
+export async function checkBottleSeriesReleaseCounts(
+  seriesIds?: readonly number[],
+): Promise<WrongBottleSeriesReleaseCount[]> {
+  return findWrongBottleSeriesReleaseCounts(db, seriesIds);
+}
+
+/** Repairs one BottleSeries after taking the row lock used by Bottle writes. */
+export async function repairBottleSeriesReleaseCount(
+  seriesId: number,
+): Promise<WrongBottleSeriesReleaseCount | null> {
+  return db.transaction(async (tx) => {
+    const [series] = await tx
+      .select({ id: bottleSeries.id })
+      .from(bottleSeries)
+      .where(eq(bottleSeries.id, seriesId))
+      .for("update");
+    if (!series) return null;
+
+    return repairExistingBottleSeriesReleaseCount(tx, seriesId);
+  });
+}

--- a/apps/server/src/lib/createBottle.ts
+++ b/apps/server/src/lib/createBottle.ts
@@ -23,12 +23,15 @@ import {
   bottleGroupDistillers,
   bottleGroups,
   bottles,
-  bottleSeries,
   bottlesToDistillers,
   changes,
 } from "@peated/server/db/schema";
 import { getPeatedSystemActor, getUserActor } from "@peated/server/lib/actors";
 import { processSeries } from "@peated/server/lib/bottleHelpers";
+import {
+  getBottleSeriesMemberships,
+  updateBottleSeriesReleaseCounts,
+} from "@peated/server/lib/bottleSeriesReleaseCounts";
 import {
   getCatalogVerificationCreationMetadata,
   queueBottleCreationVerification,
@@ -301,15 +304,6 @@ async function prepareBottleCreateInTransaction(
       createdByActorId: actorId,
       tx,
     });
-
-    if (!seriesCreated && seriesId) {
-      await tx
-        .update(bottleSeries)
-        .set({
-          numReleases: sql`(SELECT COUNT(*) FROM ${bottles} WHERE ${bottles.seriesId} = ${seriesId}) + 1`,
-        })
-        .where(eq(bottleSeries.id, seriesId));
-    }
   }
 
   const distillerIds: number[] = [];
@@ -624,6 +618,12 @@ export async function createBottleInTransaction(
   const bottleResult = await insertPreparedBottleInTransaction(tx, prepared, {
     groupId: group.id,
   });
+  if (bottleResult.bottle.seriesId !== null) {
+    const seriesMemberships = await getBottleSeriesMemberships(tx, [
+      bottleResult.bottle.id,
+    ]);
+    await updateBottleSeriesReleaseCounts(tx, [], seriesMemberships);
+  }
 
   const [persistedGroup] = await tx
     .update(bottleGroups)

--- a/apps/server/src/lib/mergeBottles.test.ts
+++ b/apps/server/src/lib/mergeBottles.test.ts
@@ -8,6 +8,7 @@ import {
   bottleObservations,
   bottleReferences,
   bottles,
+  bottleSeries,
   bottleTags,
   bottleTombstones,
   changes,
@@ -440,11 +441,15 @@ describe("exact Bottle merges", () => {
     });
   });
 
-  test("merges Bottles when their shared Entity count is too low", async ({
+  test("merges Bottles when their shared counts are too low", async ({
     fixtures,
   }) => {
     const mod = await fixtures.User({ mod: true });
     const brand = await fixtures.Entity({ name: "Low Count Merge Brand" });
+    const series = await fixtures.BottleSeries({
+      brandId: brand.id,
+      numReleases: 0,
+    });
     const country = await fixtures.Country({ totalBottles: 0 });
     const region = await fixtures.Region({
       countryId: country.id,
@@ -457,11 +462,13 @@ describe("exact Bottle merges", () => {
     const source = await fixtures.Bottle({
       name: "Low Count Merge Source",
       brandId: brand.id,
+      seriesId: series.id,
       distillerIds: [distillery.id],
     });
     const destination = await fixtures.Bottle({
       name: "Low Count Merge Destination",
       brandId: brand.id,
+      seriesId: series.id,
       distillerIds: [distillery.id],
     });
     await db
@@ -495,6 +502,57 @@ describe("exact Bottle merges", () => {
     await expect(
       db.query.regions.findFirst({ where: eq(regions.id, region.id) }),
     ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, series.id),
+      }),
+    ).resolves.toMatchObject({ numReleases: 1 });
+  });
+
+  test("updates only the retired Bottle's series in a cross-series merge", async ({
+    fixtures,
+  }) => {
+    const mod = await fixtures.User({ mod: true });
+    const brand = await fixtures.Entity({ name: "Cross Series Merge Brand" });
+    const sourceSeries = await fixtures.BottleSeries({
+      brandId: brand.id,
+      name: "Source Range",
+      numReleases: 1,
+    });
+    const destinationSeries = await fixtures.BottleSeries({
+      brandId: brand.id,
+      name: "Destination Range",
+      numReleases: 1,
+    });
+    const source = await fixtures.Bottle({
+      name: "Cross Series Source",
+      brandId: brand.id,
+      seriesId: sourceSeries.id,
+    });
+    const destination = await fixtures.Bottle({
+      name: "Cross Series Destination",
+      brandId: brand.id,
+      seriesId: destinationSeries.id,
+    });
+
+    await mergeBottles({
+      sourceBottleId: source.id,
+      destinationBottleId: destination.id,
+      context: contextFor(mod),
+    });
+
+    const seriesRows = await db
+      .select({ id: bottleSeries.id, numReleases: bottleSeries.numReleases })
+      .from(bottleSeries)
+      .where(inArray(bottleSeries.id, [sourceSeries.id, destinationSeries.id]));
+    expect(
+      Object.fromEntries(
+        seriesRows.map(({ id, numReleases }) => [id, numReleases]),
+      ),
+    ).toEqual({
+      [sourceSeries.id]: 0,
+      [destinationSeries.id]: 1,
+    });
   });
 
   test("keeps the most recently updated member review when both Bottles were reviewed", async ({

--- a/apps/server/src/lib/mergeBottles.ts
+++ b/apps/server/src/lib/mergeBottles.ts
@@ -12,7 +12,6 @@ import {
   bottleObservations,
   bottleReferences,
   bottles,
-  bottleSeries,
   bottlesToDistillers,
   bottleTags,
   bottleTombstones,
@@ -30,6 +29,10 @@ import {
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
 import { moveBottleAliasesForMergeInTransaction } from "@peated/server/lib/bottleAliases";
+import {
+  getBottleSeriesMemberships,
+  updateBottleSeriesReleaseCounts,
+} from "@peated/server/lib/bottleSeriesReleaseCounts";
 import {
   getBottleEntityLinks,
   updateEntityBottleCounts,
@@ -776,6 +779,10 @@ export async function mergeBottlesInTransaction(
     tx,
     requestedBottleIds,
   );
+  const seriesMembershipsBefore = await getBottleSeriesMemberships(
+    tx,
+    requestedBottleIds,
+  );
   const crossGroup = sourceGroupId !== destinationGroupId;
   const survivingSourceMembers = sourceMembers.filter(
     ({ id }) => id !== sourceBottleId,
@@ -958,6 +965,15 @@ export async function mergeBottlesInTransaction(
     requestedBottleIds,
   );
   await updateLocationBottleCounts(tx, locationsBefore, locationsAfter);
+  const seriesMembershipsAfter = await getBottleSeriesMemberships(
+    tx,
+    requestedBottleIds,
+  );
+  await updateBottleSeriesReleaseCounts(
+    tx,
+    seriesMembershipsBefore,
+    seriesMembershipsAfter,
+  );
 
   if (crossGroup && sourceSingleton) {
     await tx
@@ -980,15 +996,6 @@ export async function mergeBottlesInTransaction(
     source.seriesId,
     destination.seriesId,
   ]);
-  for (const seriesId of affectedSeriesIds) {
-    await tx
-      .update(bottleSeries)
-      .set({
-        numReleases: sql`(SELECT COUNT(*) FROM ${bottles} WHERE ${bottles.seriesId} = ${seriesId})`,
-      })
-      .where(eq(bottleSeries.id, seriesId));
-  }
-
   const auditData = {
     updateScope: "exact_merge",
     sourceBottleId,

--- a/apps/server/src/lib/updateBottle.test.ts
+++ b/apps/server/src/lib/updateBottle.test.ts
@@ -795,6 +795,10 @@ describe("Bottle updates", () => {
       },
       exacts: [{ edition: "One" }, { edition: "Two" }],
     });
+    await db
+      .update(bottleSeries)
+      .set({ numReleases: members.length })
+      .where(eq(bottleSeries.id, oldSeries.id));
 
     const result = await updateBottle({
       bottleId: first.bottle.id,
@@ -2134,6 +2138,17 @@ describe("Bottle updates", () => {
         { seriesId },
       );
     }
+
+    await updateBottle({
+      bottleId: members[0].bottle.id,
+      input: { series: null },
+      context: contextFor(mod),
+    });
+    await expect(
+      db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, newSeries.id),
+      }),
+    ).resolves.toMatchObject({ numReleases: 0 });
   });
 
   test("dispatches unique payloads after commit and queue failure does not undo the save", async ({

--- a/apps/server/src/lib/updateBottle.ts
+++ b/apps/server/src/lib/updateBottle.ts
@@ -47,6 +47,10 @@ import {
   type BottlePatch,
   type SystemBottlePatch,
 } from "@peated/server/lib/bottleSchemas";
+import {
+  getBottleSeriesMemberships,
+  updateBottleSeriesReleaseCounts,
+} from "@peated/server/lib/bottleSeriesReleaseCounts";
 import { queueEntityCreationVerification } from "@peated/server/lib/catalogVerification";
 import { coerceToUpsert, upsertEntity } from "@peated/server/lib/db";
 import {
@@ -1385,6 +1389,15 @@ export async function updateBottleInTransaction(
     ? members
     : members.filter(({ id }) => id === bottleId);
   const affectedIds = affectedMembers.map(({ id }) => id).sort((a, b) => a - b);
+  const memberSeriesChanged =
+    sharedChanged &&
+    affectedMembers.some(
+      (member) =>
+        member.seriesId !== desiredByBottleId.get(member.id)!.seriesId,
+    );
+  const seriesMembershipsBefore = memberSeriesChanged
+    ? await getBottleSeriesMemberships(tx, affectedIds)
+    : [];
   const bottleEntityLinksChanged = affectedMembers.some((member) => {
     const desired = desiredByBottleId.get(member.id)!;
     return (
@@ -1623,12 +1636,17 @@ export async function updateBottleInTransaction(
       );
   }
 
-  const memberSeriesChanged =
-    sharedChanged &&
-    affectedMembers.some(
-      (member) =>
-        member.seriesId !== desiredByBottleId.get(member.id)!.seriesId,
+  if (memberSeriesChanged) {
+    const seriesMembershipsAfter = await getBottleSeriesMemberships(
+      tx,
+      affectedIds,
     );
+    await updateBottleSeriesReleaseCounts(
+      tx,
+      seriesMembershipsBefore,
+      seriesMembershipsAfter,
+    );
+  }
   const seriesOwnershipChanged =
     sharedChanged &&
     group.brandId !== stable.brandId &&
@@ -1647,15 +1665,6 @@ export async function updateBottleInTransaction(
           ),
         ).sort((left, right) => left - right)
       : [];
-  for (const seriesId of affectedSeriesIds) {
-    await tx
-      .update(bottleSeries)
-      .set({
-        numReleases: sql`(SELECT COUNT(*) FROM ${bottles} WHERE ${bottles.seriesId} = ${seriesId})`,
-      })
-      .where(eq(bottleSeries.id, seriesId));
-  }
-
   if (bottleEntityLinksChanged) {
     const entityLinksAfter = await getBottleEntityLinks(tx, affectedIds);
     await updateEntityBottleCounts(tx, entityLinksBefore, entityLinksAfter);

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
@@ -15,7 +15,7 @@ describe("POST /admin/catalog/repair-bottle-counts", () => {
     await expect(
       routerClient.admin.repairBottleCounts({}, { context: { user: admin } }),
     ).resolves.toEqual({ status: "queued" });
-    expect(pushUniqueJob).toHaveBeenCalledTimes(3);
+    expect(pushUniqueJob).toHaveBeenCalledTimes(4);
     expect(pushUniqueJob).toHaveBeenNthCalledWith(
       1,
       "RepairEntityBottleCounts",
@@ -35,6 +35,14 @@ describe("POST /admin/catalog/repair-bottle-counts", () => {
     expect(pushUniqueJob).toHaveBeenNthCalledWith(
       3,
       "RepairBottleGroupBottleCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
+    expect(pushUniqueJob).toHaveBeenNthCalledWith(
+      4,
+      "RepairBottleSeriesReleaseCounts",
       {},
       {
         delay: 0,

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
@@ -37,5 +37,12 @@ export default procedure
         delay: 0,
       },
     );
+    await pushUniqueJob(
+      "RepairBottleSeriesReleaseCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
     return { status: "queued" };
   });

--- a/apps/server/src/orpc/routes/bottleSeries/merge.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/merge.test.ts
@@ -4,6 +4,7 @@ import {
   bottles,
   bottleSeries,
   bottleSeriesTombstones,
+  bottleTombstones,
   changes,
 } from "@peated/server/db/schema";
 import { createBottle } from "@peated/server/lib/createBottle";
@@ -167,7 +168,7 @@ describe("POST /bottle-series/:series/merge", () => {
     );
   });
 
-  test("rolls back when a BottleGroup cannot be moved", async ({
+  test("returns a conflict and rolls back when a representative is retired", async ({
     fixtures,
   }) => {
     const user = await fixtures.User({ admin: true });
@@ -188,18 +189,17 @@ describe("POST /bottle-series/:series/merge", () => {
         series: source.id,
       },
     });
-    const incompleteGroup = await createBottle({
+    const damagedGroup = await createBottle({
       context: { user },
       input: {
-        name: "Incomplete Bottle",
+        name: "Damaged Representative",
         brand: brand.id,
         series: source.id,
       },
     });
     await db
-      .update(bottleGroups)
-      .set({ representativeBottleId: null })
-      .where(eq(bottleGroups.id, incompleteGroup.group.id));
+      .insert(bottleTombstones)
+      .values({ bottleId: damagedGroup.bottle.id });
 
     const err = await waitError(() =>
       routerClient.bottleSeries.merge(
@@ -213,7 +213,7 @@ describe("POST /bottle-series/:series/merge", () => {
     );
 
     expect(err.message).toBe(
-      `BottleGroup ${incompleteGroup.group.id} is incomplete and cannot be moved.`,
+      `BottleGroup ${damagedGroup.group.id} is incomplete and cannot be moved.`,
     );
     expect(
       await db.query.bottleSeries.findFirst({
@@ -224,7 +224,7 @@ describe("POST /bottle-series/:series/merge", () => {
     const groups = await db.query.bottleGroups.findMany({
       where: inArray(bottleGroups.id, [
         firstGroup.group.id,
-        incompleteGroup.group.id,
+        damagedGroup.group.id,
       ]),
     });
     expect(groups).toHaveLength(2);
@@ -233,7 +233,7 @@ describe("POST /bottle-series/:series/merge", () => {
     const members = await db.query.bottles.findMany({
       where: inArray(bottles.id, [
         firstGroup.bottle.id,
-        incompleteGroup.bottle.id,
+        damagedGroup.bottle.id,
       ]),
     });
     expect(members).toHaveLength(2);

--- a/apps/server/src/orpc/routes/bottleSeries/merge.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/merge.ts
@@ -12,6 +12,7 @@ import {
   updateBottleSeriesReleaseCounts,
 } from "@peated/server/lib/bottleSeriesReleaseCounts";
 import {
+  BottleUpdateGraphError,
   finalizeBottleUpdate,
   updateBottleInTransaction,
   type BottleUpdateFinalizationManifest,
@@ -93,14 +94,23 @@ export default procedure
             message: `BottleGroup ${group.id} is incomplete and cannot be moved.`,
           });
         }
-        manifests.push(
-          await updateBottleInTransaction(tx, {
-            bottleId: group.representativeBottleId,
-            input: { series: destination.id },
-            actorId,
-            creationSource: "manual_entry",
-          }),
-        );
+        try {
+          manifests.push(
+            await updateBottleInTransaction(tx, {
+              bottleId: group.representativeBottleId,
+              input: { series: destination.id },
+              actorId,
+              creationSource: "manual_entry",
+            }),
+          );
+        } catch (error) {
+          if (!(error instanceof BottleUpdateGraphError)) throw error;
+
+          throw errors.CONFLICT({
+            message: `BottleGroup ${group.id} is incomplete and cannot be moved.`,
+            cause: error,
+          });
+        }
       }
 
       const ungroupedBottleIds = (

--- a/apps/server/src/orpc/routes/bottleSeries/merge.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/merge.ts
@@ -8,6 +8,10 @@ import {
 } from "@peated/server/db/schema";
 import { getUserActorForDatabase } from "@peated/server/lib/actors";
 import {
+  getBottleSeriesMemberships,
+  updateBottleSeriesReleaseCounts,
+} from "@peated/server/lib/bottleSeriesReleaseCounts";
+import {
   finalizeBottleUpdate,
   updateBottleInTransaction,
   type BottleUpdateFinalizationManifest,
@@ -17,7 +21,7 @@ import { requireMod } from "@peated/server/orpc/middleware";
 import { BottleSeriesSchema } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { BottleSeriesSerializer } from "@peated/server/serializers/bottleSeries";
-import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -99,15 +103,34 @@ export default procedure
         );
       }
 
+      const ungroupedBottleIds = (
+        await tx
+          .select({ id: bottles.id })
+          .from(bottles)
+          .where(and(eq(bottles.seriesId, source.id), isNull(bottles.groupId)))
+      ).map(({ id }) => id);
+      const membershipsBefore = await getBottleSeriesMemberships(
+        tx,
+        ungroupedBottleIds,
+      );
+
       await tx
         .update(bottles)
         .set({ seriesId: destination.id, updatedAt: new Date() })
         .where(and(eq(bottles.seriesId, source.id), isNull(bottles.groupId)));
+      const membershipsAfter = await getBottleSeriesMemberships(
+        tx,
+        ungroupedBottleIds,
+      );
+      await updateBottleSeriesReleaseCounts(
+        tx,
+        membershipsBefore,
+        membershipsAfter,
+      );
 
       await tx
         .update(bottleSeries)
         .set({
-          numReleases: sql`(SELECT COUNT(*) FROM ${bottles} WHERE ${bottles.seriesId} = ${destination.id})`,
           updatedAt: new Date(),
         })
         .where(eq(bottleSeries.id, destination.id));

--- a/apps/server/src/orpc/routes/bottles/delete.test.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.test.ts
@@ -123,11 +123,11 @@ describe("DELETE /bottles/:bottle", () => {
     ).toMatchObject({ bottleId: bottle.id, newBottleId: null });
   });
 
-  test("selects a remaining representative and recomputes group and series counts", async ({
+  test("selects a remaining representative and repairs group and series counts", async ({
     fixtures,
   }) => {
     const user = await fixtures.User({ admin: true });
-    const series = await fixtures.BottleSeries({ numReleases: 2 });
+    const series = await fixtures.BottleSeries({ numReleases: 0 });
     const representative = await fixtures.Bottle({
       name: "Grouped Representative",
       brandId: series.brandId,

--- a/apps/server/src/orpc/routes/bottles/delete.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.ts
@@ -5,7 +5,6 @@ import {
   bottleGroupDistillers,
   bottleGroups,
   bottleReferences,
-  bottleSeries,
   bottleTags,
   bottleTombstones,
   bottles,
@@ -19,6 +18,10 @@ import {
   tastings,
 } from "@peated/server/db/schema";
 import { getUserActorForDatabase } from "@peated/server/lib/actors";
+import {
+  getBottleSeriesMemberships,
+  updateBottleSeriesReleaseCounts,
+} from "@peated/server/lib/bottleSeriesReleaseCounts";
 import {
   getBottleEntityLinks,
   updateEntityBottleCounts,
@@ -150,6 +153,10 @@ export default procedure
       const locationsBefore = await getBottleProductionLocations(tx, [
         bottle.id,
       ]);
+      const seriesMembershipsBefore =
+        bottle.seriesId === null
+          ? []
+          : await getBottleSeriesMemberships(tx, [bottle.id]);
 
       const distillerRows = await tx
         .select({ distillerId: bottlesToDistillers.distillerId })
@@ -304,6 +311,7 @@ export default procedure
         bottle.id,
       ]);
       await updateLocationBottleCounts(tx, locationsBefore, locationsAfter);
+      await updateBottleSeriesReleaseCounts(tx, seriesMembershipsBefore, []);
 
       if (bottle.groupId !== null) {
         if (remainingGroupMemberIds.length === 0) {
@@ -316,15 +324,6 @@ export default procedure
         } else {
           await recomputeBottleGroupStatsInTransaction(tx, bottle.groupId);
         }
-      }
-
-      if (bottle.seriesId !== null) {
-        await tx
-          .update(bottleSeries)
-          .set({
-            numReleases: sql`(SELECT COUNT(*) FROM ${bottles} WHERE ${bottles.seriesId} = ${bottle.seriesId})`,
-          })
-          .where(eq(bottleSeries.id, bottle.seriesId));
       }
     });
 

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -22,6 +22,7 @@ import processNotification from "./processNotification";
 import processStorePriceMatchRetryRun from "./processStorePriceMatchRetryRun";
 import reconcileStorePriceMatchProposals from "./reconcileStorePriceMatchProposals";
 import repairBottleGroupBottleCounts from "./repairBottleGroupBottleCounts";
+import repairBottleSeriesReleaseCounts from "./repairBottleSeriesReleaseCounts";
 import repairEntityBottleCounts from "./repairEntityBottleCounts";
 import repairLocationBottleCounts from "./repairLocationBottleCounts";
 import resolveStorePriceBottle from "./resolveStorePriceBottle";
@@ -55,6 +56,10 @@ registry.add("OnEntityChange", onEntityChange);
 registry.add("ProcessNotification", processNotification);
 registry.add("ProcessStorePriceMatchRetryRun", processStorePriceMatchRetryRun);
 registry.add("RepairBottleGroupBottleCounts", repairBottleGroupBottleCounts);
+registry.add(
+  "RepairBottleSeriesReleaseCounts",
+  repairBottleSeriesReleaseCounts,
+);
 registry.add("RepairEntityBottleCounts", repairEntityBottleCounts);
 registry.add("RepairLocationBottleCounts", repairLocationBottleCounts);
 registry.add(

--- a/apps/server/src/worker/jobs/mergeEntity.test.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.test.ts
@@ -483,6 +483,77 @@ test("fails an operation when its check schema version is unsupported", async ({
   ).toHaveLength(2);
 });
 
+test("rejects an affected Bottle without a group before changing data", async ({
+  fixtures,
+}) => {
+  const source = await fixtures.Entity({ name: "Ungrouped Source" });
+  const destination = await fixtures.Entity({ name: "Ungrouped Destination" });
+  const sourceSeries = await fixtures.BottleSeries({
+    brandId: source.id,
+    name: "Range",
+    numReleases: 1,
+  });
+  const destinationSeries = await fixtures.BottleSeries({
+    brandId: destination.id,
+    name: sourceSeries.name,
+    numReleases: 0,
+  });
+  const bottle = await fixtures.LegacyBottle({
+    brandId: source.id,
+    seriesId: sourceSeries.id,
+  });
+  const moderator = await fixtures.User({ mod: true });
+  const checkBottle = await fixtures.Bottle({ brandId: destination.id });
+  const operation = await createApplyingEntityMergeOperation({
+    approvingModeratorId: moderator.id,
+    bottleId: checkBottle.id,
+    sourceEntityId: source.id,
+    destinationEntityId: destination.id,
+  });
+
+  await expect(
+    mergeEntity({
+      operationId: operation.id,
+      approvingModeratorId: moderator.id,
+    }),
+  ).rejects.toThrow(
+    `Bottle ${bottle.id} must belong to a BottleGroup before this Entity merge can continue.`,
+  );
+
+  await expect(
+    db.query.bottleOperations.findFirst({
+      where: eq(bottleOperations.id, operation.id),
+    }),
+  ).resolves.toMatchObject({
+    status: "failed",
+    error: `Bottle ${bottle.id} must belong to a BottleGroup before this Entity merge can continue.`,
+  });
+
+  await expect(
+    db.query.entities.findFirst({ where: eq(entities.id, source.id) }),
+  ).resolves.toBeDefined();
+  await expect(
+    db.query.entities.findFirst({ where: eq(entities.id, destination.id) }),
+  ).resolves.toBeDefined();
+  await expect(
+    db.query.bottleSeries.findFirst({
+      where: eq(bottleSeries.id, sourceSeries.id),
+    }),
+  ).resolves.toMatchObject({ brandId: source.id, numReleases: 1 });
+  await expect(
+    db.query.bottleSeries.findFirst({
+      where: eq(bottleSeries.id, destinationSeries.id),
+    }),
+  ).resolves.toMatchObject({ brandId: destination.id, numReleases: 0 });
+  await expect(
+    db.query.bottles.findFirst({ where: eq(bottles.id, bottle.id) }),
+  ).resolves.toMatchObject({
+    brandId: source.id,
+    seriesId: sourceSeries.id,
+    groupId: null,
+  });
+});
+
 test("merge A into B", async ({ fixtures }) => {
   const entityA = await fixtures.Entity({
     name: "Entity A",

--- a/apps/server/src/worker/jobs/mergeEntity.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.ts
@@ -55,8 +55,26 @@ import {
   EntityMergeJobInputSchema,
   isOperationEntityMergeJobInput,
 } from "@peated/server/worker/entityMerge";
-import { and, asc, eq, inArray, notInArray, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  isNull,
+  notInArray,
+  or,
+  sql,
+} from "drizzle-orm";
 import type { JobPayload } from "../types";
+
+class EntityMergeBottleGroupRequiredError extends Error {
+  constructor(bottleId: number) {
+    super(
+      `Bottle ${bottleId} must belong to a BottleGroup before this Entity merge can continue.`,
+    );
+    this.name = "EntityMergeBottleGroupRequiredError";
+  }
+}
 
 function replaceMergedEntityIds(
   ids: readonly number[],
@@ -67,6 +85,33 @@ function replaceMergedEntityIds(
   return Array.from(
     new Set(ids.map((id) => (sourceIds.has(id) ? toEntityId : id))),
   ).sort((left, right) => left - right);
+}
+
+async function findBottleWithoutGroup(
+  database: AnyDatabase,
+  fromEntityIds: number[],
+  sourceSeriesIds: number[],
+): Promise<number | null> {
+  const [bottle] = await database
+    .select({ id: bottles.id })
+    .from(bottles)
+    .leftJoin(bottlesToDistillers, eq(bottlesToDistillers.bottleId, bottles.id))
+    .where(
+      and(
+        isNull(bottles.groupId),
+        or(
+          inArray(bottles.brandId, fromEntityIds),
+          inArray(bottles.bottlerId, fromEntityIds),
+          inArray(bottlesToDistillers.distillerId, fromEntityIds),
+          sourceSeriesIds.length
+            ? inArray(bottles.seriesId, sourceSeriesIds)
+            : undefined,
+        ),
+      ),
+    )
+    .orderBy(asc(bottles.id))
+    .limit(1);
+  return bottle?.id ?? null;
 }
 
 type EntityKind = NonNullable<(typeof entities.$inferSelect)["kind"]>;
@@ -235,6 +280,32 @@ async function performEntityMerge({
       logWarn("Merge target entity not found", { extra: { toEntityId } });
       return;
     }
+
+    const sourceSeriesRows = await tx
+      .select()
+      .from(bottleSeries)
+      .where(inArray(bottleSeries.brandId, fromEntityIds));
+    const sourceSeriesIds = sourceSeriesRows.map(({ id }) => id);
+    // BottleGroup owns shared Bottle identity changes. Stop instead of
+    // partially rewriting a Bottle that has not completed group migration.
+    const bottleWithoutGroupId = await findBottleWithoutGroup(
+      tx,
+      fromEntityIds,
+      sourceSeriesIds,
+    );
+    if (bottleWithoutGroupId !== null) {
+      const error = new EntityMergeBottleGroupRequiredError(
+        bottleWithoutGroupId,
+      );
+      if (operation) {
+        throw new EntityMergeOperationExecutionError(
+          error.message,
+          operation.operationId,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
     performedMutation = true;
 
     const mutationUser =
@@ -280,12 +351,6 @@ async function performEntityMerge({
       entityId: toEntityId,
       ownerId: destinationOwnerId,
     });
-
-    const sourceSeriesRows = await tx
-      .select()
-      .from(bottleSeries)
-      .where(inArray(bottleSeries.brandId, fromEntityIds));
-    const sourceSeriesIds = sourceSeriesRows.map(({ id }) => id);
 
     const authorityGroups = await tx
       .select({ id: bottleGroups.id })

--- a/apps/server/src/worker/jobs/mergeEntity.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.ts
@@ -688,19 +688,12 @@ async function performEntityMerge({
         await tx
           .delete(bottleSeries)
           .where(eq(bottleSeries.id, sourceSeries.id));
-        await tx
-          .update(bottleSeries)
-          .set({
-            numReleases: sql`(SELECT COUNT(*) FROM ${bottles} WHERE ${bottles.seriesId} = ${targetSeries.id})`,
-          })
-          .where(eq(bottleSeries.id, targetSeries.id));
       } else {
         await tx
           .update(bottleSeries)
           .set({
             brandId: toEntity.id,
             fullName: targetFullName,
-            numReleases: sql`(SELECT COUNT(*) FROM ${bottles} WHERE ${bottles.seriesId} = ${sourceSeries.id})`,
           })
           .where(eq(bottleSeries.id, sourceSeries.id));
       }

--- a/apps/server/src/worker/jobs/repairBottleSeriesReleaseCounts.test.ts
+++ b/apps/server/src/worker/jobs/repairBottleSeriesReleaseCounts.test.ts
@@ -1,0 +1,35 @@
+import { db } from "@peated/server/db";
+import { bottleSeries } from "@peated/server/db/schema";
+import { checkBottleSeriesReleaseCounts } from "@peated/server/lib/bottleSeriesReleaseCounts";
+import { eq } from "drizzle-orm";
+import repairBottleSeriesReleaseCountsJob from "./repairBottleSeriesReleaseCounts";
+
+test("repairs wrong counts and is safe to run again", async ({ fixtures }) => {
+  const series = await fixtures.BottleSeries({ numReleases: 9 });
+  await fixtures.Bottle({ seriesId: series.id });
+  await db
+    .update(bottleSeries)
+    .set({ numReleases: 9 })
+    .where(eq(bottleSeries.id, series.id));
+
+  await expect(repairBottleSeriesReleaseCountsJob({})).resolves.toEqual({
+    wrongCount: 1,
+    repairedCount: 1,
+  });
+  await expect(checkBottleSeriesReleaseCounts()).resolves.toEqual([]);
+
+  await expect(repairBottleSeriesReleaseCountsJob({})).resolves.toEqual({
+    wrongCount: 0,
+    repairedCount: 0,
+  });
+});
+
+test.each([undefined, null, [], { unexpected: true }])(
+  "rejects malformed input %#",
+  async (input) => {
+    // SAFETY: This test bypasses the type so the job can reject invalid queue input.
+    await expect(
+      repairBottleSeriesReleaseCountsJob(input as never),
+    ).rejects.toThrow();
+  },
+);

--- a/apps/server/src/worker/jobs/repairBottleSeriesReleaseCounts.ts
+++ b/apps/server/src/worker/jobs/repairBottleSeriesReleaseCounts.ts
@@ -1,0 +1,38 @@
+import {
+  checkBottleSeriesReleaseCounts,
+  repairBottleSeriesReleaseCount,
+} from "@peated/server/lib/bottleSeriesReleaseCounts";
+import { logInfo } from "@peated/server/lib/log";
+import { z } from "zod";
+import type { JobPayload } from "../types";
+
+export const RepairBottleSeriesReleaseCountsJobArgsSchema = z
+  .object({})
+  .strict();
+
+export default async function repairBottleSeriesReleaseCountsJob(
+  input: JobPayload,
+) {
+  RepairBottleSeriesReleaseCountsJobArgsSchema.parse(input);
+
+  const wrongCounts = await checkBottleSeriesReleaseCounts();
+  let repairedCount = 0;
+
+  for (const wrongCount of wrongCounts) {
+    if (await repairBottleSeriesReleaseCount(wrongCount.seriesId)) {
+      repairedCount += 1;
+    }
+  }
+
+  logInfo("Finished BottleSeries release count repair", {
+    extra: {
+      wrongCount: wrongCounts.length,
+      repairedCount,
+    },
+  });
+
+  return {
+    wrongCount: wrongCounts.length,
+    repairedCount,
+  };
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -23,6 +23,7 @@ export type JobName =
   | "ProcessStorePriceMatchRetryRun"
   | "ProcessNotification"
   | "RepairBottleGroupBottleCounts"
+  | "RepairBottleSeriesReleaseCounts"
   | "RepairEntityBottleCounts"
   | "RepairLocationBottleCounts"
   | "ReconcileStorePriceMatchProposals"

--- a/openspec/changes/repair-bottle-series-counts/.openspec.yaml
+++ b/openspec/changes/repair-bottle-series-counts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/repair-bottle-series-counts/design.md
+++ b/openspec/changes/repair-bottle-series-counts/design.md
@@ -51,6 +51,8 @@ The job will use a strict empty input, be dispatched uniquely, and run from the 
 
 BottleSeries and Entity merges may move many Bottles and retire a BottleSeries. They will use the same count owner or its one-series recount rather than embedding their own `COUNT(*)` expressions. Their existing identity checks, tombstones, audit rows, and transaction boundaries remain unchanged.
 
+An Entity merge will stop before making changes if an affected Bottle has not completed BottleGroup migration. Moving only its BottleSeries would leave its producer links and saved identity inconsistent. The dedicated BottleSeries merge can still move an ungrouped Bottle because that operation does not change its producer identity.
+
 ## Risks / Trade-offs
 
 - **A large repair scan still reads the Bottle and BottleSeries tables.** → The scan is read-only; writes are limited to one locked BottleSeries per transaction.

--- a/openspec/changes/repair-bottle-series-counts/design.md
+++ b/openspec/changes/repair-bottle-series-counts/design.md
@@ -1,0 +1,71 @@
+## Context
+
+`BottleSeries.numReleases` is the saved number of active Bottles whose `seriesId` points to that BottleSeries. Search sorts on it and BottleSeries pages display it. The same count query is currently repeated in Bottle creation, shared Bottle updates, Bottle deletion, Bottle merges, BottleSeries merges, and Entity merges.
+
+The normal write paths already run in database transactions. A queued job must not be required for correctness, and production repair must run while Bottle editing continues.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep `numReleases` correct when its Bottle rows commit.
+- Put the count rule and repair query in one small module.
+- Change only the few BottleSeries rows affected by a normal write.
+- Repair old wrong totals one BottleSeries at a time.
+- Keep the existing admin Bottle-count action as the only repair control.
+
+**Non-Goals:**
+
+- Changing BottleSeries identity or membership rules.
+- Adding a general counter framework.
+- Changing Collection totals or other Bottle statistics.
+- Adding a migration, CLI command, or separate admin page.
+
+## Decisions
+
+### Derive normal changes from Bottle membership before and after the write
+
+The shared owner will accept the affected Bottles' series membership before and after a change. It will combine those rows into a change for each BottleSeries and update only nonzero changes in BottleSeries ID order.
+
+This keeps creation, deletion, series changes, and Bottle merges on the same rule. It also avoids recounting all releases in a series during common Bottle writes. Keeping the existing count queries in each operation was rejected because it repeats the source-of-truth rule and makes concurrent results depend on several implementations.
+
+### Save release-total changes in the source transaction
+
+Normal Bottle operations will update `numReleases` before their transaction commits. Database row updates serialize concurrent changes to the same BottleSeries. Operations affecting more than one BottleSeries will update them in ascending ID order.
+
+A queued recount was rejected because a missed, delayed, or repeated job must not leave a committed Bottle change with the wrong total.
+
+### Repair an old undercount instead of blocking a valid Bottle change
+
+A negative change will not save a value below zero. If the guarded update cannot change an existing BottleSeries, the owner will lock that series and recount it from its active Bottles after the caller's Bottle changes. A missing BottleSeries remains an error because it means the catalog relationship is invalid.
+
+This lets deletion and merge repair old drift without rolling back valid work, while still failing invalid references.
+
+### Check broadly, repair narrowly
+
+The repair job will first find BottleSeries rows whose saved and actual totals differ without taking broad locks. It will then repair each candidate in its own transaction. Each repair locks one BottleSeries row, checks its current Bottle membership again, and writes only `numReleases` when it is still wrong.
+
+The job will use a strict empty input, be dispatched uniquely, and run from the existing **Check Bottle counts** admin action. Reusing that action keeps production operation simple.
+
+### Preserve rare merge behavior while removing repeated count ownership
+
+BottleSeries and Entity merges may move many Bottles and retire a BottleSeries. They will use the same count owner or its one-series recount rather than embedding their own `COUNT(*)` expressions. Their existing identity checks, tombstones, audit rows, and transaction boundaries remain unchanged.
+
+## Risks / Trade-offs
+
+- **A large repair scan still reads the Bottle and BottleSeries tables.** → The scan is read-only; writes are limited to one locked BottleSeries per transaction.
+- **A busy BottleSeries may change after the scan.** → The per-series repair locks and rechecks before saving.
+- **Old counts can be too low for a decrement.** → The normal write recounts that one locked BottleSeries instead of failing or going negative.
+- **Merge paths have more affected Bottles than ordinary edits.** → Keep their work inside the existing merge transaction and avoid introducing another workflow.
+- **Changing lock order broadly could create new risk.** → Update affected BottleSeries rows in stable ID order and leave unrelated graph locking unchanged unless a focused concurrency test proves a conflict.
+
+## Migration Plan
+
+1. Deploy the shared owner and all normal write-path changes together.
+2. Deploy the repair worker through the existing admin action.
+3. Run **Check Bottle counts** after deployment to repair old BottleSeries totals.
+4. If rollback is needed, revert the code; no schema or irreversible data change is involved. A later repair run can restore any totals changed while old code was active.
+
+## Open Questions
+
+None.

--- a/openspec/changes/repair-bottle-series-counts/proposal.md
+++ b/openspec/changes/repair-bottle-series-counts/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`BottleSeries.numReleases` is saved because search and BottleSeries pages use it for fast sorting and display. Several Bottle and merge paths recount it separately, which repeats the rule and makes concurrent changes and old wrong totals harder to handle safely.
+
+## What Changes
+
+- Make active Bottle rows assigned to a BottleSeries the documented source of truth for its release total.
+- Put normal release-total changes in one small owner used by Bottle creation, deletion, series changes, Bottle merges, BottleSeries merges, and Entity merges.
+- Update only the affected BottleSeries rows in the same transaction as the Bottle changes.
+- Add an independent check and one-series-at-a-time repair to the existing admin Bottle-count action.
+- Cover additions, deletions, series changes, merges, concurrent writes, and old wrong totals with integration tests.
+
+## Capabilities
+
+### New Capabilities
+
+- `bottle-series-release-counts`: Correct, repairable BottleSeries release totals derived from active Bottles.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Bottle creation, update, deletion, and merge code.
+- BottleSeries and Entity merge code.
+- The existing admin Bottle-count repair route.
+- Worker registration and tests for the BottleSeries repair job.
+- No schema migration, CLI command, new admin control, public API change, or runtime dependency.

--- a/openspec/changes/repair-bottle-series-counts/specs/bottle-series-release-counts/spec.md
+++ b/openspec/changes/repair-bottle-series-counts/specs/bottle-series-release-counts/spec.md
@@ -58,6 +58,11 @@ The system SHALL save every BottleSeries release-total change in the same transa
 - **WHEN** an Entity merge moves or combines BottleSeries rows
 - **THEN** every surviving BottleSeries total matches its Bottle membership when the merge commits
 
+#### Scenario: Entity merge finds a Bottle without a group
+
+- **WHEN** an affected Bottle does not belong to a BottleGroup
+- **THEN** the Entity merge reports that the Bottle must be migrated and commits no catalog changes
+
 ### Requirement: Concurrent release-total changes
 
 The system SHALL preserve every committed release-total change when Bottle operations overlap. When one operation affects several BottleSeries rows, it SHALL change those rows in ascending BottleSeries ID order.

--- a/openspec/changes/repair-bottle-series-counts/specs/bottle-series-release-counts/spec.md
+++ b/openspec/changes/repair-bottle-series-counts/specs/bottle-series-release-counts/spec.md
@@ -48,6 +48,11 @@ The system SHALL save every BottleSeries release-total change in the same transa
 - **WHEN** one BottleSeries is merged into another
 - **THEN** the surviving BottleSeries total matches all Bottles moved to it before the retired BottleSeries is removed
 
+#### Scenario: BottleSeries merge finds an invalid representative
+
+- **WHEN** a source BottleGroup has a missing or retired representative Bottle
+- **THEN** the merge reports a conflict and commits no BottleSeries, BottleGroup, or Bottle changes
+
 #### Scenario: Entity merge changes BottleSeries ownership
 
 - **WHEN** an Entity merge moves or combines BottleSeries rows

--- a/openspec/changes/repair-bottle-series-counts/specs/bottle-series-release-counts/spec.md
+++ b/openspec/changes/repair-bottle-series-counts/specs/bottle-series-release-counts/spec.md
@@ -1,0 +1,120 @@
+## ADDED Requirements
+
+### Requirement: BottleSeries release total source
+
+The system SHALL define a BottleSeries release total as the number of active Bottle rows whose `seriesId` references that BottleSeries. A Bottle without a BottleSeries SHALL not affect any BottleSeries release total.
+
+#### Scenario: Bottle belongs to a series
+
+- **WHEN** an active Bottle references a BottleSeries
+- **THEN** that Bottle contributes exactly one to the BottleSeries release total
+
+#### Scenario: Bottle has no series
+
+- **WHEN** an active Bottle has no BottleSeries
+- **THEN** it contributes to no BottleSeries release total
+
+### Requirement: Transactional release-total changes
+
+The system SHALL save every BottleSeries release-total change in the same transaction as the Bottle membership change that caused it. A queue job SHALL NOT be required for a normal Bottle write to leave the total correct.
+
+#### Scenario: Bottle is added
+
+- **WHEN** a Bottle assigned to a BottleSeries is created
+- **THEN** that BottleSeries release total increases by one in the creation transaction
+
+#### Scenario: Bottle is deleted
+
+- **WHEN** a Bottle assigned to a BottleSeries is deleted
+- **THEN** that BottleSeries release total decreases by one in the deletion transaction
+
+#### Scenario: BottleGroup changes series
+
+- **WHEN** a shared Bottle update moves active member Bottles from one BottleSeries to another
+- **THEN** the old and new BottleSeries totals change by the number of moved Bottles in the update transaction
+
+#### Scenario: Bottle merge within one series
+
+- **WHEN** two Bottles in the same BottleSeries are merged into one Bottle
+- **THEN** that BottleSeries release total decreases by one in the merge transaction
+
+#### Scenario: Bottle merge across series
+
+- **WHEN** a Bottle is merged into a surviving Bottle assigned to another BottleSeries
+- **THEN** the retired Bottle's series loses one release and the surviving Bottle's series remains counted once
+
+#### Scenario: BottleSeries merge
+
+- **WHEN** one BottleSeries is merged into another
+- **THEN** the surviving BottleSeries total matches all Bottles moved to it before the retired BottleSeries is removed
+
+#### Scenario: Entity merge changes BottleSeries ownership
+
+- **WHEN** an Entity merge moves or combines BottleSeries rows
+- **THEN** every surviving BottleSeries total matches its Bottle membership when the merge commits
+
+### Requirement: Concurrent release-total changes
+
+The system SHALL preserve every committed release-total change when Bottle operations overlap. When one operation affects several BottleSeries rows, it SHALL change those rows in ascending BottleSeries ID order.
+
+#### Scenario: Two Bottles are added concurrently
+
+- **WHEN** two transactions add Bottles to the same BottleSeries
+- **THEN** the saved total includes both committed Bottles
+
+#### Scenario: Repair overlaps a Bottle change
+
+- **WHEN** a BottleSeries repair overlaps a committed Bottle membership change
+- **THEN** the final saved total includes the committed change
+
+### Requirement: Damaged totals do not block valid Bottle removal
+
+The system SHALL prevent negative BottleSeries totals. If an existing saved total is too low for a deletion or merge decrement, the system SHALL repair that BottleSeries from its current Bottle membership within the same transaction instead of rejecting the valid Bottle operation.
+
+#### Scenario: Deletion encounters an old zero total
+
+- **WHEN** a Bottle is deleted from a BottleSeries whose saved total is incorrectly zero
+- **THEN** the deletion commits and the BottleSeries total is repaired to the remaining active Bottle count
+
+#### Scenario: Referenced BottleSeries is missing
+
+- **WHEN** a Bottle operation must change a BottleSeries that no longer exists
+- **THEN** the transaction fails as an invalid catalog relationship
+
+### Requirement: Bounded BottleSeries release-total repair
+
+The system SHALL provide an administrator-started job that finds wrong BottleSeries release totals and repairs one BottleSeries per transaction while Bottle editing continues.
+
+#### Scenario: Wrong saved total
+
+- **WHEN** the repair job finds a BottleSeries whose saved total differs from its active Bottle count
+- **THEN** it locks that BottleSeries, checks the count again, and saves the current active Bottle count
+
+#### Scenario: Correct saved total
+
+- **WHEN** a checked BottleSeries already has the correct release total
+- **THEN** the repair leaves it unchanged
+
+#### Scenario: BottleSeries changed after the scan
+
+- **WHEN** Bottle membership changes after the broad scan but before that BottleSeries is repaired
+- **THEN** the locked recheck uses the newer committed Bottle membership
+
+#### Scenario: Candidate BottleSeries was removed
+
+- **WHEN** a BottleSeries found by the scan no longer exists when its repair begins
+- **THEN** the repair skips it without recreating it
+
+#### Scenario: Repair is requested from Maintenance
+
+- **WHEN** an administrator starts the existing Bottle-count repair action
+- **THEN** the system uniquely queues the BottleSeries release-total repair job along with the other Bottle-count repairs
+
+### Requirement: Strict repair job input
+
+The BottleSeries repair job SHALL accept only an empty object and SHALL reject unknown fields.
+
+#### Scenario: Unexpected job field
+
+- **WHEN** the repair job receives any input field
+- **THEN** it rejects the input before reading or changing BottleSeries totals

--- a/openspec/changes/repair-bottle-series-counts/tasks.md
+++ b/openspec/changes/repair-bottle-series-counts/tasks.md
@@ -1,0 +1,25 @@
+## 1. Shared release-total owner
+
+- [x] 1.1 Add integration tests for BottleSeries membership lookup, count changes, old undercounts, missing series, checking, and one-series repair.
+- [x] 1.2 Add the small BottleSeries release-count module and make new BottleSeries rows start at zero.
+
+## 2. Normal Bottle operations
+
+- [x] 2.1 Use the shared owner for Bottle creation and shared series changes, with integration coverage for existing, new, old, and removed series.
+- [x] 2.2 Use the shared owner for Bottle deletion, including deletion when the saved total is already wrong.
+- [x] 2.3 Use the shared owner for same-series and cross-series Bottle merges.
+
+## 3. Catalog merges
+
+- [x] 3.1 Remove BottleSeries merge recount ownership and cover grouped and ungrouped Bottle moves.
+- [x] 3.2 Remove Entity merge recount ownership and verify moved, combined, and unchanged BottleSeries totals.
+
+## 4. Production repair
+
+- [x] 4.1 Add and register a strict, unique BottleSeries release-total repair job.
+- [x] 4.2 Queue the BottleSeries repair from the existing admin Bottle-count action and update its dispatch tests.
+
+## 5. Verification
+
+- [x] 5.1 Add focused overlap coverage proving concurrent Bottle changes and repair preserve the final total.
+- [x] 5.2 Run focused backend tests, server and web typechecks, lint, formatting, terminology checks, and strict OpenSpec validation.

--- a/openspec/changes/repair-bottle-series-counts/tasks.md
+++ b/openspec/changes/repair-bottle-series-counts/tasks.md
@@ -24,3 +24,4 @@
 - [x] 5.1 Add focused overlap coverage proving concurrent Bottle changes and repair preserve the final total.
 - [x] 5.2 Run focused backend tests, server and web typechecks, lint, formatting, terminology checks, and strict OpenSpec validation.
 - [x] 5.3 Return a controlled conflict for an invalid BottleGroup representative during BottleSeries merge and cover rollback.
+- [x] 5.4 Reject an Entity merge before catalog mutation when an affected Bottle has not completed BottleGroup migration.

--- a/openspec/changes/repair-bottle-series-counts/tasks.md
+++ b/openspec/changes/repair-bottle-series-counts/tasks.md
@@ -23,3 +23,4 @@
 
 - [x] 5.1 Add focused overlap coverage proving concurrent Bottle changes and repair preserve the final total.
 - [x] 5.2 Run focused backend tests, server and web typechecks, lint, formatting, terminology checks, and strict OpenSpec validation.
+- [x] 5.3 Return a controlled conflict for an invalid BottleGroup representative during BottleSeries merge and cover rollback.


### PR DESCRIPTION
BottleSeries release totals now follow Bottle membership changes in the same transaction across creation, deletion, shared updates, Bottle merges, BottleSeries merges, and Entity merges. Normal writes update only the affected series, avoid full recounts, preserve concurrent changes, and repair an old undercount instead of blocking a valid deletion or merge.

The existing **Check Bottle counts** admin action now also starts a strict, unique BottleSeries repair job. It finds wrong totals with a read-only scan, then locks, rechecks, and repairs one series per transaction while Bottle edits continue. This adds no migration, CLI operation, public API change, or separate admin control.

Refs #1042
