### PR TITLE
fix(web): clarify rating scales

### DIFF
--- a/apps/web/src/app/(app)/about/ratings/page.tsx
+++ b/apps/web/src/app/(app)/about/ratings/page.tsx
@@ -3,7 +3,6 @@ import {
   RailList,
   RailListItem,
   RATING_BANDS,
-  TastingRating,
   type DataTableColumn,
 } from "@peated/web/components";
 import {
@@ -37,13 +36,6 @@ const bandColumns: DataTableColumn<(typeof RATING_BANDS)[number]>[] = [
     cell: (band) => band.range,
     header: "Range",
     key: "range",
-  },
-  {
-    align: "right",
-    cell: (band) => <TastingRating band={band.key} />,
-    header: "Marker",
-    key: "marker",
-    priority: "secondary",
   },
 ];
 

--- a/apps/web/src/components/communityFeed.stylex.tsx
+++ b/apps/web/src/components/communityFeed.stylex.tsx
@@ -1,6 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import { foundationStyles } from "../styles/foundations.stylex";
-import { colors, fonts, space } from "../styles/tokens.stylex";
+import { colors, space } from "../styles/tokens.stylex";
 import { Avatar } from "./avatar.stylex";
 import {
   BottleIdentityRow,
@@ -8,7 +8,7 @@ import {
 } from "./bottleIdentityRow.stylex";
 import { Card, CardPrimaryLink } from "./card.stylex";
 import { ItemList, ItemListItem } from "./itemList.stylex";
-import { RATING_BANDS, TastingRating, type RatingBand } from "./scoring.stylex";
+import { ReviewScore, TastingRating, type RatingBand } from "./scoring.stylex";
 import { TextLink } from "./textLink.stylex";
 import TimeSince from "./timeSince";
 
@@ -144,28 +144,13 @@ function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
                   bottle.score !== undefined || bottle.ratingBand ? (
                     <div {...stylex.props(styles.facts)}>
                       {bottle.score !== undefined ? (
-                        <span
-                          role="img"
-                          aria-label={`Review score: ${bottle.score.value} out of ${bottle.score.scale}`}
-                          {...stylex.props(styles.score)}
-                        >
-                          {bottle.score.value}
-                          <span {...stylex.props(styles.scoreScale)}>
-                            /{bottle.score.scale}
-                          </span>
-                        </span>
+                        <ReviewScore
+                          scale={bottle.score.scale}
+                          score={bottle.score.value}
+                        />
                       ) : null}
                       {bottle.ratingBand ? (
-                        <>
-                          <strong {...stylex.props(styles.rating)}>
-                            {
-                              RATING_BANDS.find(
-                                (band) => band.key === bottle.ratingBand,
-                              )?.label
-                            }
-                          </strong>
-                          <TastingRating band={bottle.ratingBand} />
-                        </>
+                        <TastingRating band={bottle.ratingBand} />
                       ) : null}
                     </div>
                   ) : undefined
@@ -262,33 +247,6 @@ const styles = stylex.create({
     alignItems: "flex-end",
     flexDirection: "column",
     gap: space.x2,
-  },
-  rating: {
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "15px",
-    fontWeight: 700,
-    lineHeight: 1.2,
-    textAlign: "right",
-    [MOBILE]: { fontSize: "13px" },
-  },
-  score: {
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "32px",
-    fontVariantNumeric: "tabular-nums",
-    fontWeight: 700,
-    letterSpacing: "-0.045em",
-    lineHeight: 1,
-    whiteSpace: "nowrap",
-    [MOBILE]: { fontSize: "26px" },
-  },
-  scoreScale: {
-    color: colors.inkMuted,
-    fontSize: "13px",
-    fontWeight: 400,
-    letterSpacing: "normal",
-    marginLeft: "3px",
   },
   excerpt: {
     marginTop: 0,

--- a/apps/web/src/components/criticReview.stylex.tsx
+++ b/apps/web/src/components/criticReview.stylex.tsx
@@ -1,8 +1,9 @@
 import * as stylex from "@stylexjs/stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
-import { colors, fonts, space } from "../styles/tokens.stylex";
+import { colors, space } from "../styles/tokens.stylex";
 import { Avatar } from "./avatar.stylex";
+import { ReviewScore } from "./scoring.stylex";
 import { TextLink } from "./textLink.stylex";
 
 export type CriticReviewProps = {
@@ -51,16 +52,10 @@ export function CriticReview({
                 </p>
               ) : null}
               {hasScore ? (
-                <span
-                  aria-label={`${publication} score ${nativeScore.value} out of ${nativeScore.scale}`}
-                  role="img"
-                  {...stylex.props(styles.rating)}
-                >
-                  {nativeScore.value}
-                  <span {...stylex.props(styles.ratingScale)}>
-                    /{nativeScore.scale}
-                  </span>
-                </span>
+                <ReviewScore
+                  scale={nativeScore.scale}
+                  score={nativeScore.value}
+                />
               ) : null}
             </div>
           ) : null}
@@ -115,26 +110,6 @@ const styles = stylex.create({
     alignItems: "flex-start",
     justifyContent: "space-between",
     gap: space.x4,
-  },
-  rating: {
-    flexShrink: 0,
-    marginLeft: "auto",
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "32px",
-    fontVariantNumeric: "tabular-nums",
-    fontWeight: 700,
-    letterSpacing: "-0.045em",
-    lineHeight: 1,
-    whiteSpace: "nowrap",
-    [MOBILE]: { fontSize: "26px" },
-  },
-  ratingScale: {
-    color: colors.inkMuted,
-    fontSize: "12px",
-    fontWeight: 400,
-    letterSpacing: "normal",
-    marginLeft: "3px",
   },
   summary: {
     maxWidth: "54ch",

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -214,6 +214,7 @@ export {
   BottleRatingSummary,
   BottleRatings,
   RATING_BANDS,
+  ReviewScore,
   TastingRating,
   TastingRatingDistribution,
 } from "./scoring.stylex";
@@ -222,6 +223,7 @@ export type {
   BottleRatingsProps,
   RatingBand,
   RatingCounts,
+  ReviewScoreProps,
   TastingRatingCounts,
   TastingRatingDistributionProps,
   TastingRatingProps,

--- a/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
@@ -8,13 +8,13 @@ import {
   Chip,
   FactList,
   MemberAvatar,
-  RATING_BANDS,
+  ReviewScore,
   TastingRating,
   TextLink,
   type RatingBand,
 } from "@peated/web/components";
 import { foundationStyles } from "../../styles/foundations.stylex";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 import { PageHeader } from "./pageLayout.stylex";
 
 type Bottle = Outputs["tastings"]["details"]["bottle"];
@@ -56,10 +56,6 @@ export function TastingReviewDetail({
 }) {
   const bottleName = formatBottleDisplayName(bottle);
   const bottleTitle = bottleName.replaceAll(" - ", "\u00a0- ");
-  const ratingBand =
-    rating.kind === "tasting" && rating.ratingBand
-      ? RATING_BANDS.find((item) => item.key === rating.ratingBand)
-      : undefined;
   const facts = [
     servingStyle
       ? { label: "Serving", value: formatServingStyle(servingStyle) }
@@ -98,31 +94,9 @@ export function TastingReviewDetail({
           </div>
 
           {rating.kind === "review" ? (
-            <div {...stylex.props(styles.reviewScore)}>
-              <strong {...stylex.props(styles.reviewScoreValue)}>
-                {rating.score}
-              </strong>
-              <span
-                {...stylex.props(
-                  foundationStyles.metadata,
-                  styles.reviewScoreScale,
-                )}
-              >
-                /100
-              </span>
-            </div>
-          ) : rating.ratingBand && ratingBand ? (
-            <div {...stylex.props(styles.tastingRatingSummary)}>
-              <TastingRating band={rating.ratingBand} />
-              <span
-                {...stylex.props(
-                  foundationStyles.metadata,
-                  styles.tastingRatingCaption,
-                )}
-              >
-                {ratingBand.label} · {ratingBand.range}
-              </span>
-            </div>
+            <ReviewScore score={rating.score} size="lg" />
+          ) : rating.ratingBand ? (
+            <TastingRating band={rating.ratingBand} size="lg" />
           ) : (
             <span {...stylex.props(foundationStyles.metadata, styles.unrated)}>
               Not rated
@@ -227,33 +201,6 @@ const styles = stylex.create({
     gap: "2px",
   },
   authorMetadata: {
-    color: colors.inkMuted,
-  },
-  reviewScore: {
-    display: "flex",
-    flexShrink: 0,
-    alignItems: "baseline",
-    color: colors.ink,
-    fontFamily: fonts.display,
-  },
-  reviewScoreValue: {
-    fontSize: "40px",
-    fontVariantNumeric: "tabular-nums",
-    fontWeight: 700,
-    letterSpacing: "-0.045em",
-    lineHeight: 0.9,
-  },
-  reviewScoreScale: {
-    color: colors.inkMuted,
-  },
-  tastingRatingSummary: {
-    display: "flex",
-    flexShrink: 0,
-    flexDirection: "column",
-    alignItems: "flex-end",
-    gap: space.x1,
-  },
-  tastingRatingCaption: {
     color: colors.inkMuted,
   },
   unrated: {

--- a/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
@@ -87,7 +87,7 @@ export function TastingReviewRail({
           end: (
             <div {...stylex.props(styles.tastingMeta)}>
               {tasting.ratingBand ? (
-                <TastingRating band={tasting.ratingBand} />
+                <TastingRating band={tasting.ratingBand} size="sm" />
               ) : null}
               <time
                 dateTime={tasting.createdAt}

--- a/apps/web/src/components/reviewScore.stories.tsx
+++ b/apps/web/src/components/reviewScore.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { ReviewScore } from "./scoring.stylex";
+import { StoryRow, StoryStack } from "./storyFixtures.stylex";
+
+const meta = {
+  title: "Components/Ratings/Review Score",
+  component: ReviewScore,
+  args: { score: 92 },
+} satisfies Meta<typeof ReviewScore>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+  render: () => (
+    <StoryStack>
+      <StoryRow>
+        <ReviewScore score={92} />
+        <ReviewScore scale={10} score={8} />
+      </StoryRow>
+      <StoryRow>
+        <ReviewScore score={92} size="lg" />
+      </StoryRow>
+    </StoryStack>
+  ),
+};

--- a/apps/web/src/components/scoring.stylex.tsx
+++ b/apps/web/src/components/scoring.stylex.tsx
@@ -36,33 +36,97 @@ export function TastingRatingDistribution({
 export type TastingRatingProps = {
   /** One tasting rating. */
   band: RatingBand;
+  size?: "sm" | "md" | "lg";
 };
 
-/** Shows one tasting rating as five cells. */
-export function TastingRating({ band }: TastingRatingProps) {
+/** Shows one tasting's named rating and range, never a five-point score. */
+export function TastingRating({ band, size = "md" }: TastingRatingProps) {
   const selectedBand = RATING_BANDS.find((candidate) => candidate.key === band);
-  const label = `${selectedBand?.label ?? "Unknown"} rating`;
+  const label = selectedBand?.label ?? "Unknown";
+  const range = selectedBand?.range ?? "Unknown";
 
   return (
-    <span
-      aria-label={label}
-      role="img"
-      title={label}
-      {...stylex.props(styles.tastingRating)}
-    >
-      {RATING_BANDS.map((candidate) => {
-        const selected = candidate.key === band;
+    <span {...stylex.props(styles.ratingLockup)}>
+      <span {...stylex.props(styles.visuallyHidden)}>
+        {label} rating, {range} range
+      </span>
+      <span
+        aria-hidden="true"
+        {...stylex.props(
+          styles.ratingLabel,
+          size === "sm" && styles.smallRatingLabel,
+          size === "lg" && styles.largeRatingLabel,
+        )}
+      >
+        {label}
+      </span>
+      <span
+        aria-hidden="true"
+        {...stylex.props(
+          styles.tastingRatingRange,
+          size === "sm" && styles.smallTastingRatingRange,
+          size === "lg" && styles.largeTastingRatingRange,
+        )}
+      >
+        {range} range
+      </span>
+    </span>
+  );
+}
 
-        return (
-          <span
-            key={candidate.key}
-            {...stylex.props(
-              styles.tastingRatingCell,
-              selected && bandFillStyles[bandFillForKey(candidate.key)],
-            )}
-          />
-        );
-      })}
+export type ReviewScoreProps = {
+  /** The original score shown by the review. */
+  score: number;
+  /** The original scoring scale. Only 100-point scores use Peated's rating names. */
+  scale?: number;
+  size?: "sm" | "md" | "lg";
+};
+
+/** Shows an exact review score and names its Peated rating on a 100-point scale. */
+export function ReviewScore({
+  score,
+  scale = 100,
+  size = "md",
+}: ReviewScoreProps) {
+  const rating = scale === 100 ? getRatingBandForScore(score) : undefined;
+  const accessibleLabel = rating
+    ? `${rating.label} review score, ${score} out of ${scale}`
+    : `Review score, ${score} out of ${scale}`;
+
+  return (
+    <span {...stylex.props(styles.ratingLockup, styles.reviewScore)}>
+      <span {...stylex.props(styles.visuallyHidden)}>{accessibleLabel}</span>
+      {rating ? (
+        <span
+          aria-hidden="true"
+          {...stylex.props(
+            styles.ratingLabel,
+            size === "sm" && styles.smallRatingLabel,
+            size === "lg" && styles.largeRatingLabel,
+          )}
+        >
+          {rating.label}
+        </span>
+      ) : null}
+      <span aria-hidden="true" {...stylex.props(styles.reviewScoreValueGroup)}>
+        <strong
+          {...stylex.props(
+            styles.reviewScoreValue,
+            size === "sm" && styles.smallReviewScoreValue,
+            size === "lg" && styles.largeReviewScoreValue,
+          )}
+        >
+          {score}
+        </strong>
+        <span
+          {...stylex.props(
+            styles.reviewScoreScale,
+            size === "sm" && styles.smallReviewScoreScale,
+          )}
+        >
+          /{scale}
+        </span>
+      </span>
     </span>
   );
 }
@@ -200,14 +264,18 @@ function getBottleRating({
   tastingCounts: RatingCounts;
 }): BottleRating | null {
   if (median !== null && scoreCount > 0) {
-    const band = RATING_BANDS.find(
-      (candidate) => median >= candidate.min && median <= candidate.max,
-    );
+    const band = getRatingBandForScore(median);
     if (band) return { exact: true, label: band.label, value: `${median}` };
   }
 
   const band = getMedianTastingBand(tastingCounts);
   return band ? { exact: false, label: band.label, value: band.range } : null;
+}
+
+function getRatingBandForScore(score: number) {
+  return RATING_BANDS.find(
+    (candidate) => score >= candidate.min && score <= candidate.max,
+  );
 }
 
 function getMedianTastingBand(counts: RatingCounts) {
@@ -423,15 +491,84 @@ const styles = stylex.create({
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   }),
-  tastingRating: { display: "inline-flex", flexShrink: 0, gap: "2px" },
-  tastingRatingCell: {
-    position: "relative",
-    display: "inline-block",
-    width: "12px",
-    height: "8px",
+  ratingLockup: {
+    display: "inline-flex",
     flexShrink: 0,
-    borderRadius: controlMetrics.radiusSmall,
-    backgroundColor: colors.bandTrack,
+    alignItems: "flex-end",
+    flexDirection: "column",
+    gap: "2px",
+    whiteSpace: "nowrap",
+  },
+  ratingLabel: {
+    color: colors.accentDeep,
+    fontFamily: fonts.display,
+    fontSize: "16px",
+    fontWeight: 700,
+    letterSpacing: "-0.025em",
+    lineHeight: 1.2,
+  },
+  smallRatingLabel: {
+    fontSize: "13px",
+    lineHeight: 1.2,
+  },
+  largeRatingLabel: {
+    fontSize: "20px",
+    lineHeight: 1.1,
+  },
+  tastingRatingRange: {
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    fontVariantNumeric: "tabular-nums",
+    fontWeight: 400,
+    letterSpacing: "normal",
+    lineHeight: 1.3,
+  },
+  smallTastingRatingRange: { fontSize: "12px" },
+  largeTastingRatingRange: { fontSize: "15px" },
+  reviewScore: { marginLeft: "auto" },
+  reviewScoreValueGroup: {
+    display: "inline-flex",
+    alignItems: "baseline",
+    color: colors.ink,
+    fontFamily: fonts.display,
+  },
+  reviewScoreValue: {
+    fontSize: "32px",
+    fontVariantNumeric: "tabular-nums",
+    fontWeight: 700,
+    letterSpacing: "-0.045em",
+    lineHeight: 0.9,
+    [COMPACT]: { fontSize: "26px" },
+  },
+  smallReviewScoreValue: {
+    fontSize: "18px",
+    [COMPACT]: { fontSize: "18px" },
+  },
+  largeReviewScoreValue: {
+    fontSize: "40px",
+    [COMPACT]: { fontSize: "36px" },
+  },
+  reviewScoreScale: {
+    marginLeft: "3px",
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    fontWeight: 400,
+    letterSpacing: "normal",
+    lineHeight: 1.45,
+  },
+  smallReviewScoreScale: { fontSize: "12px" },
+  visuallyHidden: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
   },
   bottleRatings: {
     display: "inline-flex",

--- a/apps/web/src/components/scoring.test.tsx
+++ b/apps/web/src/components/scoring.test.tsx
@@ -4,9 +4,14 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { BottleRatingSummary, BottleRatings } from "./scoring.stylex";
+import {
+  BottleRatingSummary,
+  BottleRatings,
+  ReviewScore,
+  TastingRating,
+} from "./scoring.stylex";
 
-describe("Bottle ratings", () => {
+describe("Ratings", () => {
   let container: HTMLDivElement;
   let root: Root;
 
@@ -75,5 +80,27 @@ describe("Bottle ratings", () => {
     act(() => root.render(<BottleRatings />));
 
     expect(container.innerHTML).toBe("");
+  });
+
+  it("shows a tasting's named rating and range instead of a five-point mark", () => {
+    act(() => root.render(<TastingRating band="very_good" />));
+
+    expect(container.textContent).toContain("Very good");
+    expect(container.textContent).toContain("85–89 range");
+    expect(container.querySelector('[role="img"]')).toBeNull();
+  });
+
+  it("names an exact review score on a 100-point scale", () => {
+    act(() => root.render(<ReviewScore score={92} />));
+
+    expect(container.textContent).toContain("Outstanding");
+    expect(container.textContent).toContain("92/100");
+  });
+
+  it("keeps a critic's non-100 score without assigning a Peated rating", () => {
+    act(() => root.render(<ReviewScore scale={10} score={8} />));
+
+    expect(container.textContent).not.toContain("Good");
+    expect(container.textContent).toContain("8/10");
   });
 });

--- a/apps/web/src/components/tastingRating.stories.tsx
+++ b/apps/web/src/components/tastingRating.stories.tsx
@@ -20,6 +20,9 @@ export const Overview: Story = {
           <TastingRating band={band.key} key={band.key} />
         ))}
       </StoryRow>
+      <StoryRow>
+        <TastingRating band="very_good" size="lg" />
+      </StoryRow>
     </StoryStack>
   ),
 };


### PR DESCRIPTION
Ratings now use one label-and-value pattern across activity feeds, tasting and review details, and critic reviews. A 100-point review shows its named band above the exact `/100` score, while a simplified tasting shows the same label above its score range so it cannot be mistaken for a five-point rating.

Critic scores on other native scales remain unlabeled to avoid implying a conversion. The rating guide also drops its redundant marker column, and the shared components include compact and prominent variants with explicit screen-reader wording.

Refs #1064
