### PR TITLE
feat(scrapers): prepare Cadenhead's migration

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -106,6 +106,15 @@ function prepareCompassBox(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareCadenheads(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "cadenheads", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareGordonMacphail(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "gordonmacphail", ...input },
@@ -130,6 +139,7 @@ const canonicalUrl =
 function codeOwnedSource(
   key:
     | "bourbonculture"
+    | "cadenheads"
     | "compassbox"
     | "gordonmacphail"
     | "kilchoman"
@@ -193,6 +203,11 @@ const whiskyNotesRegistry = createScraperRegistry({
 const compassBoxRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("compassbox")!],
   sources: [codeOwnedSource("compassbox")],
+});
+
+const cadenheadsRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("cadenheads")!],
+  sources: [codeOwnedSource("cadenheads")],
 });
 
 const gordonMacphailRegistry = createScraperRegistry({
@@ -584,6 +599,25 @@ async function setupCompassBoxMigration() {
     })
     .returning();
   await syncScraperDefinitions(compassBoxRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
+}
+
+async function setupCadenheadsMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "cadenheads",
+      name: "Cadenheads",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(cadenheadsRegistry);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "succeeded",
@@ -1265,6 +1299,97 @@ describe("POST /admin/scrape-sources/prepare", () => {
       code: "BAD_REQUEST",
       message: "Compass Box has no stored prices to verify.",
     });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares Cadenhead's without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupCadenheadsMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "5996",
+      name: "Cadenhead's 7-Stars Blend 46%",
+      price: 4000,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.cadenhead.shop/product/cadenheads-7-stars-blend-46/",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: null,
+      name: "Older Cadenhead's release",
+      price: 6500,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.cadenhead.shop/product/older-cadenheads-release/",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareCadenheads()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareCadenheads({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(cadenheadsRegistry);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl: "https://www.cadenhead.shop/product-category/whisky/",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+  });
+
+  test("refuses an unexpected Cadenhead's price", async ({ fixtures }) => {
+    const site = await setupCadenheadsMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "not-a-number",
+      name: "Unknown release",
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.cadenhead.shop/product/unknown-release/",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+
+    await expect(prepareCadenheads({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check Cadenhead's price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
     expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -2,6 +2,7 @@ import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import { ExternalSiteKeySchema } from "@peated/server/schemas";
 import { prepareBourbonCultureSource } from "@peated/server/scraper/configured/prepareBourbonCulture";
+import { prepareCadenheadsSource } from "@peated/server/scraper/configured/prepareCadenheads";
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
 import { prepareGordonMacphailSource } from "@peated/server/scraper/configured/prepareGordonMacphail";
 import { prepareKilchomanSource } from "@peated/server/scraper/configured/prepareKilchoman";
@@ -34,7 +35,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, compassbox, gordonmacphail, kilchoman, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
+          "The existing site's key. Currently supports bourbonculture, cadenheads, compassbox, gordonmacphail, kilchoman, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -66,6 +67,7 @@ export default procedure
   .handler(async ({ input, context, errors }) => {
     const prepareSource = {
       bourbonculture: prepareBourbonCultureSource,
+      cadenheads: prepareCadenheadsSource,
       compassbox: prepareCompassBoxSource,
       gordonmacphail: prepareGordonMacphailSource,
       kilchoman: prepareKilchomanSource,

--- a/apps/server/src/scraper/configured/prepareCadenheads.ts
+++ b/apps/server/src/scraper/configured/prepareCadenheads.ts
@@ -1,0 +1,24 @@
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks Cadenhead's by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareCadenheadsSource(input: PreparePriceSourceInput) {
+  return preparePriceSource(input, {
+    siteKey: "cadenheads",
+    siteName: "Cadenhead's",
+    targetKey: "cadenheads",
+    origin: "https://www.cadenhead.shop",
+    listUrl: "https://www.cadenhead.shop/product-category/whisky/",
+    isExpectedPrice: (price) =>
+      /^https:\/\/www\.cadenhead\.shop\/product\/[a-z0-9][a-z0-9-]*\/$/.test(
+        price.url,
+      ) &&
+      (price.externalProductId === null ||
+        /^\d+$/.test(price.externalProductId)) &&
+      price.name.trim().length > 0 &&
+      price.currency === "gbp" &&
+      price.volume === 700,
+  });
+}


### PR DESCRIPTION
## Summary

- add a guarded migration path for the existing Cadenhead's price source
- preserve price IDs, history, target ownership, and Bottle matches
- accept historical listings without a product ID while rejecting unexpected active data

## Verification

- `pnpm --filter @peated/server test -- src/orpc/routes/external-sites/scrape-sources/prepare.test.ts`
- `pnpm --filter @peated/server typecheck`
- full local configured-scraper preview: 46 products across 4 list pages, no parser issues