### PR TITLE
fix(price-matching): tolerate historical extracted categories

### DIFF
--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -550,6 +550,42 @@ describe("price match queue", () => {
     expect(candidates).toEqual([]);
   });
 
+  test("treats historical extracted categories as unknown", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const price = await fixtures.StorePrice({
+      name: "Historical Category Listing",
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "no_match",
+        extractedLabel: {
+          expression: "Historical Category",
+          category: "historical_category",
+        },
+      })
+      .returning();
+
+    const [listResult, detailsResult] = await Promise.all([
+      routerClient.prices.matchQueue.list({}, { context: { user } }),
+      routerClient.prices.matchQueue.details(
+        { proposal: proposal.id },
+        { context: { user } },
+      ),
+    ]);
+    const listItem = listResult.results.find((item) => item.id === proposal.id);
+
+    expect(listItem?.extractedLabel).toMatchObject({
+      expression: "Historical Category",
+      category: null,
+    });
+    expect(detailsResult.extractedLabel).toEqual(listItem?.extractedLabel);
+  });
+
   test("serializes persisted BottleGroup sibling cask evidence", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/prices/matchQueue/utils.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/utils.ts
@@ -39,6 +39,7 @@ type QueueRow = {
 
 const StoredValueSchema = z.json().catch(null);
 type StoredValue = z.infer<typeof StoredValueSchema>;
+const StoredObjectSchema = z.record(z.string(), z.json());
 
 const AutomationIssuePathSchema = z
   .union([z.string(), z.array(z.string())])
@@ -84,6 +85,37 @@ function normalizeStoredPriceMatchCandidates(
   }
 
   return normalized;
+}
+
+/**
+ * Stored classifier snapshots can predate the current category list. Keep the
+ * remaining extracted evidence, but expose an unrecognized category as unknown.
+ */
+function normalizeStoredExtractedLabel(
+  value: StoredValue,
+  proposalId: number,
+): ReturnType<typeof ExtractedBottleDetailsSchema.parse> {
+  const parsed = ExtractedBottleDetailsSchema.safeParse(value);
+  if (parsed.success) {
+    return parsed.data;
+  }
+
+  const hasOnlyInvalidCategory = parsed.error.issues.every(
+    (issue) => issue.path[0] === "category",
+  );
+  const storedObject = StoredObjectSchema.safeParse(value);
+  if (hasOnlyInvalidCategory && storedObject.success) {
+    const normalized = ExtractedBottleDetailsSchema.parse({
+      ...storedObject.data,
+      category: null,
+    });
+    logWarn("Discarded invalid price-match extracted category evidence", {
+      extra: { proposalId },
+    });
+    return normalized;
+  }
+
+  return ExtractedBottleDetailsSchema.parse(value);
 }
 
 function normalizeStoredProposedBottle(
@@ -250,7 +282,10 @@ export function serializeProposal(
     proposal.id,
   );
   const extractedLabel = proposal.extractedLabel
-    ? ExtractedBottleDetailsSchema.parse(proposal.extractedLabel)
+    ? normalizeStoredExtractedLabel(
+        StoredValueSchema.parse(proposal.extractedLabel),
+        proposal.id,
+      )
     : null;
   const normalizedProposedBottle = proposal.proposedBottle
     ? normalizeStoredProposedBottle(


### PR DESCRIPTION
Price-match queue reads now preserve historical extracted-label snapshots whose category no longer belongs to the current category list. Only the unsupported category is exposed as unknown, rather than failing the entire moderator queue; other invalid stored fields remain validation errors, and the discarded category is logged by proposal ID without its raw value.

Regression coverage exercises both the queue list and single-proposal detail routes with a synthetic historical category.

Fixes PEATED-4GG
