### PR TITLE
ref(scrapers): retire Gordon Macphail registration

### DIFF
--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -33,7 +33,6 @@ const registeredSources = [
   "finedrams",
   "fredminnick",
   "glenallachie",
-  "gordonmacphail",
   "healthyspirits",
   "masterofmalt",
   "missionliquor",
@@ -65,6 +64,7 @@ const registeredReviewSources = [
 const configuredSources = [
   "bourbonculture",
   "compassbox",
+  "gordonmacphail",
   "kilchoman",
   "whiskeyreviewer",
   "whiskysaga",

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -19,7 +19,6 @@ import scrapeDramfool from "./adapters/legacy/scrapeDramfool";
 import scrapeEdradour from "./adapters/legacy/scrapeEdradour";
 import scrapeFineDrams from "./adapters/legacy/scrapeFineDrams";
 import scrapeGlenAllachie from "./adapters/legacy/scrapeGlenAllachie";
-import scrapeGordonMacphail from "./adapters/legacy/scrapeGordonMacphail";
 import scrapeHealthySpirits from "./adapters/legacy/scrapeHealthySpirits";
 import scrapeMasterOfMalt from "./adapters/legacy/scrapeMasterOfMalt";
 import scrapeMissionLiquor from "./adapters/legacy/scrapeMissionLiquor";
@@ -121,11 +120,6 @@ const legacyPriceSources = [
     type: "glenallachie",
     origin: "https://shop.theglenallachie.com",
     scrape: scrapeGlenAllachie,
-  },
-  {
-    type: "gordonmacphail",
-    origin: "https://shop.gordonandmacphail.com",
-    scrape: scrapeGordonMacphail,
   },
   {
     type: "healthyspirits",
@@ -259,6 +253,15 @@ export const scraperRegistry = createScraperRegistry({
       origins: [
         {
           origin: "https://www.compassboxwhisky.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
+      key: "gordonmacphail",
+      origins: [
+        {
+          origin: "https://shop.gordonandmacphail.com",
           robots: { mode: "enforce" },
         },
       ],


### PR DESCRIPTION
## Summary

Remove Gordon Macphail from the code-owned scraper sources now that its saved v6 rules are active and verified in production. Keep its request-policy target registered so robots rules, spacing, and quotas still apply.

## Production verification

- Previewed revision 21 successfully with both current products and no parser issues.
- Manual run 531 collected 2 of 2 products with no retries, rate limits, or errors.
- Preserved price IDs 12028566 and 12028567, their product URLs, external IDs, and Bottle matches.
- Restored the 10080-minute schedule.

## Tests

- `pnpm --filter @peated/server test -- src/scraper/registry.test.ts`
- `pnpm --filter @peated/server typecheck`
- `pnpm exec prettier --check apps/server/src/scraper/registry.ts apps/server/src/scraper/registry.test.ts`
- `pnpm exec oxlint apps/server/src/scraper/registry.ts apps/server/src/scraper/registry.test.ts`