### PR TITLE
feat(scrapers): prepare Gordon Macphail migration

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -106,6 +106,15 @@ function prepareCompassBox(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareGordonMacphail(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "gordonmacphail", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareKilchoman(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "kilchoman", ...input },
@@ -122,6 +131,7 @@ function codeOwnedSource(
   key:
     | "bourbonculture"
     | "compassbox"
+    | "gordonmacphail"
     | "kilchoman"
     | "whiskeyreviewer"
     | "whiskynotes"
@@ -183,6 +193,11 @@ const whiskyNotesRegistry = createScraperRegistry({
 const compassBoxRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("compassbox")!],
   sources: [codeOwnedSource("compassbox")],
+});
+
+const gordonMacphailRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("gordonmacphail")!],
+  sources: [codeOwnedSource("gordonmacphail")],
 });
 
 const kilchomanRegistry = createScraperRegistry({
@@ -569,6 +584,25 @@ async function setupCompassBoxMigration() {
     })
     .returning();
   await syncScraperDefinitions(compassBoxRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
+}
+
+async function setupGordonMacphailMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "gordonmacphail",
+      name: "Gordon Macphail",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(gordonMacphailRegistry);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "succeeded",
@@ -1231,6 +1265,99 @@ describe("POST /admin/scrape-sources/prepare", () => {
       code: "BAD_REQUEST",
       message: "Compass Box has no stored prices to verify.",
     });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares Gordon & MacPhail without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupGordonMacphailMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "15278344929666",
+      name: "CC CASK STRENGTH GLENTURRET 2007 59.8% - 70cl",
+      price: 16000,
+      currency: "gbp",
+      volume: 700,
+      url: "https://shop.gordonandmacphail.com/products/cc-cask-strength-glenturret-2007-59-8-70cl",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "6631010533443",
+      name: "Distillery Labels Linkwood 15-year-old 46%",
+      price: 8999,
+      currency: "gbp",
+      volume: 700,
+      url: "https://shop.gordonandmacphail.com/products/distillery-labels-linkwood-15-years-old-46",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareGordonMacphail()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareGordonMacphail({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(gordonMacphailRegistry);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl: "https://shop.gordonandmacphail.com/collections/all",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+  });
+
+  test("refuses an unexpected Gordon & MacPhail price", async ({
+    fixtures,
+  }) => {
+    const site = await setupGordonMacphailMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: null,
+      name: "Unknown product",
+      currency: "gbp",
+      volume: 700,
+      url: "https://shop.gordonandmacphail.com/products/unknown-product",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+
+    await expect(prepareGordonMacphail({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check Gordon & MacPhail price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
     expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from "@peated/server/orpc/middleware";
 import { ExternalSiteKeySchema } from "@peated/server/schemas";
 import { prepareBourbonCultureSource } from "@peated/server/scraper/configured/prepareBourbonCulture";
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
+import { prepareGordonMacphailSource } from "@peated/server/scraper/configured/prepareGordonMacphail";
 import { prepareKilchomanSource } from "@peated/server/scraper/configured/prepareKilchoman";
 import { prepareWhiskeyReviewerSource } from "@peated/server/scraper/configured/prepareWhiskeyReviewer";
 import { prepareWhiskyNotesSource } from "@peated/server/scraper/configured/prepareWhiskyNotes";
@@ -33,7 +34,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, compassbox, kilchoman, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
+          "The existing site's key. Currently supports bourbonculture, compassbox, gordonmacphail, kilchoman, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -66,6 +67,7 @@ export default procedure
     const prepareSource = {
       bourbonculture: prepareBourbonCultureSource,
       compassbox: prepareCompassBoxSource,
+      gordonmacphail: prepareGordonMacphailSource,
       kilchoman: prepareKilchomanSource,
       whiskeyreviewer: prepareWhiskeyReviewerSource,
       whiskynotes: prepareWhiskyNotesSource,

--- a/apps/server/src/scraper/configured/prepareGordonMacphail.ts
+++ b/apps/server/src/scraper/configured/prepareGordonMacphail.ts
@@ -1,0 +1,25 @@
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks Gordon & MacPhail by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareGordonMacphailSource(
+  input: PreparePriceSourceInput,
+) {
+  return preparePriceSource(input, {
+    siteKey: "gordonmacphail",
+    siteName: "Gordon & MacPhail",
+    targetKey: "gordonmacphail",
+    origin: "https://shop.gordonandmacphail.com",
+    listUrl: "https://shop.gordonandmacphail.com/collections/all",
+    isExpectedPrice: (price) =>
+      /^https:\/\/shop\.gordonandmacphail\.com\/products\/[a-z0-9][a-z0-9-]*$/.test(
+        price.url,
+      ) &&
+      /^\d+$/.test(price.externalProductId ?? "") &&
+      price.name.trim().length > 0 &&
+      price.currency === "gbp" &&
+      price.volume === 700,
+  });
+}


### PR DESCRIPTION
Gordon & MacPhail can now be prepared for saved scraping rules through the existing guarded migration endpoint. Preparation requires a stopped schedule, no active run, the expected code-owned request target and origin, and official GBP product records with numeric source IDs and 700 ml volumes before it transfers request-policy ownership and creates a paused source.

The integration coverage verifies that checks do not write and that applying preserves price IDs, histories, and Bottle matches. The proposed v6 rules were also exercised separately through the local no-write runtime against the live store: both current products matched the existing URLs, prices, currency, and volume with no issues or retries.
