### PR TITLE
ref(scrapers): retire migrated review registrations

### DIFF
--- a/apps/server/src/scraper/lifecycle.test.ts
+++ b/apps/server/src/scraper/lifecycle.test.ts
@@ -99,11 +99,8 @@ test("opted-in source resumes the last successful run cursor", async ({
   fixtures,
 }) => {
   const requestedBy = await fixtures.User({ admin: true });
-  const site = await fixtures.ExternalSite({ type: "whiskynotes" });
-  const successfulCursor = {
-    page: 5,
-    processedArticleUrls: ["https://www.whiskynotes.be/2026/world/example/"],
-  };
+  const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+  const successfulCursor = { processedIssues: ["Summer 2026"] };
   await db.insert(externalSiteRuns).values([
     {
       externalSiteId: site.id,
@@ -116,7 +113,7 @@ test("opted-in source resumes the last successful run cursor", async ({
       externalSiteId: site.id,
       trigger: "scheduled",
       status: "failed",
-      cursor: { page: 8, processedArticleUrls: [] },
+      cursor: { processedIssues: ["Fall 2026"] },
       completedAt: new Date("2026-08-21T00:00:00Z"),
     },
   ]);
@@ -127,12 +124,7 @@ test("opted-in source resumes the last successful run cursor", async ({
     enqueue: async () => undefined,
   });
 
-  expect(run.cursor).toEqual({
-    ...successfulCursor,
-    checksReviewDates: false,
-    currentArticleUrls: [],
-    historyComplete: false,
-  });
+  expect(run.cursor).toEqual(successfulCursor);
 });
 
 test("active run prevents overlap", async ({ fixtures }) => {

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -1,9 +1,6 @@
 import { EXTERNAL_SITE_DEFINITIONS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import {
-  externalReviewArticles,
-  externalReviewPublications,
-  externalReviews,
   externalSiteRuns,
   externalSites,
   storePrices,
@@ -46,10 +43,8 @@ const registeredSources = [
   "totalwine",
   "whiskyadvocate",
   "whiskyfun",
-  "whiskynotes",
   "whiskyworld",
   "woodencork",
-  "wordsofwhisky",
 ];
 
 const registeredReviewSources = [
@@ -57,8 +52,6 @@ const registeredReviewSources = [
   "fredminnick",
   "whiskyadvocate",
   "whiskyfun",
-  "whiskynotes",
-  "wordsofwhisky",
 ];
 
 const configuredSources = [
@@ -69,6 +62,8 @@ const configuredSources = [
   "whiskeyreviewer",
   "whiskysaga",
   "whiskystudy",
+  "whiskynotes",
+  "wordsofwhisky",
 ];
 
 type RuntimeTestClock = ScraperHttpClock & { advanceTo(value: Date): void };
@@ -152,10 +147,6 @@ test("registers each code-owned scraper source with explicit target ownership", 
     requestsPerWindow: 30,
     windowMs: 3_600_000,
   });
-  expect(scraperRegistry.sources.get("whiskynotes")?.requestLimit).toBe(30);
-  expect(scraperRegistry.sources.get("whiskynotes")?.resumeFromLastRun).toBe(
-    true,
-  );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyfun.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskyfun")).toMatchObject({
     minimumSpacingMs: 2_500,
@@ -184,7 +175,6 @@ test("registers each code-owned scraper source with explicit target ownership", 
     requestsPerWindow: 25,
     windowMs: 3_600_000,
   });
-  expect(scraperRegistry.sources.get("wordsofwhisky")?.requestLimit).toBe(25);
   for (const type of registeredReviewSources) {
     const source = scraperRegistry.sources.get(type);
     expect(source, `${type} is not registered`).toBeDefined();
@@ -259,98 +249,6 @@ test("runs Bruichladdich through the production runtime with fixture parity", as
     itemCount: 4,
     cursor: { sequence: 1, page: 1 },
   });
-});
-
-test("runs the bounded WhiskyNotes adapter through the production runtime", async ({
-  fixtures,
-}) => {
-  await syncExternalSites();
-  await syncScraperDefinitions(scraperRegistry);
-  const [site] = await db
-    .select()
-    .from(externalSites)
-    .where(eq(externalSites.type, "whiskynotes"));
-  if (!site) throw new Error("Expected synchronized WhiskyNotes site.");
-  await db
-    .update(externalReviewPublications)
-    .set({
-      approvedAt: null,
-    })
-    .where(eq(externalReviewPublications.externalSiteId, site.id));
-  await fixtures.Bottle({ name: "Kanekou Okinawa Whisky" });
-  await fixtures.Bottle({ name: "Ben Nevis 30 yo 1996" });
-  await fixtures.Bottle({ name: "Bowmore 20 yo 2005" });
-  const [run] = await db
-    .insert(externalSiteRuns)
-    .values({
-      externalSiteId: site.id,
-      trigger: "manual",
-      requestLimit: 30,
-    })
-    .returning();
-  if (!run) throw new Error("Expected run.");
-  const archive = (await loadFixture("whiskynotes", "archive.html")).replace(
-    /<link rel="next"[^>]+>/,
-    "",
-  );
-  const singleReview = await loadFixture("whiskynotes", "single-review.html");
-  const multiReview = await loadFixture("whiskynotes", "multi-review.html");
-  const fetchImpl = vi.fn<typeof fetch>(async (input) => {
-    const url = new URL(input instanceof Request ? input.url : input);
-    if (url.pathname === "/robots.txt") {
-      return new Response("User-agent: *\nDisallow:");
-    }
-    if (url.pathname === "/") return new Response(archive);
-    if (url.pathname.includes("kanekou-okinawa-whisky")) {
-      return new Response(singleReview);
-    }
-    if (url.pathname.includes("bowmore-2005-ben-nevis")) {
-      return new Response(multiReview);
-    }
-    return new Response(null, { status: 404 });
-  });
-
-  const clock = runtimeClock();
-  let result = null;
-  for (let attempt = 0; attempt < 10; attempt += 1) {
-    result = await executeScraperRun(
-      { runId: run.id },
-      {
-        registry: scraperRegistry,
-        fetchImpl,
-        clock,
-        executionToken: "whiskynotes-owner",
-      },
-    );
-    if (result.status === "completed") break;
-    if (result.status === "deferred" || result.status === "not_ready") {
-      clock.advanceTo(result.nextAttemptAt);
-      continue;
-    }
-    throw new Error(`Unexpected scraper result: ${result.status}`);
-  }
-  expect(result).toEqual({ status: "completed" });
-
-  expect(
-    await db
-      .select()
-      .from(externalReviewArticles)
-      .where(eq(externalReviewArticles.externalSiteId, site.id)),
-  ).toHaveLength(2);
-  expect(await db.select().from(externalReviews)).toHaveLength(4);
-  expect(
-    await db
-      .select()
-      .from(externalSiteRuns)
-      .where(eq(externalSiteRuns.id, run.id)),
-  ).toMatchObject([
-    {
-      status: "succeeded",
-      requestCount: 4,
-      emittedItemCount: 4,
-      itemCount: 4,
-    },
-  ]);
 });
 
 test("dispatches migrated sources to the isolated scraper job", async ({

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -52,16 +52,6 @@ import {
   WhiskyfunObservationSchema,
 } from "./adapters/whiskyfun";
 import {
-  whiskyNotesAdapter,
-  WhiskyNotesCursorSchema,
-  WhiskyNotesObservationSchema,
-} from "./adapters/whiskyNotes";
-import {
-  wordsOfWhiskyAdapter,
-  WordsOfWhiskyCursorSchema,
-  WordsOfWhiskyObservationSchema,
-} from "./adapters/wordsOfWhisky";
-import {
   createScraperRegistry,
   defineScraperSource,
   defineScrapeTarget,
@@ -434,17 +424,6 @@ export const scraperRegistry = createScraperRegistry({
       sink: externalReviewSink,
     }),
     defineScraperSource({
-      key: "whiskynotes",
-      externalSiteKey: "whiskynotes",
-      targetKeys: ["whiskynotes"],
-      requestLimit: 30,
-      resumeFromLastRun: true,
-      cursorSchema: WhiskyNotesCursorSchema,
-      observationSchema: WhiskyNotesObservationSchema,
-      adapter: whiskyNotesAdapter,
-      sink: externalReviewSink,
-    }),
-    defineScraperSource({
       key: "whiskyfun",
       externalSiteKey: "whiskyfun",
       targetKeys: ["whiskyfun"],
@@ -453,16 +432,6 @@ export const scraperRegistry = createScraperRegistry({
       cursorSchema: WhiskyfunCursorSchema,
       observationSchema: WhiskyfunObservationSchema,
       adapter: whiskyfunAdapter,
-      sink: externalReviewSink,
-    }),
-    defineScraperSource({
-      key: "wordsofwhisky",
-      externalSiteKey: "wordsofwhisky",
-      targetKeys: ["wordsofwhisky"],
-      requestLimit: 25,
-      cursorSchema: WordsOfWhiskyCursorSchema,
-      observationSchema: WordsOfWhiskyObservationSchema,
-      adapter: wordsOfWhiskyAdapter,
       sink: externalReviewSink,
     }),
   ],


### PR DESCRIPTION
## Summary

Remove the obsolete code-owned source registrations for WhiskyNotes and Words of Whisky now that their saved v6 revisions are active and verified in production. Keep both request-policy targets registered so robots rules, spacing, and quotas still apply.

The cleanup also removes the production-runtime WhiskyNotes adapter test. The adapter’s dedicated parser tests and fixtures remain available; configured-source runtime behavior is covered by the configured scraper tests and production acceptance runs.

## Production verification

- WhiskyNotes scheduled run 523 collected 44 reviews with no retries, rate limits, or errors; 368 reviews remain stored and the daily schedule is active.
- Words of Whisky scheduled run 525 collected 12 reviews with no retries, rate limits, or errors; 25 reviews remain stored and the daily schedule is active.
- Both configured runtimes report registered with their original request targets.

## Tests

- `pnpm --filter @peated/server test -- src/scraper/registry.test.ts`
- `pnpm --filter @peated/server typecheck`
- `pnpm exec prettier --write apps/server/src/scraper/registry.ts apps/server/src/scraper/registry.test.ts`
- `pnpm exec oxlint apps/server/src/scraper/registry.ts apps/server/src/scraper/registry.test.ts --fix`