### PR TITLE
fix(web): improve loading and sparse page layouts

### DIFF
--- a/apps/web/src/app/(app)/activity/loading.tsx
+++ b/apps/web/src/app/(app)/activity/loading.tsx
@@ -1,5 +1,48 @@
-import { LoadingList } from "@peated/web/components";
+"use client";
+
+import { PageTabs } from "@peated/web/components";
+import { ActivityPage } from "@peated/web/components/pages/activityPage.stylex";
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+
+import { getActivityFeedSelection } from "./loadActivityFeed";
 
 export default function ActivityLoading() {
-  return <LoadingList label="Loading activity" rows={4} />;
+  return (
+    <Suspense fallback={<ActivityLoadingPage selectedFeed="everyone" />}>
+      <ActivityLoadingSelection />
+    </Suspense>
+  );
+}
+
+function ActivityLoadingSelection() {
+  const searchParams = useSearchParams();
+  const selectedFeed = getActivityFeedSelection(
+    searchParams.get("feed") ?? undefined,
+  );
+
+  return <ActivityLoadingPage selectedFeed={selectedFeed} />;
+}
+
+function ActivityLoadingPage({
+  selectedFeed,
+}: {
+  selectedFeed: "everyone" | "following";
+}) {
+  return (
+    <ActivityPage
+      items={[]}
+      loading
+      selector={
+        <PageTabs
+          ariaLabel="Activity feeds"
+          currentHref={`/activity?feed=${selectedFeed}`}
+          items={[
+            { href: "/activity?feed=following", label: "Following" },
+            { href: "/activity?feed=everyone", label: "Everyone" },
+          ]}
+        />
+      }
+    />
+  );
 }

--- a/apps/web/src/components/pages/activityPage.stories.tsx
+++ b/apps/web/src/components/pages/activityPage.stories.tsx
@@ -74,6 +74,15 @@ type Story = StoryObj<typeof meta>;
 
 export const Overview: Story = {};
 
+export const Loading: Story = {
+  args: {
+    items: [],
+    libraryBottles: [],
+    loading: true,
+    pagination: undefined,
+  },
+};
+
 export const NoFollows: Story = {
   args: {
     note: "You're not following anyone yet. Showing everyone's activity.",

--- a/apps/web/src/components/pages/activityPage.stylex.tsx
+++ b/apps/web/src/components/pages/activityPage.stylex.tsx
@@ -1,7 +1,13 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { ButtonLink, EmptyState, TextLink, type BottleListItem } from "..";
+import {
+  ButtonLink,
+  EmptyState,
+  LoadingList,
+  TextLink,
+  type BottleListItem,
+} from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 import { CommunityFeed, type CommunityFeedItem } from "../communityFeed.stylex";
@@ -15,10 +21,12 @@ export function ActivityPage({
   note,
   pagination,
   selector,
+  loading = false,
   libraryBottles = [],
   libraryHref,
 }: {
   items: readonly CommunityFeedItem[];
+  loading?: boolean;
   note?: string;
   pagination?: ReactNode;
   libraryBottles?: readonly BottleListItem[];
@@ -69,7 +77,9 @@ export function ActivityPage({
             {note}
           </p>
         ) : null}
-        {items.length ? (
+        {loading ? (
+          <LoadingList label="Loading activity" rows={4} />
+        ) : items.length ? (
           <CommunityFeed ariaLabel="Latest activity" items={items} limit={20} />
         ) : (
           <EmptyState heading="Nothing here yet">

--- a/apps/web/src/components/pages/activityPage.test.tsx
+++ b/apps/web/src/components/pages/activityPage.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test } from "vitest";
+
+import { ActivityPage } from "./activityPage.stylex";
+
+test("keeps known activity content visible while the feed loads", () => {
+  const html = renderToStaticMarkup(
+    <ActivityPage items={[]} loading selector={<span>Feed selection</span>} />,
+  );
+
+  expect(html).toContain("Activity");
+  expect(html).toContain("Feed selection");
+  expect(html).toContain("What have you tried?");
+  expect(html).toContain("Loading activity");
+  expect(html).not.toContain("Nothing here yet");
+});

--- a/apps/web/src/components/pages/authentication.stylex.tsx
+++ b/apps/web/src/components/pages/authentication.stylex.tsx
@@ -232,7 +232,11 @@ export function AuthenticationDetails({
 const styles = stylex.create({
   shell: {
     display: "grid",
+    width: "100%",
+    maxWidth: "1320px",
     minHeight: "100dvh",
+    marginRight: "auto",
+    marginLeft: "auto",
     gridTemplateColumns: "minmax(0, 1fr) 520px",
     backgroundColor: colors.ground,
     [NARROW]: {

--- a/apps/web/src/components/pages/tastingReviewDetail.stories.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stories.tsx
@@ -1,0 +1,52 @@
+import { mockTasting } from "@peated/server/orpc/mock/fixtures";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { ButtonLink } from "../button.stylex";
+import { StoryCanvas } from "../storyFixtures.stylex";
+import { TastingReviewDetail } from "./tastingReviewDetail.stylex";
+
+const meta = {
+  title: "Pages/Tasting and Review Detail",
+  component: TastingReviewDetail,
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="wide">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+  args: {
+    author: mockTasting.createdBy,
+    bottle: mockTasting.bottle,
+    color: mockTasting.color,
+    createdAt: mockTasting.createdAt,
+    footer: (
+      <ButtonLink href="/login" size="sm" variant="tonal">
+        Toast
+      </ButtonLink>
+    ),
+    friends: mockTasting.friends,
+    notes: mockTasting.notes,
+    rating: { kind: "tasting", ratingBand: mockTasting.ratingBand },
+    servingStyle: mockTasting.servingStyle,
+    tags: mockTasting.tags,
+  },
+  argTypes: {
+    footer: { control: false },
+  },
+} satisfies Meta<typeof TastingReviewDetail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {};
+
+export const WithoutNotes: Story = {
+  args: {
+    color: null,
+    friends: [],
+    notes: null,
+    servingStyle: undefined,
+    tags: [],
+  },
+};

--- a/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
@@ -176,10 +176,7 @@ const styles = stylex.create({
     minWidth: 0,
   },
   body: {
-    paddingTop: "20px",
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.sectionRule,
+    paddingTop: space.x4,
   },
   recordHeader: {
     display: "flex",
@@ -210,9 +207,6 @@ const styles = stylex.create({
   facts: {
     minWidth: 0,
     marginTop: space.x3,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
   },
   recordNotes: {
     maxWidth: "62ch",


### PR DESCRIPTION
Activity loading now preserves the page title, feed selector, and “What have you tried?” rail while skeletonizing only the asynchronous feed rows. Tasting details use whitespace instead of redundant rules, avoiding stacked dividers in sparse reviews, and authentication pages cap and center their two-column composition on ultra-wide displays.

The shared activity page owns the explicit loading state so the route fallback and Storybook exercise the same hierarchy. Focused regression coverage confirms known activity content stays visible, while a sparse tasting story covers the no-notes state.

Visual QA covered desktop and mobile activity and tasting states, plus the login page at mobile and 2560px widths. Web typecheck, lint, all 429 web tests, the Storybook build, and the production Next build pass.

Refs #1064.
