### PR TITLE
style(web): improve activity feed bottle hierarchy

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -362,12 +362,17 @@ JSDoc.
 
 - Put catalog images on a white canvas with a complete frame. Do not assume
   source images have useful transparency.
-- Standard three-line rows share one thumbnail size across bottle lists,
-  activity, search, selection, and loading states. Keep the full bottle visible;
-  never crop it to an avatar square. Single-line library additions use smaller
-  thumbnails. Sidebar bottle lists use the shared sidebar variant with smaller
-  thumbnails, compact titles limited to two lines, and trailing details below
-  the identity. Recent tastings show their date and rating as supporting details.
+- Standard three-line catalog, search, selection, and loading rows share one
+  thumbnail size. Activity keeps the same identity with an image one full size
+  larger in wide feed columns so the whisky anchors each entry, then returns to
+  the standard row size in sidebars and on mobile. The space stays consistent
+  for square and portrait photos. Each photo keeps its original proportions,
+  and its white frame fits the photo instead of filling unused space. Keep the
+  full bottle visible; never crop it to an avatar square. Single-line library
+  additions use smaller thumbnails.
+  Sidebar bottle lists use the shared sidebar variant with smaller thumbnails,
+  compact titles limited to two lines, and trailing details below the identity.
+  Recent tastings show their date and rating as supporting details.
 - State precise values. Do not replace known numbers with vague labels.
 - Do not invent data, rankings, totals, ranges, or derived values in a visual
   component.

--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -56,7 +56,7 @@ const meta = {
   argTypes: {
     variant: {
       control: "inline-radio",
-      options: ["standard", "search", "sidebar", "compact"],
+      options: ["standard", "activity", "search", "sidebar", "compact"],
     },
   },
   args: {
@@ -72,6 +72,7 @@ const meta = {
 | Variant | Use | Content |
 | --- | --- | --- |
 | standard (default) | Catalog, tastings, reviews, and selection | Name, provenance, and release facts; 48 × 64px thumbnail (42 × 58px on mobile). |
+| activity | Community feed tastings and reviews | Top-aligned identity with a 96px square space in wide feed columns, the usual 48 × 64px space in a desktop sidebar, and 42 × 58px on mobile. The frame fits the photo without changing its shape. |
 | search | Typeahead results | Standard identity and thumbnail, 15px compact title, and 8px vertical padding. |
 | sidebar | Sidebar bottle lists | 15px title limited to two lines, 32 × 46px thumbnail, and trailing content below the identity. |
 | compact | Single or grouped library additions | One regular-weight name line, 24 × 32px thumbnail, and a 44px hit area. |
@@ -180,7 +181,7 @@ export const RowLayouts: Story = {
     docs: {
       description: {
         story:
-          "Compare the actual bottle, sidebar, activity, tasting, search, selection, and loading components at wide and phone widths. Standard rows use three identity lines and a medium thumbnail. Sidebars use a small thumbnail, compact two-line titles, and trailing details below the identity. Compact library additions use the extra-small thumbnail.",
+          "Compare the actual bottle, sidebar, activity, tasting, search, selection, and loading components at wide and phone widths. Standard rows use three identity lines and a medium thumbnail; activity makes that image larger in wide feed columns. Sidebars use a small thumbnail, compact two-line titles, and trailing details below the identity. Compact library additions use the extra-small thumbnail.",
       },
     },
   },

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -33,15 +33,18 @@ export type BottleIdentityRowProps = {
     href: string;
   };
   subtitle?: ReactNode;
+  /** Activity-only review text or byline shown beside the bottle image. */
+  activityDetails?: ReactNode;
   /** Sidebar uses a small thumbnail, a two-line name, and a footer for trailing content. */
-  variant?: "standard" | "search" | "sidebar" | "compact";
+  variant?: "standard" | "activity" | "search" | "sidebar" | "compact";
   /** Tightens vertical padding when the row is nested inside another surface. */
   verticalPadding?: "sm" | "md";
 };
 
 /**
  * Bottle identity for lists and activity. Standard shows name, provenance, then
- * release facts; search tightens the title and spacing for typeahead results;
+ * release facts; activity keeps that identity with a larger feed thumbnail;
+ * search tightens the title and spacing for typeahead results;
  * sidebar uses compact titles and small thumbnails; compact shows one regular-weight
  * name line for dense lists of library additions. Sidebar names use two lines with
  * the full name in title.
@@ -52,7 +55,8 @@ export type BottleIdentityRowProps = {
  * Use layout="cell" inside an existing row/selection control. Linked cells keep
  * their link inside the bottle identity. Use linkArea="title" when the
  * surrounding card is also clickable. Compact omits provenance, metadata,
- * subtitle, status, and related releases; end remains available.
+ * subtitle, status, and related releases; end remains available. Activity may
+ * add review text below the bottle details without forcing it beneath the image.
  */
 export function BottleIdentityRow({
   align = "center",
@@ -70,12 +74,14 @@ export function BottleIdentityRow({
   provenance = [],
   relatedReleases,
   subtitle,
+  activityDetails,
   variant = "standard",
   verticalPadding = "md",
 }: BottleIdentityRowProps) {
   const compact = variant === "compact";
+  const activity = variant === "activity";
   const sidebar = variant === "sidebar";
-  const compactTitle = variant !== "standard";
+  const compactTitle = variant !== "standard" && !activity;
   const trailingContent = end ? (
     <div
       {...stylex.props(
@@ -87,11 +93,107 @@ export function BottleIdentityRow({
       {end}
     </div>
   ) : null;
+  const bottleDetails = (
+    <div {...stylex.props(styles.copy)}>
+      <div
+        {...stylex.props(
+          foundationStyles.rowTitle,
+          compactTitle && foundationStyles.compactRowTitle,
+          styles.nameLine,
+        )}
+      >
+        {href ? (
+          <AppLink
+            href={href}
+            onClick={onClick}
+            title={name}
+            {...stylex.props(
+              styles.name,
+              sidebar && styles.sidebarName,
+              compact && styles.compactName,
+              linkArea === "row"
+                ? linkedRowStyles.primaryLink
+                : styles.titleLink,
+            )}
+          >
+            <MatchedText query={query} text={name} />
+          </AppLink>
+        ) : (
+          <span
+            title={name}
+            {...stylex.props(
+              styles.name,
+              sidebar && styles.sidebarName,
+              compact && styles.compactName,
+            )}
+          >
+            <MatchedText query={query} text={name} />
+          </span>
+        )}
+        {!compact && !sidebar && isLibrary ? (
+          <MemberStatus kind="library" />
+        ) : null}
+        {!compact && !sidebar && hasTasted ? (
+          <MemberStatus kind="tasted" />
+        ) : null}
+      </div>
+      {!compact && provenance.length ? (
+        <div {...stylex.props(foundationStyles.metadata, styles.subtitle)}>
+          <Join divider=" · ">
+            {provenance.map((item, index) =>
+              item.href ? (
+                <TextLink href={item.href} key={index} size="inherit">
+                  {item.name}
+                </TextLink>
+              ) : (
+                <span key={index}>{item.name}</span>
+              ),
+            )}
+          </Join>
+        </div>
+      ) : null}
+      {!compact && subtitle ? (
+        <div
+          title={getTextTitle(subtitle)}
+          {...stylex.props(foundationStyles.metadata, styles.subtitle)}
+        >
+          {subtitle}
+        </div>
+      ) : null}
+      {!compact && metadata.length ? (
+        <div
+          title={metadata.join(" · ")}
+          {...stylex.props(foundationStyles.metadata, styles.metadata)}
+        >
+          {metadata.map((item, index) => (
+            <span key={`${item}-${index}`}>
+              {index ? <span aria-hidden="true"> · </span> : null}
+              {item}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {!compact && relatedReleases && relatedReleases.count > 1 ? (
+        <AppLink
+          href={relatedReleases.href}
+          {...stylex.props(
+            foundationStyles.interactiveSmall,
+            styles.relatedReleases,
+            linkedRowStyles.nestedAction,
+          )}
+        >
+          {relatedReleases.count.toLocaleString("en-US")} related releases
+        </AppLink>
+      ) : null}
+      {sidebar ? trailingContent : null}
+    </div>
+  );
   return (
     <div
       {...stylex.props(
         styles.row,
         verticalPadding === "sm" && styles.smallVerticalPadding,
+        activity && styles.activityRow,
         variant === "search" && styles.searchRow,
         sidebar && styles.sidebarRow,
         compact && styles.compactRow,
@@ -106,102 +208,24 @@ export function BottleIdentityRow({
     >
       <BottleVisual
         imageUrl={imageUrl}
-        size={compact ? "xs" : sidebar ? "sm" : "md"}
+        size={compact ? "xs" : sidebar ? "sm" : activity ? "activity" : "md"}
       />
-      <div {...stylex.props(styles.copy)}>
-        <div
-          {...stylex.props(
-            foundationStyles.rowTitle,
-            compactTitle && foundationStyles.compactRowTitle,
-            styles.nameLine,
-          )}
-        >
-          {href ? (
-            <AppLink
-              href={href}
-              onClick={onClick}
-              title={name}
-              {...stylex.props(
-                styles.name,
-                sidebar && styles.sidebarName,
-                compact && styles.compactName,
-                linkArea === "row"
-                  ? linkedRowStyles.primaryLink
-                  : styles.titleLink,
-              )}
-            >
-              <MatchedText query={query} text={name} />
-            </AppLink>
-          ) : (
-            <span
-              title={name}
-              {...stylex.props(
-                styles.name,
-                sidebar && styles.sidebarName,
-                compact && styles.compactName,
-              )}
-            >
-              <MatchedText query={query} text={name} />
-            </span>
-          )}
-          {!compact && !sidebar && isLibrary ? (
-            <MemberStatus kind="library" />
-          ) : null}
-          {!compact && !sidebar && hasTasted ? (
-            <MemberStatus kind="tasted" />
+      {activity ? (
+        <div {...stylex.props(styles.activityBody)}>
+          <div {...stylex.props(styles.activitySummary)}>
+            {bottleDetails}
+            {trailingContent}
+          </div>
+          {activityDetails ? (
+            <div {...stylex.props(styles.activityDetails)}>
+              {activityDetails}
+            </div>
           ) : null}
         </div>
-        {!compact && provenance.length ? (
-          <div {...stylex.props(foundationStyles.metadata, styles.subtitle)}>
-            <Join divider=" · ">
-              {provenance.map((item, index) =>
-                item.href ? (
-                  <TextLink href={item.href} key={index} size="inherit">
-                    {item.name}
-                  </TextLink>
-                ) : (
-                  <span key={index}>{item.name}</span>
-                ),
-              )}
-            </Join>
-          </div>
-        ) : null}
-        {!compact && subtitle ? (
-          <div
-            title={getTextTitle(subtitle)}
-            {...stylex.props(foundationStyles.metadata, styles.subtitle)}
-          >
-            {subtitle}
-          </div>
-        ) : null}
-        {!compact && metadata.length ? (
-          <div
-            title={metadata.join(" · ")}
-            {...stylex.props(foundationStyles.metadata, styles.metadata)}
-          >
-            {metadata.map((item, index) => (
-              <span key={`${item}-${index}`}>
-                {index ? <span aria-hidden="true"> · </span> : null}
-                {item}
-              </span>
-            ))}
-          </div>
-        ) : null}
-        {!compact && relatedReleases && relatedReleases.count > 1 ? (
-          <AppLink
-            href={relatedReleases.href}
-            {...stylex.props(
-              foundationStyles.interactiveSmall,
-              styles.relatedReleases,
-              linkedRowStyles.nestedAction,
-            )}
-          >
-            {relatedReleases.count.toLocaleString("en-US")} related releases
-          </AppLink>
-        ) : null}
-        {sidebar ? trailingContent : null}
-      </div>
-      {!sidebar ? trailingContent : null}
+      ) : (
+        bottleDetails
+      )}
+      {!activity && !sidebar ? trailingContent : null}
     </div>
   );
 }
@@ -227,6 +251,26 @@ const styles = stylex.create({
   smallVerticalPadding: {
     paddingTop: space.x2,
     paddingBottom: space.x2,
+  },
+  activityRow: {
+    alignItems: "flex-start",
+    paddingTop: space.x1,
+    paddingBottom: 0,
+  },
+  activityBody: {
+    display: "flex",
+    minWidth: 0,
+    flex: 1,
+    flexDirection: "column",
+  },
+  activitySummary: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "flex-start",
+    gap: space.x3,
+  },
+  activityDetails: {
+    marginTop: space.x3,
   },
   searchRow: {
     paddingTop: space.x2,

--- a/apps/web/src/components/bottleVisual.stories.tsx
+++ b/apps/web/src/components/bottleVisual.stories.tsx
@@ -13,7 +13,10 @@ const meta = {
     size: "md",
   },
   argTypes: {
-    size: { control: "inline-radio", options: ["xs", "sm", "md", "lg", "xl"] },
+    size: {
+      control: "inline-radio",
+      options: ["xs", "sm", "md", "activity", "lg", "xl"],
+    },
   },
   decorators: [
     (Story) => (
@@ -32,6 +35,7 @@ const meta = {
 | xs | Single-line library additions (24 × 32px). |
 | sm | Two-line sidebar rails (32 × 46px). |
 | md (default) | Standard rows, search, and selection (48 × 64px; 42 × 58px on mobile). |
+| activity | Tastings and reviews in the community feed. Uses a 96px square space in wide feed columns, the usual 48 × 64px space in a desktop sidebar, and 42 × 58px on mobile. The frame fits the photo without changing its shape. |
 | lg | Detail media (132 × 176px; 80 × 120px on mobile). |
 | xl | Full-width detail media with a 4:5 frame. |
 

--- a/apps/web/src/components/bottleVisual.stylex.tsx
+++ b/apps/web/src/components/bottleVisual.stylex.tsx
@@ -9,9 +9,11 @@ import {
 import { ImageViewer } from "./imageViewer.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
+const NARROW_FEED = "@container (max-width: 559px)";
+const ACTIVITY_SIZE = "96px";
 const bottleIconUrl = "/assets/bottle.svg";
 
-export type BottleVisualSize = "xs" | "sm" | "md" | "lg" | "xl";
+export type BottleVisualSize = "xs" | "sm" | "md" | "activity" | "lg" | "xl";
 
 export type BottleVisualProps = {
   expandable?: boolean;
@@ -23,8 +25,9 @@ export type BottleVisualProps = {
 /**
  * Shows a bottle image or Peated's bottle glyph when no image exists.
  * BottleIdentityRow chooses its own size. Use this primitive directly only when
- * composing another layout: sm for sidebar rows, md for standard rows, lg/xl
- * for detail media. Omit label beside visible bottle text; expandable needs a label.
+ * composing another layout: sm for sidebar rows, md for standard rows, activity
+ * for feed rows, and lg/xl for detail media. Omit label beside visible bottle
+ * text; expandable needs a label.
  * Fixed-size frames cap both dimensions so source images cannot enlarge a row.
  * Row images load near the viewport; lg/xl detail images load immediately.
  */
@@ -55,7 +58,11 @@ export function BottleVisual({
             alt=""
             src={imageUrl}
             loading={loading}
-            {...stylex.props(styles.image, expandableImagePaddingStyles[size])}
+            {...stylex.props(
+              styles.image,
+              expandableImagePaddingStyles[size],
+              size === "activity" && styles.activityImage,
+            )}
           />
         </ImageViewer>
       ) : imageUrl ? (
@@ -63,7 +70,10 @@ export function BottleVisual({
           alt=""
           src={imageUrl}
           loading={loading}
-          {...stylex.props(styles.image)}
+          {...stylex.props(
+            styles.image,
+            size === "activity" && styles.activityImage,
+          )}
         />
       ) : (
         <span
@@ -121,6 +131,32 @@ const styles = stylex.create({
     maxHeight: bottleThumbnailMetrics.height,
     padding: space.x2,
   },
+  visualActivity: {
+    width: {
+      default: ACTIVITY_SIZE,
+      [COMPACT]: bottleThumbnailMetrics.width,
+      [NARROW_FEED]: bottleThumbnailMetrics.width,
+    },
+    maxWidth: {
+      default: ACTIVITY_SIZE,
+      [COMPACT]: bottleThumbnailMetrics.width,
+      [NARROW_FEED]: bottleThumbnailMetrics.width,
+    },
+    height: {
+      default: ACTIVITY_SIZE,
+      [COMPACT]: bottleThumbnailMetrics.height,
+      [NARROW_FEED]: bottleThumbnailMetrics.height,
+    },
+    maxHeight: {
+      default: ACTIVITY_SIZE,
+      [COMPACT]: bottleThumbnailMetrics.height,
+      [NARROW_FEED]: bottleThumbnailMetrics.height,
+    },
+    alignItems: "flex-start",
+    padding: 0,
+    backgroundColor: "transparent",
+    boxShadow: "none",
+  },
   visualLarge: {
     width: { default: "132px", [COMPACT]: "80px" },
     maxWidth: { default: "132px", [COMPACT]: "80px" },
@@ -145,6 +181,13 @@ const styles = stylex.create({
     minHeight: 0,
     objectFit: "contain",
   },
+  activityImage: {
+    width: "auto",
+    height: "auto",
+    borderRadius: controlMetrics.radiusSmall,
+    backgroundColor: colors.imageBackground,
+    boxShadow: `inset 0 0 0 1px ${colors.hairline}`,
+  },
   expandableImageExtraSmall: {
     padding: "2px",
   },
@@ -153,6 +196,9 @@ const styles = stylex.create({
   },
   expandableImageMedium: {
     padding: space.x2,
+  },
+  expandableImageActivity: {
+    padding: 0,
   },
   expandableImageLarge: {
     padding: { default: space.x2, [COMPACT]: space.x1 },
@@ -180,6 +226,7 @@ const visualSizeStyles = {
   xs: styles.visualExtraSmall,
   sm: styles.visualSmall,
   md: styles.visualMedium,
+  activity: styles.visualActivity,
   lg: styles.visualLarge,
   xl: styles.visualExtraLarge,
 } satisfies Record<BottleVisualSize, stylex.StyleXStyles>;
@@ -188,6 +235,7 @@ const expandableImagePaddingStyles = {
   xs: styles.expandableImageExtraSmall,
   sm: styles.expandableImageSmall,
   md: styles.expandableImageMedium,
+  activity: styles.expandableImageActivity,
   lg: styles.expandableImageLarge,
   xl: styles.expandableImageExtraLarge,
 } satisfies Record<BottleVisualSize, stylex.StyleXStyles>;

--- a/apps/web/src/components/communityFeed.stories.tsx
+++ b/apps/web/src/components/communityFeed.stories.tsx
@@ -4,12 +4,30 @@ import {
   mockTastings,
 } from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import PortraitBottleImage from "../../../../packages/bottle-classifier/src/eval-fixtures/assets/exclusive-malts-islay-2007.jpg";
+import BottleImage from "../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
 import {
   getCommunityFeedItems,
   getTastingFeedItems,
 } from "../lib/communityFeed";
-import { CommunityFeed } from "./communityFeed.stylex";
+import { CommunityFeed, type CommunityFeedItem } from "./communityFeed.stylex";
 import { StoryCanvas } from "./storyFixtures.stylex";
+
+function withStoryImages(items: readonly CommunityFeedItem[]) {
+  return items.map((item, itemIndex) => ({
+    ...item,
+    actorImageUrl: null,
+    bottles: item.bottles.map((bottle, bottleIndex) => ({
+      ...bottle,
+      imageUrl:
+        item.kind === "collection_add"
+          ? null
+          : (itemIndex + bottleIndex) % 2
+            ? PortraitBottleImage.src
+            : BottleImage.src,
+    })),
+  }));
+}
 
 const meta = {
   title: "Components/Reviews & Tastings/Community Feed",
@@ -30,10 +48,12 @@ const meta = {
     ),
   ],
   args: {
-    items: getCommunityFeedItems({
-      activity: mockActivity,
-      criticReviews: [mockExternalReview],
-    }),
+    items: withStoryImages(
+      getCommunityFeedItems({
+        activity: mockActivity,
+        criticReviews: [mockExternalReview],
+      }),
+    ),
   },
 } satisfies Meta<typeof CommunityFeed>;
 export default meta;
@@ -42,14 +62,33 @@ export const Overview: Story = {};
 export const TastingList: Story = {
   args: {
     ariaLabel: "Tastings",
-    items: getTastingFeedItems(mockTastings.slice(0, 3)),
+    items: withStoryImages(getTastingFeedItems(mockTastings.slice(0, 3))),
+  },
+};
+export const NarrowColumn: Story = {
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="compact">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A narrow desktop column, such as a sidebar, keeps the usual activity image size even when the screen itself is wide.",
+      },
+    },
   },
 };
 export const WithoutCriticByline: Story = {
   args: {
-    items: getCommunityFeedItems({
-      activity: [],
-      criticReviews: [{ ...mockExternalReview, reviewerName: null }],
-    }),
+    items: withStoryImages(
+      getCommunityFeedItems({
+        activity: [],
+        criticReviews: [{ ...mockExternalReview, reviewerName: null }],
+      }),
+    ),
   },
 };

--- a/apps/web/src/components/communityFeed.stylex.tsx
+++ b/apps/web/src/components/communityFeed.stylex.tsx
@@ -131,7 +131,7 @@ function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
             <div key={bottle.id} {...stylex.props(styles.bottle)}>
               <BottleIdentityRow
                 variant={
-                  item.kind === "collection_add" ? "compact" : "standard"
+                  item.kind === "collection_add" ? "compact" : "activity"
                 }
                 provenance={bottle.provenance}
                 name={bottle.name}
@@ -140,6 +140,33 @@ function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
                 linkArea="title"
                 metadata={bottle.metadata}
                 verticalPadding="sm"
+                activityDetails={
+                  bottle.description || bottle.byline ? (
+                    <>
+                      {bottle.description ? (
+                        <p
+                          {...stylex.props(
+                            foundationStyles.body,
+                            styles.excerpt,
+                            Boolean(bottle.byline) && styles.excerptWithFooter,
+                          )}
+                        >
+                          {bottle.description}
+                        </p>
+                      ) : null}
+                      {bottle.byline ? (
+                        <div
+                          {...stylex.props(
+                            foundationStyles.metadata,
+                            styles.footer,
+                          )}
+                        >
+                          By {bottle.byline}
+                        </div>
+                      ) : null}
+                    </>
+                  ) : undefined
+                }
                 end={
                   bottle.score !== undefined || bottle.ratingBand ? (
                     <div {...stylex.props(styles.facts)}>
@@ -156,25 +183,6 @@ function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
                   ) : undefined
                 }
               />
-              {bottle.description || bottle.byline ? (
-                <div {...stylex.props(styles.details)}>
-                  {bottle.description ? (
-                    <p {...stylex.props(foundationStyles.body, styles.excerpt)}>
-                      {bottle.description}
-                    </p>
-                  ) : null}
-                  {bottle.byline ? (
-                    <div
-                      {...stylex.props(
-                        foundationStyles.metadata,
-                        styles.footer,
-                      )}
-                    >
-                      By {bottle.byline}
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
             </div>
           ))}
           {item.more ? (
@@ -205,6 +213,10 @@ function getActivityLinkLabel(item: CommunityFeedItem) {
 const MOBILE = "@media (max-width: 559px)";
 const styles = stylex.create({
   entry: {
+    containerType: "inline-size",
+    display: "grid",
+    gridTemplateColumns: "auto minmax(0, 1fr)",
+    columnGap: { default: space.x3, [MOBILE]: space.x2 },
     width: "calc(100% + 24px)",
     marginRight: "-12px",
     marginLeft: "-12px",
@@ -214,10 +226,10 @@ const styles = stylex.create({
     paddingLeft: "12px",
   },
   author: {
-    display: "flex",
+    display: "grid",
+    gridColumn: "1 / -1",
+    gridTemplateColumns: "subgrid",
     alignItems: "center",
-    gap: space.x3,
-    [MOBILE]: { gap: space.x2 },
   },
   context: { minWidth: 0, color: colors.inkMuted },
   activityLink: {
@@ -229,18 +241,14 @@ const styles = stylex.create({
   date: { whiteSpace: "nowrap" },
   content: {
     minWidth: 0,
-    marginLeft: "38px",
     display: "flex",
+    gridColumn: "2",
     flexDirection: "column",
     gap: space.x3,
-    [MOBILE]: { marginLeft: "34px" },
+    [MOBILE]: { gridColumn: "1 / -1" },
   },
   bottle: { minWidth: 0 },
   compactContent: { gap: 0 },
-  details: {
-    marginLeft: "60px",
-    ["@media (max-width: 639px)"]: { marginLeft: "54px" },
-  },
   facts: {
     display: "flex",
     flexShrink: 0,
@@ -250,8 +258,9 @@ const styles = stylex.create({
   },
   excerpt: {
     marginTop: 0,
-    marginBottom: space.x2,
+    marginBottom: 0,
     color: colors.ink,
   },
+  excerptWithFooter: { marginBottom: space.x2 },
   footer: { color: colors.inkMuted },
 });

--- a/apps/web/src/components/pages/tastingReviewRail.stories.tsx
+++ b/apps/web/src/components/pages/tastingReviewRail.stories.tsx
@@ -54,7 +54,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "The sidebar used by tasting and review pages, shown at its 336px desktop width. Long names retain a full accessible label and title, with a two-line visual limit. Dates and optional ratings sit below the name. Includes long names, missing images, and an unrated tasting using fixture data.",
+          "The sidebar used by tasting and review pages, shown at its 336px desktop width. Long names retain a full accessible label and title, with a two-line visual limit. Dates and optional ratings share one line below the name. Includes long names, missing images, and an unrated tasting using fixture data.",
       },
     },
   },

--- a/apps/web/src/components/scoring.stylex.tsx
+++ b/apps/web/src/components/scoring.stylex.tsx
@@ -39,14 +39,22 @@ export type TastingRatingProps = {
   size?: "sm" | "md" | "lg";
 };
 
-/** Shows one tasting's named rating and range, never a five-point score. */
+/**
+ * Shows one tasting's named rating and range, never a five-point score.
+ * Small ratings keep the label and range inline for compact metadata rows.
+ */
 export function TastingRating({ band, size = "md" }: TastingRatingProps) {
   const selectedBand = RATING_BANDS.find((candidate) => candidate.key === band);
   const label = selectedBand?.label ?? "Unknown";
   const range = selectedBand?.range ?? "Unknown";
 
   return (
-    <span {...stylex.props(styles.ratingLockup)}>
+    <span
+      {...stylex.props(
+        styles.ratingLayout,
+        size === "sm" && styles.smallRatingLayout,
+      )}
+    >
       <span {...stylex.props(styles.visuallyHidden)}>
         {label} rating, {range} range
       </span>
@@ -64,7 +72,6 @@ export function TastingRating({ band, size = "md" }: TastingRatingProps) {
         aria-hidden="true"
         {...stylex.props(
           styles.tastingRatingRange,
-          size === "sm" && styles.smallTastingRatingRange,
           size === "lg" && styles.largeTastingRatingRange,
         )}
       >
@@ -94,7 +101,7 @@ export function ReviewScore({
     : `Review score, ${score} out of ${scale}`;
 
   return (
-    <span {...stylex.props(styles.ratingLockup, styles.reviewScore)}>
+    <span {...stylex.props(styles.ratingLayout, styles.reviewScore)}>
       <span {...stylex.props(styles.visuallyHidden)}>{accessibleLabel}</span>
       {rating ? (
         <span
@@ -118,14 +125,7 @@ export function ReviewScore({
         >
           {score}
         </strong>
-        <span
-          {...stylex.props(
-            styles.reviewScoreScale,
-            size === "sm" && styles.smallReviewScoreScale,
-          )}
-        >
-          /{scale}
-        </span>
+        <span {...stylex.props(styles.reviewScoreScale)}>/{scale}</span>
       </span>
     </span>
   );
@@ -491,13 +491,18 @@ const styles = stylex.create({
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   }),
-  ratingLockup: {
+  ratingLayout: {
     display: "inline-flex",
     flexShrink: 0,
     alignItems: "flex-end",
     flexDirection: "column",
     gap: "2px",
     whiteSpace: "nowrap",
+  },
+  smallRatingLayout: {
+    alignItems: "baseline",
+    flexDirection: "row",
+    gap: space.x1,
   },
   ratingLabel: {
     color: colors.accentDeep,
@@ -524,7 +529,6 @@ const styles = stylex.create({
     letterSpacing: "normal",
     lineHeight: 1.3,
   },
-  smallTastingRatingRange: { fontSize: "12px" },
   largeTastingRatingRange: { fontSize: "15px" },
   reviewScore: { marginLeft: "auto" },
   reviewScoreValueGroup: {
@@ -558,7 +562,6 @@ const styles = stylex.create({
     letterSpacing: "normal",
     lineHeight: 1.45,
   },
-  smallReviewScoreScale: { fontSize: "12px" },
   visuallyHidden: {
     position: "absolute",
     width: "1px",

--- a/apps/web/src/components/tastingRating.stories.tsx
+++ b/apps/web/src/components/tastingRating.stories.tsx
@@ -21,6 +21,7 @@ export const Overview: Story = {
         ))}
       </StoryRow>
       <StoryRow>
+        <TastingRating band="very_good" size="sm" />
         <TastingRating band="very_good" size="lg" />
       </StoryRow>
     </StoryStack>

--- a/docs/features/bottle-presentation.md
+++ b/docs/features/bottle-presentation.md
@@ -371,15 +371,15 @@ The components live in `apps/web/src/components/`, with stories beside them.
 Storybook's **Components / Bottles / Bottle Identity Row / Row Layouts** is the
 shared visual reference for desktop and phone layouts.
 
-| Need                        | Component                             | Responsibility                                                                                                                          |
-| --------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| One standard bottle row     | `BottleIdentityRow`                   | Full marketed name, provenance, release facts, thumbnail, and linked hit area.                                                          |
-| One-line library addition   | `BottleIdentityRow variant="compact"` | Same name, smaller thumbnail, and a 44px hit area; long names truncate visually.                                                        |
-| Catalog list                | `BottleList`                          | List semantics and optional ratings or row actions.                                                                                     |
-| Mixed activity              | `CommunityFeed`                       | Author, action, date, grouped bottles, scores, and review links; chooses compact rows for library additions.                            |
-| Selected bottle in a form   | `SelectedBottleSummary`               | Standard identity and optional change action.                                                                                           |
-| Sidebar bottle suggestions  | `pages/BottleRailSection`             | Shared sidebar rows with compact two-line names, small thumbnails, trailing details below the identity, and an optional section action. |
-| Image within another layout | `BottleVisual`                        | Image sizing, white frame, missing-image glyph, and optional expansion.                                                                 |
+| Need                        | Component                             | Responsibility                                                                                                                                                                                |
+| --------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| One standard bottle row     | `BottleIdentityRow`                   | Full marketed name, provenance, release facts, thumbnail, and linked hit area.                                                                                                                |
+| One-line library addition   | `BottleIdentityRow variant="compact"` | Same name, smaller thumbnail, and a 44px hit area; long names truncate visually.                                                                                                              |
+| Catalog list                | `BottleList`                          | List semantics and optional ratings or row actions.                                                                                                                                           |
+| Mixed activity              | `CommunityFeed`                       | Author, action, date, grouped bottles, scores, and review links; uses larger bottle photos in wide columns, the usual size in sidebars and on mobile, and compact rows for library additions. |
+| Selected bottle in a form   | `SelectedBottleSummary`               | Standard identity and optional change action.                                                                                                                                                 |
+| Sidebar bottle suggestions  | `pages/BottleRailSection`             | Shared sidebar rows with compact two-line names, small thumbnails, trailing details below the identity, and an optional section action.                                                       |
+| Image within another layout | `BottleVisual`                        | Image sizing, white frame, missing-image glyph, and optional expansion.                                                                                                                       |
 
 Use `toBottleListItem` from `apps/web/src/lib/bottleListItem.ts` for full API
 Bottles. For partial reads, `getBottleIdentityProps` supplies the name,


### PR DESCRIPTION
Activity entries now give bottle photos more prominence in wide feeds while keeping the existing smaller sizes on mobile and in narrow columns. Bottle details, ratings, and tasting notes align to the feed grid, with ratings preceding review text; square and portrait photos keep their proportions without adding empty frame space.

Sidebar bottle rows remain compact, and small tasting ratings stay on one line so the tasting detail “More from” section does not break. The shared bottle and rating components continue to own these behaviors, and their stories and design guidance document the responsive rules. The updated feed and tasting sidebar were checked at wide, narrow, and mobile sizes in Storybook.

Refs #1064
