### PR TITLE
fix(scrapers): exclude North Star liqueurs

### DIFF
--- a/apps/server/__fixtures__/northstarspirits/bottle-list.json
+++ b/apps/server/__fixtures__/northstarspirits/bottle-list.json
@@ -78,6 +78,18 @@
           "price": "33.00"
         }
       ]
+    },
+    {
+      "title": "Campbeltown Amaretto SOOP Liqueur",
+      "handle": "campbeltown-amaretto-soop-liqueur",
+      "body_html": "<p>An amaretto liqueur made with Scotch whisky.</p>",
+      "images": [],
+      "variants": [
+        {
+          "available": true,
+          "price": "29.00"
+        }
+      ]
     }
   ]
 }

--- a/apps/server/src/scraper/adapters/legacy/scrapeNorthStarSpirits.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeNorthStarSpirits.ts
@@ -44,9 +44,10 @@ function extractVolume(title: string, bodyHtml: string | null): number {
   }
 }
 
-function isExplicitlyNonWhisky(title: string, bodyHtml: string | null) {
-  const text = `${title} ${bodyHtml ?? ""}`;
-  return /\bgin\b/i.test(title) && !/\bwhisk(?:y|ey)\b/i.test(text);
+function isExplicitlyNonWhisky(title: string) {
+  return (
+    /\b(?:gin|liqueur)\b/i.test(title) && !/\bwhisk(?:y|ey)\b/i.test(title)
+  );
 }
 
 function parseNorthStarProducts(
@@ -57,7 +58,7 @@ function parseNorthStarProducts(
   const products: StorePrice[] = [];
 
   for (const product of payload.products) {
-    if (isExplicitlyNonWhisky(product.title, product.body_html ?? null)) {
+    if (isExplicitlyNonWhisky(product.title)) {
       logScrapeWarning(SITE, "Unsupported non-whisky product", {
         rawName: product.title,
       });


### PR DESCRIPTION
## Summary

Exclude products labeled as gin or liqueur from the North Star whisky scraper unless the title itself also identifies the product as whisky. This removes a current amaretto liqueur from future collections without rejecting whisky that mentions a gin or liqueur cask.

## Why

North Star currently lists “Campbeltown Amaretto SOOP Liqueur” in its general shop, and the legacy adapter only excluded gin. Production therefore records that liqueur as a whisky price.

## Tests

- `pnpm --filter @peated/server test -- src/scraper/adapters/legacy/scrapeNorthStarSpirits.test.ts`
- `pnpm --filter @peated/server typecheck`
- `pnpm exec prettier --write apps/server/src/scraper/adapters/legacy/scrapeNorthStarSpirits.ts apps/server/__fixtures__/northstarspirits/bottle-list.json`
- `pnpm exec oxlint apps/server/src/scraper/adapters/legacy/scrapeNorthStarSpirits.ts apps/server/src/scraper/adapters/legacy/scrapeNorthStarSpirits.test.ts --fix`