### PR TITLE
fix(web): inherit typography for inline links

### DIFF
--- a/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
@@ -57,11 +57,7 @@ export function AboutText({ children }: { children: ReactNode }) {
 }
 
 export function AboutLink({ children, ...props }: TextLinkProps) {
-  return (
-    <TextLink {...props} size="inherit">
-      {children}
-    </TextLink>
-  );
+  return <TextLink {...props}>{children}</TextLink>;
 }
 
 export function AboutTextStack({ children }: { children: ReactNode }) {

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
@@ -28,18 +28,9 @@ export function BottleCatalogNavigation({
       {scope === "following" ? (
         <p {...stylex.props(foundationStyles.body, styles.scopeHelp)}>
           Bottles from distillers, brands, and bottlers you follow. See followed{" "}
-          <TextLink href="/distillers?filter=following" size="inherit">
-            distillers
-          </TextLink>
-          ,{" "}
-          <TextLink href="/brands?filter=following" size="inherit">
-            brands
-          </TextLink>
-          , or{" "}
-          <TextLink href="/bottlers?filter=following" size="inherit">
-            bottlers
-          </TextLink>
-          .
+          <TextLink href="/distillers?filter=following">distillers</TextLink>,{" "}
+          <TextLink href="/brands?filter=following">brands</TextLink>, or{" "}
+          <TextLink href="/bottlers?filter=following">bottlers</TextLink>.
         </p>
       ) : null}
     </div>

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -9,7 +9,6 @@ import { usePathname, useRouter } from "next/navigation";
 import { createContext, useContext, useState, type ReactNode } from "react";
 
 import {
-  AppLink,
   Button,
   ButtonLink,
   EmptyState,
@@ -18,6 +17,7 @@ import {
   PageTabs,
   RowMenu,
   SectionError,
+  TextLink,
   type CriticReviewProps,
   type FactListItem,
   type PageTabItem,
@@ -73,9 +73,9 @@ function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
     {
       label: "Series",
       value: bottle.series ? (
-        <AppLink href={getBottleSeriesUrl(bottle.series)}>
+        <TextLink href={getBottleSeriesUrl(bottle.series)}>
           {bottle.series.name}
-        </AppLink>
+        </TextLink>
       ) : null,
     },
     {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -15,14 +15,13 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
         <>
           <TextLink
             href={`/locations/${entity.country.slug}/regions/${entity.region.slug}`}
-            size="inherit"
           >
             {entity.region.name}
           </TextLink>
           <span>, </span>
         </>
       ) : null}
-      <TextLink href={`/locations/${entity.country.slug}`} size="inherit">
+      <TextLink href={`/locations/${entity.country.slug}`}>
         {entity.country.name}
       </TextLink>
     </>
@@ -34,7 +33,7 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
     {
       label: "Part of",
       value: entity.owner ? (
-        <TextLink href={getEntityUrl(entity.owner)} size="inherit">
+        <TextLink href={getEntityUrl(entity.owner)}>
           {entity.owner.name}
         </TextLink>
       ) : null,
@@ -42,12 +41,7 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
     {
       label: "Website",
       value: entity.website ? (
-        <TextLink
-          href={entity.website}
-          rel="noreferrer"
-          size="inherit"
-          target="_blank"
-        >
+        <TextLink href={entity.website} rel="noreferrer" target="_blank">
           {parseDomain(entity.website)}
         </TextLink>
       ) : null,

--- a/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
@@ -47,7 +47,7 @@ export function EntityMap({ entity }: { entity: Entity }) {
           <span {...stylex.props(foundationStyles.code, styles.coordinates)}>
             {coordinateLabel}
           </span>
-          <TextLink href={mapHref} rel="noreferrer" target="_blank">
+          <TextLink href={mapHref} rel="noreferrer" size="sm" target="_blank">
             Open in map →
           </TextLink>
         </div>

--- a/apps/web/src/app/(app)/events/eventList.stylex.tsx
+++ b/apps/web/src/app/(app)/events/eventList.stylex.tsx
@@ -24,7 +24,6 @@ export function EventList({ events }: { events: Event[] }) {
                   <TextLink
                     href={event.website}
                     rel="noreferrer"
-                    size="inherit"
                     target="_blank"
                   >
                     {event.name}

--- a/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
@@ -69,9 +69,7 @@ export function LocationPageFrame({
           description={description}
           parent={
             country ? (
-              <TextLink href={country.href} size="inherit">
-                {country.name}
-              </TextLink>
+              <TextLink href={country.href}>{country.name}</TextLink>
             ) : undefined
           }
           title={location.name}

--- a/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
+++ b/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
@@ -145,7 +145,7 @@ export function NotificationList({
                     {...stylex.props(foundationStyles.metadata, styles.message)}
                   >
                     {from ? (
-                      <TextLink href={`/users/${from.username}`} size="inherit">
+                      <TextLink href={`/users/${from.username}`}>
                         {from.username}
                       </TextLink>
                     ) : null}{" "}
@@ -153,7 +153,6 @@ export function NotificationList({
                       <TextLink
                         href={href}
                         onClick={() => markRead(notification.id)}
-                        size="inherit"
                       >
                         {getNotificationMessage(notification)}
                       </TextLink>

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewLayout.stylex.tsx
@@ -4,12 +4,12 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import {
-  AppLink,
   FactList,
   type FactListItem,
   LoadingList,
   LoadingPlaceholder,
   SectionHeading,
+  TextLink,
 } from "@peated/web/components";
 import {
   PageColumns,
@@ -47,7 +47,9 @@ export function ProfileActivitySection({
     <section aria-label="Recent activity">
       <div {...stylex.props(styles.sectionHeader)}>
         <SectionHeading>Recent activity</SectionHeading>
-        <AppLink href={`/users/${username}/activity`}>View all</AppLink>
+        <TextLink href={`/users/${username}/activity`} size="sm">
+          View all
+        </TextLink>
       </div>
       {children}
     </section>

--- a/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
@@ -161,12 +161,7 @@ export default function ModerationBottlePicker({
               <>
                 {" "}
                 Source:{" "}
-                <TextLink
-                  href={source}
-                  rel="noreferrer"
-                  size="inherit"
-                  target="_blank"
-                >
+                <TextLink href={source} rel="noreferrer" target="_blank">
                   {source}
                 </TextLink>
                 .

--- a/apps/web/src/components/admin/reviewScoringForm.stylex.tsx
+++ b/apps/web/src/components/admin/reviewScoringForm.stylex.tsx
@@ -391,9 +391,7 @@ export function ReviewScoringForm({ settings, onPreview, onSave }: Props) {
                   key: "review",
                   header: "Review",
                   cell: (sample) => (
-                    <TextLink href={sample.url} size="inherit">
-                      {sample.name}
-                    </TextLink>
+                    <TextLink href={sample.url}>{sample.name}</TextLink>
                   ),
                 },
                 {

--- a/apps/web/src/components/appLink.tsx
+++ b/apps/web/src/components/appLink.tsx
@@ -1,4 +1,3 @@
-import { foundationStyles } from "@peated/web/styles/foundations.stylex";
 import * as stylex from "@stylexjs/stylex";
 import NextLink from "next/link";
 import {
@@ -19,9 +18,10 @@ export function isInternalAppHref(href: string) {
 
 /**
  * Uses client navigation for app routes and native anchors for other targets.
- * A bare link gets the shared text-link interaction treatment. Composite
- * components replace it by supplying their own class. Use TextLink for inline
- * text because its API also owns typography and truncation.
+ * A bare link gets the shared text-link interaction treatment and inherits its
+ * surrounding typography. Composite components replace that treatment by
+ * supplying their own class. Use TextLink for inline text because its API also
+ * owns tone, compact sizing, and truncation.
  */
 export const AppLink = forwardRef(function AppLink(
   {
@@ -37,7 +37,7 @@ export const AppLink = forwardRef(function AppLink(
 ) {
   const fallbackProps = className
     ? undefined
-    : stylex.props(textLinkStyles.link, foundationStyles.interactiveSmall);
+    : stylex.props(textLinkStyles.link);
   const linkProps = {
     ...props,
     className: className ?? fallbackProps?.className,

--- a/apps/web/src/components/bottleChecks/checkSummary.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/checkSummary.stylex.tsx
@@ -68,7 +68,7 @@ export function BottleCheckSubject({
 }) {
   if (check.bottleId) {
     return (
-      <TextLink href={`/bottles/${check.bottleId}`} size="inherit">
+      <TextLink href={`/bottles/${check.bottleId}`}>
         Bottle #{check.bottleId}
       </TextLink>
     );

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -142,7 +142,7 @@ export function BottleIdentityRow({
           <Join divider=" · ">
             {provenance.map((item, index) =>
               item.href ? (
-                <TextLink href={item.href} key={index} size="inherit">
+                <TextLink href={item.href} key={index}>
                   {item.name}
                 </TextLink>
               ) : (

--- a/apps/web/src/components/communityFeed.stylex.tsx
+++ b/apps/web/src/components/communityFeed.stylex.tsx
@@ -80,9 +80,7 @@ function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
           />
           <div {...stylex.props(foundationStyles.metadata, styles.context)}>
             {item.actorHref ? (
-              <TextLink href={item.actorHref} size="inherit">
-                {item.actor}
-              </TextLink>
+              <TextLink href={item.actorHref}>{item.actor}</TextLink>
             ) : (
               <strong>{item.actor}</strong>
             )}{" "}
@@ -109,7 +107,7 @@ function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
                     {item.destination.label}
                   </CardPrimaryLink>
                 ) : (
-                  <TextLink href={item.destination.href} size="inherit">
+                  <TextLink href={item.destination.href}>
                     {item.destination.label}
                   </TextLink>
                 )}

--- a/apps/web/src/components/criticReview.stylex.tsx
+++ b/apps/web/src/components/criticReview.stylex.tsx
@@ -65,9 +65,7 @@ export function CriticReview({
               {byline ? <span>{byline}</span> : null}
               {byline && href ? <span aria-hidden="true"> · </span> : null}
               {href ? (
-                <TextLink href={href} size="inherit">
-                  Read at {publication} ↗
-                </TextLink>
+                <TextLink href={href}>Read at {publication} ↗</TextLink>
               ) : null}
             </div>
           ) : null}

--- a/apps/web/src/components/entityLinks.tsx
+++ b/apps/web/src/components/entityLinks.tsx
@@ -21,7 +21,7 @@ export function EntityLinks({
   return (
     <Join divider=", ">
       {entities.map((entity) => (
-        <TextLink href={getEntityUrl(entity)} key={entity.id} size="inherit">
+        <TextLink href={getEntityUrl(entity)} key={entity.id}>
           {entity.name}
         </TextLink>
       ))}

--- a/apps/web/src/components/flavorWheel.stories.tsx
+++ b/apps/web/src/components/flavorWheel.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
   args: {
     profile,
     footer: (
-      <TextLink href="/about/tasting-wheel" tone="muted">
+      <TextLink href="/about/tasting-wheel" size="sm" tone="muted">
         About the tasting wheel
       </TextLink>
     ),

--- a/apps/web/src/components/historyTimeline.stylex.tsx
+++ b/apps/web/src/components/historyTimeline.stylex.tsx
@@ -67,7 +67,6 @@ export function HistoryTimeline({ events, summary }: HistoryTimelineProps) {
                   <TextLink
                     href={event.source.href}
                     rel="noreferrer"
-                    size="inherit"
                     target="_blank"
                   >
                     {event.source.label ?? "Source"}

--- a/apps/web/src/components/locationMapIcon/credit.stylex.tsx
+++ b/apps/web/src/components/locationMapIcon/credit.stylex.tsx
@@ -9,17 +9,11 @@ export function RegionMapCredit() {
   return (
     <p {...stylex.props(foundationStyles.metadata, styles.credit)}>
       Maps adapted from{" "}
-      <TextLink
-        href="https://commons.wikimedia.org/wiki/File:Scotch_regions.svg"
-        size="inherit"
-      >
+      <TextLink href="https://commons.wikimedia.org/wiki/File:Scotch_regions.svg">
         Briangotts and Interiot
       </TextLink>
       {" · "}
-      <TextLink
-        href="https://creativecommons.org/licenses/by-sa/3.0/"
-        size="inherit"
-      >
+      <TextLink href="https://creativecommons.org/licenses/by-sa/3.0/">
         CC BY-SA 3.0
       </TextLink>
     </p>

--- a/apps/web/src/components/pages/authentication.stylex.tsx
+++ b/apps/web/src/components/pages/authentication.stylex.tsx
@@ -177,7 +177,7 @@ export function AuthenticationDivider({ label }: { label?: string }) {
 type AuthenticationLinkProps = TextLinkProps;
 
 export function AuthenticationLink(props: AuthenticationLinkProps) {
-  return <TextLink {...props} size="inherit" />;
+  return <TextLink {...props} />;
 }
 
 export function AuthenticationTextButton({

--- a/apps/web/src/components/pages/contentPage.stylex.tsx
+++ b/apps/web/src/components/pages/contentPage.stylex.tsx
@@ -80,11 +80,7 @@ export function ContentList({ children }: { children: ReactNode }) {
 }
 
 export function ContentLink({ children, ...props }: TextLinkProps) {
-  return (
-    <TextLink {...props} size="inherit">
-      {children}
-    </TextLink>
-  );
+  return <TextLink {...props}>{children}</TextLink>;
 }
 
 const styles = stylex.create({

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -53,7 +53,7 @@ export function HomeHighestRated({
     <section {...stylex.props(styles.section)}>
       <HomeModuleHeading
         action={
-          <TextLink href="/bottles?sort=-score&minScore=0">
+          <TextLink href="/bottles?sort=-score&minScore=0" size="sm">
             All {totalRated.toLocaleString("en-US")} rated{" "}
             <span aria-hidden="true">→</span>
           </TextLink>
@@ -81,7 +81,7 @@ export function HomeLatestReleases({
     <section {...stylex.props(styles.section)}>
       <HomeModuleHeading
         action={
-          <TextLink href={seeAllHref}>
+          <TextLink href={seeAllHref} size="sm">
             View all <span aria-hidden="true">→</span>
           </TextLink>
         }
@@ -99,7 +99,7 @@ export function HomeActivityFeed({ children }: { children: ReactNode }) {
     <section {...stylex.props(styles.section)}>
       <HomeModuleHeading
         action={
-          <TextLink href="/activity">
+          <TextLink href="/activity" size="sm">
             View all <span aria-hidden="true">→</span>
           </TextLink>
         }
@@ -140,7 +140,7 @@ export function HomeOrigins({
     <section {...stylex.props(styles.section)}>
       <HomeModuleHeading
         action={
-          <TextLink href="/locations">
+          <TextLink href="/locations" size="sm">
             Open the map <span aria-hidden="true">→</span>
           </TextLink>
         }

--- a/apps/web/src/components/pages/railListSection.stylex.tsx
+++ b/apps/web/src/components/pages/railListSection.stylex.tsx
@@ -41,7 +41,9 @@ export function RailListSection({
       ) : null}
       {action ? (
         "href" in action ? (
-          <TextLink href={action.href}>{action.label}</TextLink>
+          <TextLink href={action.href} size="sm">
+            {action.label}
+          </TextLink>
         ) : (
           <button
             aria-controls={action.ariaControls}

--- a/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
@@ -135,7 +135,7 @@ export function TastingReviewDetail({
                     ? " and "
                     : ", "
                   : null}
-                <TextLink href={`/users/${friend.username}`} size="inherit">
+                <TextLink href={`/users/${friend.username}`}>
                   {friend.username}
                 </TextLink>
               </span>

--- a/apps/web/src/components/textLink.stories.tsx
+++ b/apps/web/src/components/textLink.stories.tsx
@@ -15,6 +15,22 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Overview: Story = {
+  render: (args) => (
+    <StoryStack>
+      <p>
+        Body copy with an <TextLink {...args}>inherited-size link</TextLink>.
+      </p>
+      <TextLink href="#compact" size="sm">
+        Compact standalone action
+      </TextLink>
+      <TextLink href="/about/tasting-wheel" tone="muted">
+        Muted supporting reference
+      </TextLink>
+    </StoryStack>
+  ),
+};
+
 export const InteractionStates: Story = {
   render: (args) => (
     <StoryStack>
@@ -31,13 +47,6 @@ export const InteractionStates: Story = {
       <TextLink href="/about/tasting-wheel" tone="muted">
         About the tasting wheel
       </TextLink>
-      <p>
-        Body copy with an{" "}
-        <TextLink href="#inherited" size="inherit">
-          inherited-size link
-        </TextLink>
-        .
-      </p>
     </StoryStack>
   ),
   parameters: {

--- a/apps/web/src/components/textLink.stylex.tsx
+++ b/apps/web/src/components/textLink.stylex.tsx
@@ -10,16 +10,19 @@ export type TextLinkProps = Omit<
   "href" | "className" | "style"
 > & {
   href: string;
-  size?: "inherit" | "sm";
+  size?: "sm";
   truncate?: boolean;
   tone?: "accent" | "muted";
 };
 
-/** Shared inline link. Use muted for supporting references; its underline stays visible. */
+/**
+ * Shared inline link. Typography inherits by default; use `sm` for a compact
+ * standalone action. Muted supporting references keep a visible underline.
+ */
 export function TextLink({
   children,
   href,
-  size = "sm",
+  size,
   truncate = false,
   tone = "accent",
   ...props

--- a/apps/web/src/features/flavorProfile/flavorProfileSection.tsx
+++ b/apps/web/src/features/flavorProfile/flavorProfileSection.tsx
@@ -80,7 +80,7 @@ function FlavorProfileContent({
       ) : (
         <FlavorWheel
           footer={
-            <TextLink href="/about/tasting-wheel" tone="muted">
+            <TextLink href="/about/tasting-wheel" size="sm" tone="muted">
               About the tasting wheel
             </TextLink>
           }


### PR DESCRIPTION
Inline links now inherit the typography of their surrounding text instead of defaulting every bare `AppLink` and `TextLink` to the 13px compact action style. This makes linked fact values, entity names, prose, metadata, and headings match adjacent content; compact standalone actions opt into `size="sm"` explicitly.

Review the shared `AppLink` and `TextLink` behavior first. The bottle Series fact now uses `TextLink`, redundant `size="inherit"` props are removed, and the Storybook overview demonstrates inherited, compact, and muted variants.

Validated with the web TypeScript check, five focused component test files (12 tests), lint, a Storybook test build, and browser inspection of the updated TextLink story.
