### PR TITLE
fix(collections): keep Bottle counts correct

### DIFF
--- a/apps/server/src/lib/collectionBottleCounts.test.ts
+++ b/apps/server/src/lib/collectionBottleCounts.test.ts
@@ -1,0 +1,260 @@
+import { db } from "@peated/server/db";
+import { getPostgresConnectionConfig } from "@peated/server/db/connection";
+import { collectionBottles, collections } from "@peated/server/db/schema";
+import { eq } from "drizzle-orm";
+import pg from "pg";
+import {
+  checkCollectionBottleCounts,
+  repairCollectionBottleCount,
+  updateCollectionBottleCounts,
+} from "./collectionBottleCounts";
+
+const { Client } = pg;
+type NodePgClient = InstanceType<typeof Client>;
+
+async function waitForSessionBlockedBy(
+  observer: NodePgClient,
+  blockerPid: number,
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const result = await observer.query<{ pid: number }>(
+      `SELECT pid
+       FROM pg_stat_activity
+       WHERE $1 = ANY(pg_blocking_pids(pid))
+       LIMIT 1`,
+      [blockerPid],
+    );
+    if (result.rows.length) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for the Collection repair lock.");
+}
+
+describe("Collection Bottle counts", () => {
+  test("counts a membership added in the same transaction", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      createdById: defaults.user.id,
+      totalBottles: 0,
+    });
+    const bottle = await fixtures.Bottle();
+
+    await db.transaction(async (tx) => {
+      await tx.insert(collectionBottles).values({
+        collectionId: collection.id,
+        bottleId: bottle.id,
+      });
+      await updateCollectionBottleCounts(tx, [], [collection.id]);
+    });
+
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, collection.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(checkCollectionBottleCounts([collection.id])).resolves.toEqual(
+      [],
+    );
+  });
+
+  test("repairs an old undercount when removing a membership", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      createdById: defaults.user.id,
+      totalBottles: 0,
+    });
+    const removedBottle = await fixtures.Bottle();
+    const retainedBottle = await fixtures.Bottle();
+    await db.insert(collectionBottles).values([
+      { collectionId: collection.id, bottleId: removedBottle.id },
+      { collectionId: collection.id, bottleId: retainedBottle.id },
+    ]);
+
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(collectionBottles)
+        .where(eq(collectionBottles.bottleId, removedBottle.id));
+      await updateCollectionBottleCounts(tx, [collection.id], []);
+    });
+
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, collection.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(checkCollectionBottleCounts([collection.id])).resolves.toEqual(
+      [],
+    );
+  });
+
+  test("rolls back earlier changes when a Collection is missing", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      createdById: defaults.user.id,
+      totalBottles: 0,
+    });
+    const missingCollectionId = 2_147_483_647;
+
+    await expect(
+      db.transaction((tx) =>
+        updateCollectionBottleCounts(
+          tx,
+          [],
+          [collection.id, missingCollectionId],
+        ),
+      ),
+    ).rejects.toThrow(
+      `Cannot update Bottle count: Collection ${missingCollectionId} is missing.`,
+    );
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, collection.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 0 });
+  });
+
+  test("counts memberships saved at the same time", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      createdById: defaults.user.id,
+      totalBottles: 0,
+    });
+    const bottles = await Promise.all([fixtures.Bottle(), fixtures.Bottle()]);
+
+    await Promise.all(
+      bottles.map((bottle) =>
+        db.transaction(async (tx) => {
+          await tx.insert(collectionBottles).values({
+            collectionId: collection.id,
+            bottleId: bottle.id,
+          });
+          await updateCollectionBottleCounts(tx, [], [collection.id]);
+        }),
+      ),
+    );
+
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, collection.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 2 });
+  });
+
+  test("finds and repairs wrong saved counts", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const wrong = await fixtures.Collection({
+      createdById: defaults.user.id,
+      name: "Wrong count",
+      totalBottles: 8,
+    });
+    const correctEmpty = await fixtures.Collection({
+      createdById: defaults.user.id,
+      name: "Correct empty",
+      totalBottles: 0,
+    });
+    const bottle = await fixtures.Bottle();
+    await db.insert(collectionBottles).values({
+      collectionId: wrong.id,
+      bottleId: bottle.id,
+    });
+
+    await expect(
+      checkCollectionBottleCounts([wrong.id, correctEmpty.id]),
+    ).resolves.toEqual([
+      { collectionId: wrong.id, savedCount: 8, actualCount: 1 },
+    ]);
+    await expect(checkCollectionBottleCounts([])).resolves.toEqual([]);
+
+    await expect(repairCollectionBottleCount(wrong.id)).resolves.toEqual({
+      collectionId: wrong.id,
+      savedCount: 8,
+      actualCount: 1,
+    });
+    await expect(
+      checkCollectionBottleCounts([wrong.id, correctEmpty.id]),
+    ).resolves.toEqual([]);
+    await expect(
+      repairCollectionBottleCount(2_147_483_647),
+    ).resolves.toBeNull();
+  });
+
+  test("recounts after an earlier membership change commits", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      createdById: defaults.user.id,
+      totalBottles: 0,
+    });
+    const existingBottle = await fixtures.Bottle();
+    const addedBottle = await fixtures.Bottle();
+    await db.insert(collectionBottles).values({
+      collectionId: collection.id,
+      bottleId: existingBottle.id,
+    });
+
+    const writer = new Client(getPostgresConnectionConfig());
+    const observer = new Client(getPostgresConnectionConfig());
+    let writerCommitted = false;
+    let repair: ReturnType<typeof repairCollectionBottleCount> | null = null;
+
+    await writer.connect();
+    await observer.connect();
+    try {
+      await writer.query("BEGIN");
+      const writerPid = (
+        await writer.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")
+      ).rows[0]?.pid;
+      if (!writerPid) throw new Error("Unable to load Collection writer pid.");
+
+      await writer.query("SELECT id FROM collection WHERE id = $1 FOR UPDATE", [
+        collection.id,
+      ]);
+      await writer.query(
+        "INSERT INTO collection_bottle (collection_id, bottle_id) VALUES ($1, $2)",
+        [collection.id, addedBottle.id],
+      );
+      await writer.query(
+        "UPDATE collection SET total_bottles = total_bottles + 1 WHERE id = $1",
+        [collection.id],
+      );
+
+      repair = repairCollectionBottleCount(collection.id);
+      void repair.catch(() => undefined);
+      await waitForSessionBlockedBy(observer, writerPid);
+
+      await writer.query("COMMIT");
+      writerCommitted = true;
+
+      await expect(repair).resolves.toEqual({
+        collectionId: collection.id,
+        savedCount: 1,
+        actualCount: 2,
+      });
+    } finally {
+      if (!writerCommitted) {
+        await writer.query("ROLLBACK").catch(() => undefined);
+      }
+      if (repair) await repair.catch(() => undefined);
+      await writer.end();
+      await observer.end();
+    }
+
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, collection.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 2 });
+  });
+});

--- a/apps/server/src/lib/collectionBottleCounts.ts
+++ b/apps/server/src/lib/collectionBottleCounts.ts
@@ -1,0 +1,148 @@
+import { db, type AnyDatabase, type AnyTransaction } from "@peated/server/db";
+import { collectionBottles, collections } from "@peated/server/db/schema";
+import { and, eq, gte, inArray, sql } from "drizzle-orm";
+
+export type WrongCollectionBottleCount = {
+  collectionId: number;
+  savedCount: number;
+  actualCount: number;
+};
+
+function uniqueSorted(values: readonly number[]): number[] {
+  return Array.from(new Set(values)).sort((left, right) => left - right);
+}
+
+function addCountChanges(
+  changes: Map<number, number>,
+  collectionIds: readonly number[],
+  change: number,
+) {
+  for (const collectionId of collectionIds) {
+    changes.set(collectionId, (changes.get(collectionId) ?? 0) + change);
+  }
+}
+
+type CountQueryRow = {
+  collectionId: number | string;
+  savedCount: number | string;
+  actualCount: number | string;
+};
+
+async function findWrongCollectionBottleCounts(
+  database: AnyDatabase,
+  collectionIds?: readonly number[],
+): Promise<WrongCollectionBottleCount[]> {
+  const ids =
+    collectionIds === undefined ? undefined : uniqueSorted(collectionIds);
+  if (ids?.length === 0) return [];
+  const collectionFilter = ids ? inArray(collections.id, ids) : sql`TRUE`;
+  const membershipFilter = ids
+    ? inArray(collectionBottles.collectionId, ids)
+    : sql`TRUE`;
+
+  const result = await database.execute<CountQueryRow>(sql`
+    WITH actual_counts AS (
+      SELECT ${collectionBottles.collectionId} AS collection_id, COUNT(*) AS total
+      FROM ${collectionBottles}
+      WHERE ${membershipFilter}
+      GROUP BY ${collectionBottles.collectionId}
+    )
+    SELECT
+      ${collections.id} AS "collectionId",
+      ${collections.totalBottles} AS "savedCount",
+      COALESCE(actual_counts.total, 0) AS "actualCount"
+    FROM ${collections}
+    LEFT JOIN actual_counts ON actual_counts.collection_id = ${collections.id}
+    WHERE ${collectionFilter}
+      AND ${collections.totalBottles} <> COALESCE(actual_counts.total, 0)
+    ORDER BY ${collections.id}
+  `);
+
+  return result.rows.map((row) => ({
+    collectionId: Number(row.collectionId),
+    savedCount: Number(row.savedCount),
+    actualCount: Number(row.actualCount),
+  }));
+}
+
+async function repairExistingCollectionBottleCount(
+  tx: AnyTransaction,
+  collectionId: number,
+): Promise<WrongCollectionBottleCount | null> {
+  const [difference] = await findWrongCollectionBottleCounts(tx, [
+    collectionId,
+  ]);
+  if (!difference) return null;
+
+  await tx
+    .update(collections)
+    .set({ totalBottles: difference.actualCount })
+    .where(eq(collections.id, collectionId));
+  return difference;
+}
+
+/** Saves Collection membership changes in the caller's transaction. */
+export async function updateCollectionBottleCounts(
+  tx: AnyTransaction,
+  collectionIdsBefore: readonly number[],
+  collectionIdsAfter: readonly number[],
+): Promise<void> {
+  const changes = new Map<number, number>();
+  addCountChanges(changes, collectionIdsBefore, -1);
+  addCountChanges(changes, collectionIdsAfter, 1);
+
+  for (const [collectionId, change] of Array.from(changes)
+    .filter(([, change]) => change !== 0)
+    .sort(([left], [right]) => left - right)) {
+    // Membership writes own this count. Repair an old undercount before it can
+    // make a valid removal or Bottle merge fail.
+    const [updatedCollection] = await tx
+      .update(collections)
+      .set({ totalBottles: sql`${collections.totalBottles} + ${change}` })
+      .where(
+        and(
+          eq(collections.id, collectionId),
+          change < 0 ? gte(collections.totalBottles, -change) : undefined,
+        ),
+      )
+      .returning({ id: collections.id });
+    if (updatedCollection) continue;
+
+    const [collection] = await tx
+      .select({ id: collections.id })
+      .from(collections)
+      .where(eq(collections.id, collectionId))
+      .limit(1)
+      .for("update");
+    if (!collection) {
+      throw new Error(
+        `Cannot update Bottle count: Collection ${collectionId} is missing.`,
+      );
+    }
+
+    await repairExistingCollectionBottleCount(tx, collectionId);
+  }
+}
+
+/** Checks saved Bottle counts against Collection membership rows. */
+export async function checkCollectionBottleCounts(
+  collectionIds?: readonly number[],
+): Promise<WrongCollectionBottleCount[]> {
+  return findWrongCollectionBottleCounts(db, collectionIds);
+}
+
+/** Repairs one Collection after taking the row lock used by membership writes. */
+export async function repairCollectionBottleCount(
+  collectionId: number,
+): Promise<WrongCollectionBottleCount | null> {
+  return db.transaction(async (tx) => {
+    const [collection] = await tx
+      .select({ id: collections.id })
+      .from(collections)
+      .where(eq(collections.id, collectionId))
+      .for("update");
+    if (!collection) return null;
+
+    return repairExistingCollectionBottleCount(tx, collectionId);
+  });
+}

--- a/apps/server/src/lib/mergeBottles.test.ts
+++ b/apps/server/src/lib/mergeBottles.test.ts
@@ -73,8 +73,10 @@ describe("exact Bottle merges", () => {
     const destinationGroupId = destination.groupId!;
     const user = await fixtures.User();
     const externalSite = await fixtures.ExternalSite();
-    const collectionWithCollision = await fixtures.Collection();
-    const collectionToMove = await fixtures.Collection();
+    const collectionWithCollision = await fixtures.Collection({
+      totalBottles: 2,
+    });
+    const collectionToMove = await fixtures.Collection({ totalBottles: 1 });
     const flightWithCollision = await fixtures.Flight();
     const sourceAlias = await fixtures.BottleReference({
       bottleId: source.id,
@@ -327,6 +329,16 @@ describe("exact Bottle merges", () => {
         .from(collectionBottles)
         .where(eq(collectionBottles.collectionId, collectionToMove.id)),
     ).toEqual([expect.objectContaining({ bottleId: destination.id })]);
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, collectionWithCollision.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, collectionToMove.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
     expect(
       await db
         .select()
@@ -654,7 +666,7 @@ describe("exact Bottle merges", () => {
     const destination = await fixtures.Bottle({
       name: "Membership Destination",
     });
-    const collection = await fixtures.Collection({ totalBottles: 2 });
+    const collection = await fixtures.Collection({ totalBottles: 0 });
     const flight = await fixtures.Flight();
 
     await db.insert(collectionBottles).values([

--- a/apps/server/src/lib/mergeBottles.ts
+++ b/apps/server/src/lib/mergeBottles.ts
@@ -17,7 +17,6 @@ import {
   bottleTombstones,
   changes,
   collectionBottles,
-  collections,
   externalReviews,
   flightBottles,
   incomingBottleDecisionLogs,
@@ -33,6 +32,7 @@ import {
   getBottleSeriesMemberships,
   updateBottleSeriesReleaseCounts,
 } from "@peated/server/lib/bottleSeriesReleaseCounts";
+import { updateCollectionBottleCounts } from "@peated/server/lib/collectionBottleCounts";
 import {
   getBottleEntityLinks,
   updateEntityBottleCounts,
@@ -187,7 +187,8 @@ async function consolidateCollectionMemberships(
     else rowsByCollectionId.set(row.collectionId, [row]);
   }
 
-  const changedCollectionIds = new Set<number>();
+  const collectionIdsBefore = rows.map(({ collectionId }) => collectionId);
+  const collectionIdsAfter: number[] = [];
   let moved = 0;
   let collapsed = 0;
 
@@ -199,6 +200,7 @@ async function consolidateCollectionMemberships(
       ...collectionRows.filter(({ bottleId }) => bottleId === sourceBottleId),
     ];
     const survivor = preferredRows[0]!;
+    collectionIdsAfter.push(survivor.collectionId);
     const imageUrl = survivor.imageUrl?.trim()
       ? survivor.imageUrl
       : (preferredRows.find(({ imageUrl }) => imageUrl?.trim())?.imageUrl ??
@@ -209,7 +211,6 @@ async function consolidateCollectionMemberships(
       await tx
         .delete(collectionBottles)
         .where(eq(collectionBottles.id, row.id));
-      changedCollectionIds.add(row.collectionId);
       collapsed += 1;
     }
 
@@ -220,14 +221,11 @@ async function consolidateCollectionMemberships(
     if (survivor.bottleId === sourceBottleId) moved += 1;
   }
 
-  for (const collectionId of changedCollectionIds) {
-    await tx
-      .update(collections)
-      .set({
-        totalBottles: sql`(SELECT COUNT(*) FROM ${collectionBottles} WHERE ${collectionBottles.collectionId} = ${collectionId})`,
-      })
-      .where(eq(collections.id, collectionId));
-  }
+  await updateCollectionBottleCounts(
+    tx,
+    collectionIdsBefore,
+    collectionIdsAfter,
+  );
   return { moved, collapsed };
 }
 

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
@@ -15,7 +15,7 @@ describe("POST /admin/catalog/repair-bottle-counts", () => {
     await expect(
       routerClient.admin.repairBottleCounts({}, { context: { user: admin } }),
     ).resolves.toEqual({ status: "queued" });
-    expect(pushUniqueJob).toHaveBeenCalledTimes(4);
+    expect(pushUniqueJob).toHaveBeenCalledTimes(5);
     expect(pushUniqueJob).toHaveBeenNthCalledWith(
       1,
       "RepairEntityBottleCounts",
@@ -43,6 +43,14 @@ describe("POST /admin/catalog/repair-bottle-counts", () => {
     expect(pushUniqueJob).toHaveBeenNthCalledWith(
       4,
       "RepairBottleSeriesReleaseCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
+    expect(pushUniqueJob).toHaveBeenNthCalledWith(
+      5,
+      "RepairCollectionBottleCounts",
       {},
       {
         delay: 0,

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
@@ -11,7 +11,7 @@ export default procedure
     summary: "Repair saved bottle counts",
     description:
       "Check saved bottle totals and fix any that are wrong. Requires administrator privileges.",
-    operationId: "repairEntityBottleCounts",
+    operationId: "repairBottleCounts",
   })
   .input(z.object({}).strict().default({}))
   .output(z.object({ status: z.literal("queued") }).strict())
@@ -39,6 +39,13 @@ export default procedure
     );
     await pushUniqueJob(
       "RepairBottleSeriesReleaseCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
+    await pushUniqueJob(
+      "RepairCollectionBottleCounts",
       {},
       {
         delay: 0,

--- a/apps/server/src/orpc/routes/collections/bottles/create.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/create.ts
@@ -2,6 +2,7 @@ import { db } from "@peated/server/db";
 import type { CollectionBottle } from "@peated/server/db/schema";
 import { collectionBottles, collections } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
+import { updateCollectionBottleCounts } from "@peated/server/lib/collectionBottleCounts";
 import {
   getReservedCollection,
   isReservedCollectionSlug,
@@ -18,7 +19,7 @@ import {
   requireAuth,
   requireTosAccepted,
 } from "@peated/server/orpc/middleware";
-import { and, asc, eq, sql } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 import {
   findCollectionBottleEntry,
@@ -154,12 +155,7 @@ export default implement(collectionBottleCreateContract)
       if (!collectionBottle) {
         collectionBottle = await findMembership();
       } else {
-        await tx
-          .update(collections)
-          .set({
-            totalBottles: sql`${collections.totalBottles} + 1`,
-          })
-          .where(eq(collections.id, collection.id));
+        await updateCollectionBottleCounts(tx, [], [collection.id]);
       }
 
       return collectionBottle
@@ -181,15 +177,15 @@ export default implement(collectionBottleCreateContract)
         }
 
         await db.transaction(async (tx) => {
-          await tx
+          const deleted = await tx
             .delete(collectionBottles)
-            .where(eq(collectionBottles.id, collectionBottle.id));
-          await tx
-            .update(collections)
-            .set({
-              totalBottles: sql`${collections.totalBottles} - 1`,
-            })
-            .where(eq(collections.id, collection.id));
+            .where(eq(collectionBottles.id, collectionBottle.id))
+            .returning({ collectionId: collectionBottles.collectionId });
+          await updateCollectionBottleCounts(
+            tx,
+            deleted.map(({ collectionId }) => collectionId),
+            [],
+          );
         });
       };
 

--- a/apps/server/src/orpc/routes/collections/bottles/delete.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/delete.test.ts
@@ -40,6 +40,14 @@ describe("DELETE /users/:user/collections/:collection/bottles", () => {
       },
       { context: { user: defaults.user } },
     );
+    await routerClient.collections.bottles.delete(
+      {
+        user: "me",
+        collection: collection.id,
+        bottle: bottle.id,
+      },
+      { context: { user: defaults.user } },
+    );
 
     expect(
       await db.query.collectionBottles.findFirst({
@@ -88,6 +96,37 @@ describe("DELETE /users/:user/collections/:collection/bottles", () => {
         where: eq(collectionBottles.collectionId, collection.id),
       }),
     ).toMatchObject([{ bottleId: retained.id }]);
+  });
+
+  test("repairs an old zero count while removing a Bottle", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const removed = await fixtures.Bottle();
+    const retained = await fixtures.Bottle();
+    const collection = await fixtures.Collection({
+      createdById: defaults.user.id,
+      totalBottles: 0,
+    });
+    await db.insert(collectionBottles).values([
+      { collectionId: collection.id, bottleId: removed.id },
+      { collectionId: collection.id, bottleId: retained.id },
+    ]);
+
+    await routerClient.collections.bottles.delete(
+      {
+        user: "me",
+        collection: collection.id,
+        bottle: removed.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, collection.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
   });
 
   test("rejects the removed target input", async ({ defaults, fixtures }) => {

--- a/apps/server/src/orpc/routes/collections/bottles/delete.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/delete.ts
@@ -1,6 +1,7 @@
 import { db } from "@peated/server/db";
 import { collectionBottles, collections } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
+import { updateCollectionBottleCounts } from "@peated/server/lib/collectionBottleCounts";
 import {
   getReservedCollection,
   isReservedCollectionSlug,
@@ -11,7 +12,7 @@ import {
   requireAuth,
   requireTosAccepted,
 } from "@peated/server/orpc/middleware";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { z } from "zod";
 
 export default implement(collectionBottleDeleteContract)
@@ -68,14 +69,11 @@ export default implement(collectionBottleDeleteContract)
         )
         .returning();
 
-      if (deleted.length) {
-        await tx
-          .update(collections)
-          .set({
-            totalBottles: sql`${collections.totalBottles} - ${deleted.length}`,
-          })
-          .where(eq(collections.id, collection.id));
-      }
+      await updateCollectionBottleCounts(
+        tx,
+        deleted.map(({ collectionId }) => collectionId),
+        [],
+      );
     });
 
     return {};

--- a/apps/server/src/orpc/routes/collections/bottles/image-update.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/image-update.test.ts
@@ -1,5 +1,9 @@
 import { db } from "@peated/server/db";
-import { bottles, collectionBottles } from "@peated/server/db/schema";
+import {
+  bottles,
+  collectionBottles,
+  collections,
+} from "@peated/server/db/schema";
 import { createPendingImageUpload } from "@peated/server/lib/pendingUploads";
 import waitError from "@peated/server/lib/test/waitError";
 import { compressAndResizeImage } from "@peated/server/lib/uploads";
@@ -27,6 +31,7 @@ describe("PUT /users/:user/collections/:collection/bottles/:collectionBottle/ima
     const libraryCollection = await fixtures.Collection({
       name: "Library",
       createdById: defaults.user.id,
+      totalBottles: 1,
     });
     const [entry] = await db
       .insert(collectionBottles)
@@ -70,6 +75,11 @@ describe("PUT /users/:user/collections/:collection/bottles/:collectionBottle/ima
       /^\/uploads\/collection-bottles\/collection_bottle-\d+-pending-upload-.+\.webp$/,
     );
     expect(canonicalBottle?.imageUrl).toBe("/uploads/bottles/canonical.webp");
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, libraryCollection.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
   });
 
   test("returns the Bottle after replacing its entry image", async ({

--- a/apps/server/src/orpc/routes/collections/bottles/update.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/update.test.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { collectionBottles } from "@peated/server/db/schema";
+import { collectionBottles, collections } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
@@ -27,6 +27,7 @@ describe("PATCH /users/:user/collections/:collection/bottles/:collectionBottle",
     const libraryCollection = await fixtures.Collection({
       name: "Library",
       createdById: defaults.user.id,
+      totalBottles: 1,
     });
     const [entry] = await db
       .insert(collectionBottles)
@@ -67,6 +68,11 @@ describe("PATCH /users/:user/collections/:collection/bottles/:collectionBottle",
     expect(cleared.id).toBe(entry.id);
     expect(cleared.status).toBeNull();
     expect(row.status).toBeNull();
+    await expect(
+      db.query.collections.findFirst({
+        where: eq(collections.id, libraryCollection.id),
+      }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
   });
 
   test("rejects updates by non-owner", async ({ defaults, fixtures }) => {

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -23,6 +23,7 @@ import processStorePriceMatchRetryRun from "./processStorePriceMatchRetryRun";
 import reconcileStorePriceMatchProposals from "./reconcileStorePriceMatchProposals";
 import repairBottleGroupBottleCounts from "./repairBottleGroupBottleCounts";
 import repairBottleSeriesReleaseCounts from "./repairBottleSeriesReleaseCounts";
+import repairCollectionBottleCounts from "./repairCollectionBottleCounts";
 import repairEntityBottleCounts from "./repairEntityBottleCounts";
 import repairLocationBottleCounts from "./repairLocationBottleCounts";
 import resolveStorePriceBottle from "./resolveStorePriceBottle";
@@ -60,6 +61,7 @@ registry.add(
   "RepairBottleSeriesReleaseCounts",
   repairBottleSeriesReleaseCounts,
 );
+registry.add("RepairCollectionBottleCounts", repairCollectionBottleCounts);
 registry.add("RepairEntityBottleCounts", repairEntityBottleCounts);
 registry.add("RepairLocationBottleCounts", repairLocationBottleCounts);
 registry.add(

--- a/apps/server/src/worker/jobs/repairCollectionBottleCounts.test.ts
+++ b/apps/server/src/worker/jobs/repairCollectionBottleCounts.test.ts
@@ -1,0 +1,45 @@
+import { db } from "@peated/server/db";
+import { collectionBottles, collections } from "@peated/server/db/schema";
+import { checkCollectionBottleCounts } from "@peated/server/lib/collectionBottleCounts";
+import { eq } from "drizzle-orm";
+import repairCollectionBottleCountsJob from "./repairCollectionBottleCounts";
+
+test("repairs wrong counts and is safe to run again", async ({
+  defaults,
+  fixtures,
+}) => {
+  const collection = await fixtures.Collection({
+    createdById: defaults.user.id,
+    totalBottles: 9,
+  });
+  const bottle = await fixtures.Bottle();
+  await db.insert(collectionBottles).values({
+    collectionId: collection.id,
+    bottleId: bottle.id,
+  });
+  await db
+    .update(collections)
+    .set({ totalBottles: 9 })
+    .where(eq(collections.id, collection.id));
+
+  await expect(repairCollectionBottleCountsJob({})).resolves.toEqual({
+    wrongCount: 1,
+    repairedCount: 1,
+  });
+  await expect(checkCollectionBottleCounts()).resolves.toEqual([]);
+
+  await expect(repairCollectionBottleCountsJob({})).resolves.toEqual({
+    wrongCount: 0,
+    repairedCount: 0,
+  });
+});
+
+test.each([undefined, null, [], { unexpected: true }])(
+  "rejects malformed input %#",
+  async (input) => {
+    // SAFETY: This test bypasses the type so the job can reject invalid queue input.
+    await expect(
+      repairCollectionBottleCountsJob(input as never),
+    ).rejects.toThrow();
+  },
+);

--- a/apps/server/src/worker/jobs/repairCollectionBottleCounts.ts
+++ b/apps/server/src/worker/jobs/repairCollectionBottleCounts.ts
@@ -1,0 +1,36 @@
+import {
+  checkCollectionBottleCounts,
+  repairCollectionBottleCount,
+} from "@peated/server/lib/collectionBottleCounts";
+import { logInfo } from "@peated/server/lib/log";
+import { z } from "zod";
+import type { JobPayload } from "../types";
+
+export const RepairCollectionBottleCountsJobArgsSchema = z.object({}).strict();
+
+export default async function repairCollectionBottleCountsJob(
+  input: JobPayload,
+) {
+  RepairCollectionBottleCountsJobArgsSchema.parse(input);
+
+  const wrongCounts = await checkCollectionBottleCounts();
+  let repairedCount = 0;
+
+  for (const wrongCount of wrongCounts) {
+    if (await repairCollectionBottleCount(wrongCount.collectionId)) {
+      repairedCount += 1;
+    }
+  }
+
+  logInfo("Finished Collection Bottle count repair", {
+    extra: {
+      wrongCount: wrongCounts.length,
+      repairedCount,
+    },
+  });
+
+  return {
+    wrongCount: wrongCounts.length,
+    repairedCount,
+  };
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-// TODO: how can we automate registration here without importing the job code?
 export type JobName =
   | "CapturePriceImage"
   | "CleanupPendingUploads"
@@ -24,6 +23,7 @@ export type JobName =
   | "ProcessNotification"
   | "RepairBottleGroupBottleCounts"
   | "RepairBottleSeriesReleaseCounts"
+  | "RepairCollectionBottleCounts"
   | "RepairEntityBottleCounts"
   | "RepairLocationBottleCounts"
   | "ReconcileStorePriceMatchProposals"

--- a/openspec/changes/repair-collection-bottle-counts/.openspec.yaml
+++ b/openspec/changes/repair-collection-bottle-counts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/repair-collection-bottle-counts/design.md
+++ b/openspec/changes/repair-collection-bottle-counts/design.md
@@ -1,0 +1,68 @@
+## Context
+
+`Collection.totalBottles` is the saved number of rows in `collection_bottle` for that Collection. Collection pages display the saved value. Add and remove routes change it now, while Bottle merge recounts selected collections. The existing **Check Bottle counts** action repairs other saved Bottle totals but not collections.
+
+Membership changes already use database transactions. A queued job must not be required for a normal user action to leave the count correct, and production repair must run while users keep editing collections.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep `totalBottles` correct when a membership change commits.
+- Put the count rule and repair query in one small module.
+- Change only the Collections affected by a normal write.
+- Repair old wrong totals one Collection at a time.
+- Keep the existing admin Bottle-count action as the only repair control.
+
+**Non-Goals:**
+
+- Changing collection membership, status, or image behavior.
+- Counting quantities beyond one row per Bottle and Collection.
+- Adding a general counter framework.
+- Adding a migration, CLI command, or separate admin page.
+
+## Decisions
+
+### Derive count changes from membership rows before and after the write
+
+The shared owner will accept Collection IDs represented by membership rows before and after a change. It will combine them into a change for each Collection and update only nonzero changes in Collection ID order.
+
+Creation supplies the new membership, removal supplies the deleted membership, and Bottle merge supplies its membership rows before and after duplicate cleanup. Status and image updates supply no changes because they do not create, remove, or move membership.
+
+Keeping separate arithmetic and recounts in each route was rejected because it repeats the rule and makes merge recounts vulnerable to overwriting an overlapping membership change.
+
+### Save count changes in the membership transaction
+
+Normal collection operations will update `totalBottles` before the membership transaction commits. Database row updates serialize overlapping changes to the same Collection. Operations affecting more than one Collection will update them in ascending ID order.
+
+A queued recount was rejected because a missed, delayed, or repeated job must not leave a completed user action with the wrong count.
+
+### Repair an old undercount instead of blocking a valid removal
+
+A negative change will not save a value below zero. If the guarded update cannot change an existing Collection, the owner will lock that Collection and recount it from its membership rows after the caller's membership changes. A missing Collection remains an error because it means the relationship is invalid.
+
+This also makes failed image-upload cleanup conditional on the membership row actually being removed, so an overlapping removal cannot subtract twice.
+
+### Check broadly, repair narrowly
+
+The repair job will first find Collections whose saved and actual counts differ without taking broad locks. It will then repair each candidate in its own transaction. Each repair locks one Collection row, checks its current membership again, and writes only `totalBottles` when it is still wrong.
+
+The job will use a strict empty input, be dispatched uniquely, and run from the existing **Check Bottle counts** admin action.
+
+## Risks / Trade-offs
+
+- **A repair scan reads all Collection membership rows.** → The scan is read-only; writes and locks are limited to one Collection per transaction.
+- **A Collection may change after the scan.** → The per-Collection repair locks and checks again before saving.
+- **An old count can be too low for a decrement.** → The normal write recounts that one locked Collection instead of failing or going negative.
+- **Bottle merge can affect many Collections.** → It keeps the existing transaction and changes affected Collection rows in stable order without adding another workflow.
+
+## Migration Plan
+
+1. Deploy the shared owner and all normal membership-path changes together.
+2. Deploy the repair worker through the existing admin action.
+3. Run **Check Bottle counts** after deployment to repair old Collection totals.
+4. If rollback is needed, revert the code; there is no schema or irreversible data change. A later repair run can restore totals changed while old code was active.
+
+## Open Questions
+
+None.

--- a/openspec/changes/repair-collection-bottle-counts/proposal.md
+++ b/openspec/changes/repair-collection-bottle-counts/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`Collection.totalBottles` is saved for fast display, but its rule is spread across collection routes and Bottle merge code. Old wrong totals can also become negative when a user removes a Bottle, and the existing admin repair action does not check collections.
+
+## What Changes
+
+- Define a collection's Bottle total as its number of Bottle membership rows.
+- Put normal count changes in one small owner used by collection add, remove, cleanup, and Bottle merge paths.
+- Save membership and count changes in the same transaction without relying on the queue.
+- Repair an old wrong total during a valid removal instead of blocking the user or saving a negative value.
+- Add a one-collection-at-a-time repair job to the existing admin Bottle-count action.
+- Cover additions, deletions, non-membership updates, Bottle merges, overlapping writes, and old wrong totals with integration tests.
+
+## Capabilities
+
+### New Capabilities
+
+- `collection-bottle-counts`: Correct, repairable Collection Bottle totals derived from membership rows.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Collection Bottle creation and deletion routes.
+- Cleanup after a failed Collection Bottle image upload.
+- Bottle merge handling for duplicate collection memberships.
+- The existing admin Bottle-count repair route.
+- Worker registration and tests for the Collection repair job.
+- No schema migration, CLI command, new admin control, public API change, or runtime dependency.

--- a/openspec/changes/repair-collection-bottle-counts/specs/collection-bottle-counts/spec.md
+++ b/openspec/changes/repair-collection-bottle-counts/specs/collection-bottle-counts/spec.md
@@ -1,0 +1,120 @@
+## ADDED Requirements
+
+### Requirement: Collection Bottle total source
+
+The system SHALL define a Collection Bottle total as the number of Bottle membership rows that reference that Collection. Each membership row SHALL contribute exactly one regardless of its status or image.
+
+#### Scenario: Bottle belongs to a Collection
+
+- **WHEN** a Bottle membership row references a Collection
+- **THEN** that row contributes exactly one to the Collection Bottle total
+
+#### Scenario: Membership details change
+
+- **WHEN** a membership's status or image changes without adding, removing, or moving the row
+- **THEN** the Collection Bottle total does not change
+
+### Requirement: Transactional Collection count changes
+
+The system SHALL save every Collection Bottle count change in the same transaction as the membership change that caused it. A queue job SHALL NOT be required for a normal Collection write to leave the count correct.
+
+#### Scenario: Membership is added
+
+- **WHEN** a Bottle membership is added to a Collection
+- **THEN** that Collection Bottle total increases by one in the creation transaction
+
+#### Scenario: Membership is removed
+
+- **WHEN** a Bottle membership is removed from a Collection
+- **THEN** that Collection Bottle total decreases by one in the removal transaction
+
+#### Scenario: Duplicate add is ignored
+
+- **WHEN** adding a Bottle finds that the Collection already contains it
+- **THEN** no membership or count is added
+
+#### Scenario: Failed image upload removes a new membership
+
+- **WHEN** cleanup removes a membership created for an image upload that did not finish
+- **THEN** the Collection Bottle total decreases in the cleanup transaction
+
+#### Scenario: Cleanup finds the membership already removed
+
+- **WHEN** failed-image cleanup finds that its new membership was already removed
+- **THEN** the Collection Bottle total does not change again
+
+#### Scenario: Bottle merge moves a membership
+
+- **WHEN** a Bottle merge changes a membership to the surviving Bottle without finding a duplicate in that Collection
+- **THEN** the Collection Bottle total does not change
+
+#### Scenario: Bottle merge combines duplicate memberships
+
+- **WHEN** a Bottle merge combines source and destination memberships in one Collection
+- **THEN** that Collection Bottle total decreases by one in the merge transaction
+
+### Requirement: Concurrent Collection count changes
+
+The system SHALL preserve every committed Collection Bottle count change when membership operations overlap. When one operation affects several Collections, it SHALL change those rows in ascending Collection ID order.
+
+#### Scenario: Two memberships are added concurrently
+
+- **WHEN** two transactions add different Bottles to the same Collection
+- **THEN** the saved total includes both committed memberships
+
+#### Scenario: Repair overlaps a membership change
+
+- **WHEN** a Collection repair overlaps a committed membership change
+- **THEN** the final saved total includes the committed change
+
+### Requirement: Damaged totals do not block valid membership removal
+
+The system SHALL prevent negative Collection Bottle totals. If an existing saved total is too low for a removal or Bottle merge decrement, the system SHALL repair that Collection from its current membership rows within the same transaction instead of rejecting the valid operation.
+
+#### Scenario: Removal encounters an old zero total
+
+- **WHEN** a membership is removed from a Collection whose saved total is incorrectly zero
+- **THEN** the removal commits and the Collection total is repaired to the remaining membership count
+
+#### Scenario: Referenced Collection is missing
+
+- **WHEN** a membership operation must change a Collection that no longer exists
+- **THEN** the transaction fails as an invalid relationship
+
+### Requirement: Bounded Collection Bottle count repair
+
+The system SHALL provide an administrator-started job that finds wrong Collection Bottle totals and repairs one Collection per transaction while Collection editing continues.
+
+#### Scenario: Wrong saved total
+
+- **WHEN** the repair job finds a Collection whose saved total differs from its membership count
+- **THEN** it locks that Collection, checks the count again, and saves the current membership count
+
+#### Scenario: Correct saved total
+
+- **WHEN** a checked Collection already has the correct Bottle total
+- **THEN** the repair leaves it unchanged
+
+#### Scenario: Collection changed after the scan
+
+- **WHEN** membership changes after the broad scan but before that Collection is repaired
+- **THEN** the locked check uses the newer committed membership
+
+#### Scenario: Candidate Collection was removed
+
+- **WHEN** a Collection found by the scan no longer exists when its repair begins
+- **THEN** the repair skips it without recreating it
+
+#### Scenario: Repair is requested from Maintenance
+
+- **WHEN** an administrator starts the existing Bottle-count repair action
+- **THEN** the system uniquely queues the Collection Bottle count repair job with the other Bottle-count repairs
+
+### Requirement: Strict repair job input
+
+The Collection Bottle count repair job SHALL accept only an empty object and SHALL reject unknown fields.
+
+#### Scenario: Unexpected job field
+
+- **WHEN** the repair job receives any input field
+- **THEN** it rejects the input before reading or changing Collection totals

--- a/openspec/changes/repair-collection-bottle-counts/tasks.md
+++ b/openspec/changes/repair-collection-bottle-counts/tasks.md
@@ -1,0 +1,21 @@
+## 1. Shared Collection count owner
+
+- [x] 1.1 Add integration tests for count changes, old undercounts, missing Collections, checking, and one-Collection repair.
+- [x] 1.2 Add the small Collection Bottle count module.
+
+## 2. Membership operations
+
+- [x] 2.1 Use the shared owner for Collection Bottle creation and deletion.
+- [x] 2.2 Make failed image-upload cleanup change the count only when it removes the created membership.
+- [x] 2.3 Use the shared owner for Bottle merge membership moves and duplicate cleanup.
+- [x] 2.4 Verify status and image updates leave Collection counts unchanged.
+
+## 3. Production repair
+
+- [x] 3.1 Add and register a strict, unique Collection Bottle count repair job.
+- [x] 3.2 Queue the Collection repair from the existing admin Bottle-count action and update its dispatch test.
+
+## 4. Verification
+
+- [x] 4.1 Add focused overlap coverage proving concurrent membership changes and repair preserve the final count.
+- [x] 4.2 Run focused backend tests, server typecheck, lint, formatting, terminology checks, and strict OpenSpec validation.


### PR DESCRIPTION
Collection Bottle totals now change in the same transaction as membership additions, removals, failed-photo cleanup, and Bottle merges. Each write touches only the affected Collections, and a valid removal repairs an old low total instead of making it negative or failing. Status and photo updates still leave the total unchanged.

The existing **Check Bottle counts** Maintenance action now also queues a Collection repair. It checks all saved totals without broad write locks, then repairs one Collection per transaction while collection edits continue. This adds no schema change, CLI command, or new admin control and completes the saved Bottle counter work tracked in #1042.

Fixes #1042
