### PR TITLE
perf(classifier): skip obvious listing work

### DIFF
--- a/apps/server/src/orpc/routes/admin/moderation/automation.test.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/automation.test.ts
@@ -9,6 +9,7 @@ import { BOTTLE_CHECK_SCHEMA_VERSION } from "@peated/server/lib/bottleChecks";
 import { routerClient } from "@peated/server/orpc/router";
 import {
   createModerationAutomationProcedure,
+  summarizeListingAutomation,
   type ModerationQueueCountLoader,
 } from "@peated/server/orpc/routes/admin/moderation/automation";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -151,5 +152,43 @@ describe("admin moderation automation", () => {
         status: "failed",
       }),
     );
+  });
+
+  test("reports automatic, manual, and failed listing checks", () => {
+    const attempts = [
+      {
+        initialStatus: "ignored" as const,
+        finalStatus: "ignored" as const,
+        automationEligible: false,
+      },
+      {
+        initialStatus: "verified" as const,
+        finalStatus: "approved" as const,
+        automationEligible: false,
+      },
+      {
+        initialStatus: "pending_review" as const,
+        finalStatus: "approved" as const,
+        automationEligible: true,
+      },
+      {
+        initialStatus: "pending_review" as const,
+        finalStatus: "approved" as const,
+        automationEligible: false,
+      },
+      {
+        initialStatus: "errored" as const,
+        finalStatus: "errored" as const,
+        automationEligible: false,
+      },
+    ];
+
+    expect(summarizeListingAutomation(attempts)).toEqual({
+      sampleSize: 5,
+      automatic: 3,
+      manual: 1,
+      failed: 1,
+      rate: 60,
+    });
   });
 });

--- a/apps/server/src/orpc/routes/admin/moderation/automation.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/automation.ts
@@ -2,14 +2,58 @@ import { db } from "@peated/server/db";
 import {
   bottleOperations,
   incomingBottleDecisionLogs,
+  storePriceMatchAttempts,
   storePriceMatchProposals,
   storePriceMatchRetryRuns,
 } from "@peated/server/db/schema";
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import { getQueue } from "@peated/server/worker/queue";
-import { desc, eq, gte, inArray, sql } from "drizzle-orm";
+import { desc, eq, gte, inArray, isNotNull, sql } from "drizzle-orm";
 import { ModerationAutomationResponseSchema } from "./schemas";
+
+const LISTING_AUTOMATION_SAMPLE_SIZE = 100;
+
+type CompletedListingAttempt = Pick<
+  typeof storePriceMatchAttempts.$inferSelect,
+  "automationEligible" | "finalStatus" | "initialStatus"
+>;
+
+export function summarizeListingAutomation(
+  attempts: CompletedListingAttempt[],
+) {
+  let automatic = 0;
+  let failed = 0;
+
+  for (const attempt of attempts) {
+    if (attempt.finalStatus === "errored") {
+      failed += 1;
+      continue;
+    }
+
+    if (
+      (attempt.finalStatus === "approved" ||
+        attempt.finalStatus === "ignored") &&
+      (attempt.initialStatus === "verified" ||
+        attempt.initialStatus === "ignored" ||
+        attempt.automationEligible)
+    ) {
+      automatic += 1;
+    }
+  }
+
+  const manual = attempts.length - automatic - failed;
+  return {
+    sampleSize: attempts.length,
+    automatic,
+    manual,
+    failed,
+    rate:
+      attempts.length > 0
+        ? Math.round((automatic / attempts.length) * 100)
+        : null,
+  };
+}
 
 export type ModerationQueueCountLoader = () => Promise<{
   active?: number;
@@ -47,6 +91,7 @@ export function createModerationAutomationProcedure(
         proposalCounts,
         operationCounts,
         decisionCounts,
+        recentListingAttempts,
         retryCounts,
         recentRetryRuns,
         failedRetries,
@@ -67,6 +112,16 @@ export function createModerationAutomationProcedure(
           .select({ count: sql<number>`count(*)::int` })
           .from(incomingBottleDecisionLogs)
           .where(gte(incomingBottleDecisionLogs.createdAt, startOfToday)),
+        db
+          .select({
+            automationEligible: storePriceMatchAttempts.automationEligible,
+            finalStatus: storePriceMatchAttempts.finalStatus,
+            initialStatus: storePriceMatchAttempts.initialStatus,
+          })
+          .from(storePriceMatchAttempts)
+          .where(isNotNull(storePriceMatchAttempts.finalStatus))
+          .orderBy(desc(storePriceMatchAttempts.id))
+          .limit(LISTING_AUTOMATION_SAMPLE_SIZE),
         db
           .select({
             processing: sql<number>`count(*) filter (where ${storePriceMatchRetryRuns.status} IN ('pending', 'running'))::int`,
@@ -111,6 +166,7 @@ export function createModerationAutomationProcedure(
             (operationCounts[0]?.clearedToday ?? 0) +
             (retryCounts[0]?.completedToday ?? 0),
         },
+        listingAutomation: summarizeListingAutomation(recentListingAttempts),
         needsAttention: [
           ...failedOperations.map((operation) => ({
             key: `operation:${operation.id}`,

--- a/apps/server/src/orpc/routes/admin/moderation/schemas.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/schemas.ts
@@ -172,6 +172,15 @@ export const ModerationAutomationResponseSchema = z
         clearedToday: z.number().int().min(0),
       })
       .strict(),
+    listingAutomation: z
+      .object({
+        sampleSize: z.number().int().min(0).max(100),
+        automatic: z.number().int().min(0),
+        manual: z.number().int().min(0),
+        failed: z.number().int().min(0),
+        rate: z.number().int().min(0).max(100).nullable(),
+      })
+      .strict(),
     needsAttention: z.array(AutomationItemSchema),
     recentRuns: z.array(AutomationItemSchema),
   })

--- a/apps/web/src/components/admin/moderation/automationPage.tsx
+++ b/apps/web/src/components/admin/moderation/automationPage.tsx
@@ -103,6 +103,31 @@ export default function AutomationPage() {
           <AdminStat label="Failed" value={data.counts.failed} />
           <AdminStat label="Cleared today" value={data.counts.clearedToday} />
         </AdminStatGrid>
+        <AdminSection
+          title="Listing decisions"
+          description={
+            data.listingAutomation.sampleSize
+              ? `Last ${data.listingAutomation.sampleSize} completed checks`
+              : "No completed checks"
+          }
+        >
+          <AdminStatGrid>
+            <AdminStat
+              label="Automatic rate"
+              value={
+                data.listingAutomation.rate === null
+                  ? "—"
+                  : `${data.listingAutomation.rate}%`
+              }
+            />
+            <AdminStat
+              label="Automatic"
+              value={data.listingAutomation.automatic}
+            />
+            <AdminStat label="Manual" value={data.listingAutomation.manual} />
+            <AdminStat label="Failed" value={data.listingAutomation.failed} />
+          </AdminStatGrid>
+        </AdminSection>
         {activeRun.data.run ? (
           <AdminSection
             title={`Active listing retry · Run #${activeRun.data.run.id}`}

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -215,8 +215,9 @@ fills supported creation facts after local code has settled Bottle identity. It
 does not run for structured input or a deterministic match. A failed or empty
 read is recorded and classification continues with a fresh page-read allowance.
 
-Ignored input does not run the agent. An exact stored reference may use the
-preflight above. All other reference decisions use one bounded agent loop.
+Explicit bundle, multi-bottle, and damaged-condition names are ignored before
+text extraction. Other ignored input does not run the agent. An exact stored
+reference may use the preflight above. All other reference decisions use one bounded agent loop.
 Deterministic identifiers such as SMWS are input anchors, not bypasses.
 
 ## Audit Safety

--- a/docs/research/bottle-classifier-evaluation-2026-09.md
+++ b/docs/research/bottle-classifier-evaluation-2026-09.md
@@ -39,7 +39,7 @@ not just the pass count.
 
 ## Changes we kept
 
-Six changes solved a specific problem without adding broad instructions:
+Seven changes solved a specific problem without adding broad instructions:
 
 1. **Reject an unsupported cask-specific match.** Luna repeatedly matched a
    general product to a Bottle whose cask code appeared only in the candidate
@@ -71,6 +71,11 @@ Six changes solved a specific problem without adding broad instructions:
    `rawLabelText`. It now passes that text through so a visible code is not lost
    merely because it was omitted from a structured identity field. This adds no
    model work and does not decide what the code means.
+7. **Close explicit multi-item listings before extraction.** Numeric bottle
+   counts and structural names such as a combo pack or trilogy set now bypass
+   text extraction as well as Luna. A selected production keyword sample rose
+   from 16/37 to 26/37 recognized listings. The ten added cases use zero model
+   tokens, but they are too few to materially change the whole queue alone.
 
 These rules contain no product names from the test cases. They rely on accepted
 Peated references, exact identifiers, and the source URL already supplied with
@@ -115,6 +120,34 @@ Broad prompt changes and broad source-page reading did not hold up:
 
 These results favor small code checks for facts Peated already knows. Extra
 prompt text and extra model passes need a stronger measured gain.
+
+## Production moderation snapshot
+
+A read-only snapshot on September 4, 2026 found 12,738 actionable listing
+proposals. About 64% were errors, 30% proposed a new Bottle, and 6% were
+inconclusive. Existing matches and corrections together were below 1%.
+
+Provider budget limits caused 99 of 100 oldest sampled errors and 96 of 100
+newest sampled errors. Four other recent errors reached the eight-turn limit.
+The first work needed for an 80% automatic rate is therefore operational:
+restore provider capacity, then retry the failed listings under the current
+Luna configuration. Classifier wording cannot resolve an input that never gets
+a model response.
+
+The 100 most recent completed listing decisions in moderation history were 47
+automatic and 53 manual. That history excludes ignored listings, so it is not
+the true incoming automation rate. The Automation page now calculates the rate
+from the last 100 completed classifier attempts, including automatic ignores
+and failures.
+
+The recent creation sample also points to a narrower follow-up. Twenty-one of
+100 queued creation records had no stored blocker but still had an older
+`automationEligible: false` result; all were Terra runs from August 14. In the
+same sample, unsupported ABV was the most common individual evidence gap. A
+safe experiment must prove that supported facts separate the proposed Bottle
+from every nearby candidate and must omit any unsupported optional field before
+automatic creation. Simply removing the evidence blocker would risk duplicate
+or inaccurate Bottles.
 
 ## Corrections to the checks
 

--- a/packages/bottle-classifier/evals/experiments/C27-multi-item-preflight.md
+++ b/packages/bottle-classifier/evals/experiments/C27-multi-item-preflight.md
@@ -1,0 +1,66 @@
+# C27: Ignore explicit multi-item listings before extraction
+
+**Decision: Accepted.**
+
+## Problem
+
+Gift sets, bundles, and multi-bottle listings do not identify one Bottle. The
+classifier already ignored several clear title patterns, but only after text
+extraction. Two structural forms in the production review queue were also
+missing: an explicit bottle count such as `8 Bottles`, and count words such as
+`Dual Pack`, `Combo Pack`, or `Trilogy Set`.
+
+This matters during an outage. On September 4, 2026, provider budget errors
+accounted for 99 of 100 oldest sampled errors and 96 of 100 newest sampled
+errors. A listing that depends on extraction cannot reach the existing ignore
+rule while that provider call is failing.
+
+## Change
+
+- Recognize a numeric bottle count.
+- Recognize `dual`, `duo`, `trio`, `trilogy`, or `combo` followed by a pack,
+  set, bundle, or collection word.
+- Run bundle, multi-bottle, and damaged-condition title checks before text
+  extraction when no extraction was supplied by the caller.
+
+The early check does not include the broader non-whisky rule. A whisky title
+can contain another spirit word as a maturation fact, so that rule still waits
+for extraction.
+
+## Production sample
+
+Read-only queue searches for `gift`, `pack`, `bottles`, `bundle`, and `sampler`
+returned 37 distinct actionable listings. This was a selected keyword sample,
+not an estimate of the whole queue.
+
+| Measure                                 | Before | After |
+| --------------------------------------- | -----: | ----: |
+| Listings recognized as multi-item       |  16/37 | 26/37 |
+| Listings newly recognized               |      — |    10 |
+| Text extraction for recognized listings |      1 |     0 |
+| Classifier-agent calls                  |      0 |     0 |
+| Model tokens after the change           |      — |     0 |
+| Model cost after the change             |      — |    $0 |
+
+The ten added cases were three structural pack names and seven titles that
+stated `8 Bottles`. Existing bundle and sampler cases remained recognized.
+`Bottled in Bond` and `The Gifted Horse` are negative controls and continue to
+the classifier.
+
+Wall-clock savings were not measured because the sampled production records
+were inspected without rerunning paid extraction. The change removes one text
+extraction request from every title it recognizes.
+
+## Verification
+
+- The focused classifier tests pass, including the positive and negative
+  controls.
+- Package type checking passes.
+- No live Luna run is needed: the accepted path makes no model request and the
+  test asserts that extraction, catalog search, and the classifier agent are
+  not called.
+
+## Limit
+
+This clears obvious noise cheaply, but the sample shows only ten additional
+queue items. It cannot by itself move overall automation close to 80%.

--- a/packages/bottle-classifier/evals/experiments/README.md
+++ b/packages/bottle-classifier/evals/experiments/README.md
@@ -66,6 +66,7 @@ their records remain. Test-case corrections are separate from classifier changes
 | [C24: Subject-labeled page passages](./C24-subject-labeled-page-passages.md)         | Sort exact page passages into whole-product and component evidence                   | Stopped: exact producer page made both targets pass without the change         |
 | [C25: Page read after search exhaustion](./C25-page-read-after-search-exhaustion.md) | Tell Luna when its page-read allowance remains after search is exhausted             | Rejected: no target gain, two lost judgments, and 6.6% higher cost             |
 | [C26: Single-cask examples](./C26-single-cask-examples.md)                           | Explain true, false, and unknown values beside the output field                      | Inconclusive: focused gain cost more; broad runs used different code           |
+| [C27: Multi-item preflight](./C27-multi-item-preflight.md)                           | Ignore explicit multi-item titles before text extraction                             | Accepted: ten more sampled listings recognized with zero model work            |
 
 C09 and C10 add narrow checks after Luna, and C11 removes model work for an
 identity Peated has already accepted. The measurement and test-case corrections

--- a/packages/bottle-classifier/evals/experiments/checklist.md
+++ b/packages/bottle-classifier/evals/experiments/checklist.md
@@ -305,6 +305,14 @@ and cases with different Bottle names from the failure that led to it.
       the comparison still does not isolate the examples. See
       [C26 results](./C26-single-cask-examples.md).
 
+- [x] **C27 — Ignore explicit multi-item listings before extraction.**
+      **Accepted.** Numeric bottle counts and structural pack or set names now
+      close before text extraction. A read-only production keyword sample rose
+      from 16/37 to 26/37 recognized listings, adding ten cases. Each recognized
+      title now uses zero model tokens and $0 in model cost. `Bottled in Bond`
+      and `The Gifted Horse` remain negative controls. See
+      [C27 results](./C27-multi-item-preflight.md).
+
 ## Current stopping point
 
 C09 and C10 improve checks after Luna, while C11 removes model work for Bottle
@@ -332,6 +340,28 @@ so the apparent two-pass loss and unsupported exact-cask creation cannot be
 assigned to the examples. The unsafe output is still a valid failure. The
 descriptions were reverted until a same-revision comparison can establish a
 net gain.
+
+## Reach 80% automatic moderation
+
+These items use completed classifier attempts as the denominator. Automatic
+ignores, matches, and creations count; failures and decisions made by a person
+do not.
+
+- [x] **Q01 — Measure the real rate.** The Automation page now reports the last
+      100 completed listing checks, including ignored listings and failures.
+- [x] **Q02 — Remove obvious work before model calls.** C27 moves explicit
+      multi-item and damaged-condition names before text extraction.
+- [ ] **Q03 — Recover provider-budget failures in a bounded run.** Restore
+      production model capacity, retry 100 errored listings with full evidence,
+      and record automatic, review, and failed counts before retrying more.
+- [ ] **Q04 — Recheck stale creation proposals with Luna.** Run 100 older Terra
+      creation proposals through the current full path. Review every automatic
+      creation and record cost, tokens, time, and the resulting automatic rate.
+- [ ] **C28 — Allow supported creation while omitting unsupported optional
+      facts.** Require the proposed identity to have an externally supported
+      difference from every nearby candidate. Drop any optional field without
+      support before writing. Compare with cases where ABV, year, or edition is
+      the only fact that prevents a duplicate.
 
 ## Completion rule
 

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -1151,11 +1151,14 @@ describe("createBottleClassifier", () => {
     expect(runBottleClassifierAgent).not.toHaveBeenCalled();
   });
 
-  test("auto ignores multi-pack listings even when extraction finds a bottle identity", async () => {
+  test("auto ignores multi-pack listings before extracting bottle identity", async () => {
     const runBottleClassifierAgent = vi.fn();
     const searchBottles = vi.fn(async (): Promise<BottleCandidate[]> => []);
+    const extractFromText = vi.fn(async () =>
+      Promise.resolve(buffaloTraceStraightBourbonIdentity),
+    );
     const { classifier } = createTestClassifier({
-      extractedIdentity: buffaloTraceStraightBourbonIdentity,
+      extractFromText,
       searchBottles,
       runBottleClassifierAgent,
     });
@@ -1171,18 +1174,90 @@ describe("createBottleClassifier", () => {
       reason:
         "Reference is a bundle or multi-bottle listing, not a single bottle listing.",
       artifacts: {
-        extractedIdentity: buffaloTraceStraightBourbonIdentity,
+        extractedIdentity: null,
       },
     });
+    expect(extractFromText).not.toHaveBeenCalled();
     expect(searchBottles).not.toHaveBeenCalled();
     expect(runBottleClassifierAgent).not.toHaveBeenCalled();
   });
 
-  test("auto ignores bundle listings even when extraction finds a bottle identity", async () => {
+  test.each([
+    "Buffalo Trace Full Collection - 8 Bottles",
+    "Buffalo Trace and Eagle Rare Combo Pack",
+    "Buffalo Trace Trilogy Set",
+  ])("auto ignores explicit multi-bottle listing %s", async (name) => {
     const runBottleClassifierAgent = vi.fn();
     const searchBottles = vi.fn(async (): Promise<BottleCandidate[]> => []);
+    const extractFromText = vi.fn(async () =>
+      Promise.resolve(buffaloTraceStraightBourbonIdentity),
+    );
     const { classifier } = createTestClassifier({
-      extractedIdentity: buffaloTraceStraightBourbonIdentity,
+      extractFromText,
+      searchBottles,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: { name },
+    });
+
+    expect(result).toMatchObject({
+      status: "ignored",
+      reason:
+        "Reference is a bundle or multi-bottle listing, not a single bottle listing.",
+    });
+    expect(extractFromText).not.toHaveBeenCalled();
+    expect(searchBottles).not.toHaveBeenCalled();
+    expect(runBottleClassifierAgent).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    "Garrison Brothers Bottled in Bond Bourbon",
+    "Orphan Barrel The Gifted Horse",
+  ])(
+    "does not treat nearby product wording as a multi-item listing: %s",
+    async (name) => {
+      const runBottleClassifierAgent = vi.fn(
+        async (): Promise<ReasoningResult> => ({
+          decision: {
+            action: "no_match",
+            rationale: "No matching Bottle was found.",
+            identityScope: "product",
+            observation: null,
+            matchedBottleId: null,
+            candidateBottleIds: [],
+            proposedBottle: null,
+          },
+          artifacts: {
+            extractedIdentity: buffaloTraceStraightBourbonIdentity,
+            searchEvidence: [],
+            candidates: [],
+            resolvedEntities: [],
+          },
+        }),
+      );
+      const { classifier } = createTestClassifier({
+        extractedIdentity: buffaloTraceStraightBourbonIdentity,
+        runBottleClassifierAgent,
+      });
+
+      await classifier.classifyBottleReference({
+        reference: { name },
+      });
+
+      expect(runBottleClassifierAgent).toHaveBeenCalledOnce();
+    },
+  );
+
+  test("auto ignores bundle listings before extracting bottle identity", async () => {
+    const runBottleClassifierAgent = vi.fn();
+    const searchBottles = vi.fn(async (): Promise<BottleCandidate[]> => []);
+    const extractFromText = vi.fn(async () =>
+      Promise.resolve(buffaloTraceStraightBourbonIdentity),
+    );
+    const { classifier } = createTestClassifier({
+      extractFromText,
       searchBottles,
       runBottleClassifierAgent,
     });
@@ -1198,18 +1273,22 @@ describe("createBottleClassifier", () => {
       reason:
         "Reference is a bundle or multi-bottle listing, not a single bottle listing.",
       artifacts: {
-        extractedIdentity: buffaloTraceStraightBourbonIdentity,
+        extractedIdentity: null,
       },
     });
+    expect(extractFromText).not.toHaveBeenCalled();
     expect(searchBottles).not.toHaveBeenCalled();
     expect(runBottleClassifierAgent).not.toHaveBeenCalled();
   });
 
-  test("auto ignores damaged-condition listings even when extraction finds a bottle identity", async () => {
+  test("auto ignores damaged-condition listings before extracting bottle identity", async () => {
     const runBottleClassifierAgent = vi.fn();
     const searchBottles = vi.fn(async (): Promise<BottleCandidate[]> => []);
+    const extractFromText = vi.fn(async () =>
+      Promise.resolve(blantonsOriginalIdentity),
+    );
     const { classifier } = createTestClassifier({
-      extractedIdentity: blantonsOriginalIdentity,
+      extractFromText,
       searchBottles,
       runBottleClassifierAgent,
     });
@@ -1225,9 +1304,10 @@ describe("createBottleClassifier", () => {
       reason:
         "Reference describes a damaged or non-standard sale-condition bottle, not a standard bottle listing.",
       artifacts: {
-        extractedIdentity: blantonsOriginalIdentity,
+        extractedIdentity: null,
       },
     });
+    expect(extractFromText).not.toHaveBeenCalled();
     expect(searchBottles).not.toHaveBeenCalled();
     expect(runBottleClassifierAgent).not.toHaveBeenCalled();
   });

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -57,6 +57,7 @@ import {
 import {
   finalizeBottleReferenceClassification,
   getAutoIgnoreBottleReferenceReason,
+  getPreExtractionAutoIgnoreBottleReferenceReason,
 } from "./reviewPolicy";
 import {
   buildAgentInput,
@@ -1004,6 +1005,24 @@ export function createBottleClassifier(
     candidateExpansion: CandidateExpansionMode;
     allowAutoIgnore?: boolean;
   }) => {
+    const preExtractionAutoIgnoreReason =
+      suppliedExtractedIdentity === undefined && allowAutoIgnore
+        ? getPreExtractionAutoIgnoreBottleReferenceReason(reference.name)
+        : null;
+    if (preExtractionAutoIgnoreReason) {
+      return {
+        artifacts: buildBottleClassificationArtifacts({
+          extractedIdentity: null,
+          extractedIdentitySource: null,
+          imageEvidence: imageEvidence ?? null,
+          searchEvidence: options.initialSearchEvidence ?? [],
+        }),
+        autoIgnoreReason: preExtractionAutoIgnoreReason,
+        deterministicDecision: null,
+        webSearchBudget: createBottleWebSearchBudget(options.maxSearchQueries),
+      };
+    }
+
     const deterministicIdentitySeed = getDeterministicIdentitySeed(reference);
     const extractedReference =
       suppliedExtractedIdentity !== undefined

--- a/packages/bottle-classifier/src/internal/policy.ts
+++ b/packages/bottle-classifier/src/internal/policy.ts
@@ -1,5 +1,6 @@
 export {
   finalizeBottleReferenceClassification,
   getAutoIgnoreBottleReferenceReason,
+  getPreExtractionAutoIgnoreBottleReferenceReason,
   shouldAutoIgnoreBottleReference,
 } from "../reviewPolicy";

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -49,7 +49,9 @@ const MULTI_ITEM_REFERENCE_PATTERNS = [
   GIFT_SET_PACKAGING_KEYWORDS,
   /\bbundle\b/i,
   /\b(?:sampler|tasting|variety)\s+(?:pack|set|bundle)\b/i,
+  /\b(?:dual|duo|trio|trilogy|combo)\s+(?:pack|set|bundle|collection)\b/i,
   /\b\d+\s*(?:-|x)?\s*pack\b/i,
+  /\b\d+\s+bottles?\b/i,
   /\b(?:pack|set|case)\s+of\s+\d+\b/i,
   /\b\d+\s*x\s*\d+(?:\.\d+)?\s?(?:ml|cl|l|oz)\b/i,
 ] as const;
@@ -896,6 +898,30 @@ export function shouldAutoIgnoreBottleReference(
   );
 }
 
+export function getPreExtractionAutoIgnoreBottleReferenceReason(
+  referenceName: string,
+): string | null {
+  const normalizedName = normalizeString(referenceName).toLowerCase();
+
+  if (
+    MULTI_ITEM_REFERENCE_PATTERNS.some((pattern) =>
+      pattern.test(normalizedName),
+    )
+  ) {
+    return "Reference is a bundle or multi-bottle listing, not a single bottle listing.";
+  }
+
+  if (
+    NON_STANDARD_CONDITION_REFERENCE_PATTERNS.some((pattern) =>
+      pattern.test(normalizedName),
+    )
+  ) {
+    return "Reference describes a damaged or non-standard sale-condition bottle, not a standard bottle listing.";
+  }
+
+  return null;
+}
+
 export function getAutoIgnoreBottleReferenceReason(
   referenceName: string,
   extractedIdentity: BottleClassificationArtifacts["extractedIdentity"],
@@ -920,23 +946,7 @@ export function getAutoIgnoreBottleReferenceReason(
     }
   }
 
-  if (
-    MULTI_ITEM_REFERENCE_PATTERNS.some((pattern) =>
-      pattern.test(normalizedName),
-    )
-  ) {
-    return "Reference is a bundle or multi-bottle listing, not a single bottle listing.";
-  }
-
-  if (
-    NON_STANDARD_CONDITION_REFERENCE_PATTERNS.some((pattern) =>
-      pattern.test(normalizedName),
-    )
-  ) {
-    return "Reference describes a damaged or non-standard sale-condition bottle, not a standard bottle listing.";
-  }
-
-  return null;
+  return getPreExtractionAutoIgnoreBottleReferenceReason(referenceName);
 }
 
 export function finalizeBottleReferenceClassification({


### PR DESCRIPTION
Obvious bundles and damaged listings currently reach text extraction before the classifier can ignore them, so they still spend model work and cannot close during provider failures. This change moves those structural checks ahead of extraction and adds explicit bottle-count, combo-pack, and trilogy-set forms found in the production queue. A selected 37-listing keyword sample rises from 16 to 26 recognized items; recognized titles now use zero model tokens. `Bottled in Bond` and `The Gifted Horse` remain covered as negative controls.

The Moderation Automation page now reports automatic, manual, and failed outcomes across the last 100 completed listing checks, including ignored listings. This gives the 80% automation goal a visible measure. The research record also captures the September 4 queue snapshot: provider budget limits caused 195 of 200 sampled errors, so the next step is a bounded recovery run before broader classifier tuning.

The classifier suite passes 437 tests. The focused moderation route tests and server, web, and classifier type checks also pass.
