### PR TITLE
fix(scrapers): prepare retired source links

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -6,6 +6,7 @@ import {
   externalReviews,
   externalSiteRuns,
   externalSites,
+  externalSiteScrapeTargets,
   scrapeSourceRuns,
   scrapeSources,
   scrapeTargets,
@@ -1122,6 +1123,22 @@ describe("POST /admin/scrape-sources/prepare", () => {
     const prices = await db.select().from(storePrices);
     const histories = await db.select().from(storePriceHistories);
     const runs = await db.select().from(externalSiteRuns);
+    // Retiring a code source leaves its request target in place but makes the
+    // site link inactive until saved rules take ownership.
+    await syncScraperDefinitions(
+      createScraperRegistry({
+        targets: [scraperRegistry.targets.get("compassbox")!],
+        sources: [],
+      }),
+    );
+    expect(await db.select().from(externalSiteScrapeTargets)).toEqual([
+      expect.objectContaining({
+        externalSiteId: site.id,
+        targetKey: "compassbox",
+        managedBy: "code",
+        active: false,
+      }),
+    ]);
     await db.update(scrapeTargets).set({
       blockedUntil: new Date(Date.now() + 60_000),
       windowRequestCount: 3,
@@ -1158,6 +1175,14 @@ describe("POST /admin/scrape-sources/prepare", () => {
     expect(await db.select().from(externalSiteRuns)).toEqual(runs);
     expect(await db.select().from(scrapeTargets)).toEqual([
       { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(externalSiteScrapeTargets)).toEqual([
+      expect.objectContaining({
+        externalSiteId: site.id,
+        targetKey: "compassbox",
+        managedBy: "admin",
+        active: true,
+      }),
     ]);
     expect(await db.select().from(scrapeSources)).toEqual([
       expect.objectContaining({

--- a/apps/server/src/scraper/configured/prepareExistingSource.ts
+++ b/apps/server/src/scraper/configured/prepareExistingSource.ts
@@ -91,7 +91,6 @@ export async function inspectExistingSource(
   if (
     siteTargets.length !== 1 ||
     siteTargets[0].targetKey !== definition.targetKey ||
-    !siteTargets[0].active ||
     siteTargets[0].managedBy !== "code" ||
     targetSites.length !== 1 ||
     targetSites[0].externalSiteId !== site.id ||
@@ -123,7 +122,7 @@ export async function createPreparedSource(
 ) {
   await tx
     .update(externalSiteScrapeTargets)
-    .set({ managedBy: "admin", updatedAt: new Date() })
+    .set({ managedBy: "admin", active: true, updatedAt: new Date() })
     .where(
       and(
         eq(externalSiteScrapeTargets.externalSiteId, input.externalSiteId),


### PR DESCRIPTION
Preparing a saved-rule scraper now accepts the one retained code-owned site link even when a prior definition sync marked that link inactive. Applying the migration reactivates the link under administrator ownership, so the configured scraper can run without weakening the existing checks for site, target, origin, robots policy, schedule, active runs, or stored records.

This unblocks Compass Box after its legacy source registration was retired before the production migration ran. The existing integration test now reproduces that deployment order and verifies the inactive link becomes active while prices, Bottle matches, histories, and runs remain unchanged.
