### PR TITLE
feat(api): support Bottle reference corrections

### DIFF
--- a/apps/server/src/lib/bottleReferences.ts
+++ b/apps/server/src/lib/bottleReferences.ts
@@ -140,6 +140,33 @@ export class BottleReferenceIdentityChangedError extends Error {
   }
 }
 
+export class BottleReferenceNotFoundError extends Error {
+  constructor(readonly referenceId: number) {
+    super(`Bottle reference ${referenceId} was not found.`);
+    this.name = "BottleReferenceNotFoundError";
+  }
+}
+
+export class StaleBottleReferenceCorrectionError extends Error {
+  constructor(
+    readonly referenceId: number,
+    readonly expectedBottleId: number | null,
+    readonly actualBottleId: number | null,
+    readonly expectedIgnored: boolean,
+    readonly actualIgnored: boolean,
+  ) {
+    super(`Bottle reference ${referenceId} changed before it was corrected.`);
+    this.name = "StaleBottleReferenceCorrectionError";
+  }
+}
+
+export class CanonicalBottleReferenceCorrectionError extends Error {
+  constructor(readonly referenceId: number) {
+    super("A Bottle's current full name cannot be reassigned or unassigned.");
+    this.name = "CanonicalBottleReferenceCorrectionError";
+  }
+}
+
 export type BottleReferenceReviewIdentitySnapshot = Pick<
   typeof externalReviews.$inferSelect,
   "id" | "name" | "bottleId"
@@ -859,4 +886,199 @@ export async function assignBottleReference(
   await finalizeBottleReferenceAssignment(result, contexts);
 
   return result;
+}
+
+export type BottleReferenceCorrectionInput = {
+  referenceId: number;
+  expectedBottleId: number | null;
+  expectedIgnored: boolean;
+  bottleId: number | null;
+  ignored: boolean;
+  assignedByActorId: number;
+};
+
+export type BottleReferenceCorrectionResult = {
+  id: number;
+  name: string;
+  createdAt: Date;
+  bottleId: number | null;
+  ignored: boolean;
+  assignmentSource: BottleReferenceAssignmentSource;
+  assignedByActorId: number;
+};
+
+/** Corrects one accepted reference and only consumers that still use its old identity. */
+export async function correctBottleReference(
+  {
+    referenceId,
+    expectedBottleId,
+    expectedIgnored,
+    bottleId,
+    ignored,
+    assignedByActorId,
+  }: BottleReferenceCorrectionInput,
+  contexts?: SentryLogContexts,
+): Promise<BottleReferenceCorrectionResult> {
+  const result = await db.transaction(async (tx) => {
+    if (bottleId !== null) {
+      await lockActiveBottleInTransaction(tx, bottleId);
+    }
+
+    const [reference] = await tx
+      .select({
+        id: bottleReferences.id,
+        name: bottleReferences.name,
+        createdAt: bottleReferences.createdAt,
+        bottleId: bottleReferences.bottleId,
+        ignored: bottleReferences.ignored,
+        assignmentSource: bottleReferences.assignmentSource,
+        assignedByActorId: bottleReferences.assignedByActorId,
+      })
+      .from(bottleReferences)
+      .where(eq(bottleReferences.id, referenceId))
+      .limit(1)
+      .for("update");
+    if (!reference) {
+      throw new BottleReferenceNotFoundError(referenceId);
+    }
+
+    const currentIgnored = reference.ignored === true;
+    if (
+      reference.bottleId !== expectedBottleId ||
+      currentIgnored !== expectedIgnored
+    ) {
+      throw new StaleBottleReferenceCorrectionError(
+        referenceId,
+        expectedBottleId,
+        reference.bottleId,
+        expectedIgnored,
+        currentIgnored,
+      );
+    }
+    if (reference.bottleId === bottleId && currentIgnored === ignored) {
+      return {
+        reference: {
+          id: reference.id,
+          name: reference.name,
+          createdAt: reference.createdAt,
+          bottleId: reference.bottleId,
+          ignored: currentIgnored,
+          assignmentSource: reference.assignmentSource,
+          assignedByActorId: reference.assignedByActorId,
+        },
+        previousBottleId: reference.bottleId,
+        changed: false,
+      };
+    }
+
+    if (reference.bottleId !== null) {
+      const sourceBottle = await tx.query.bottles.findFirst({
+        where: eq(bottles.id, reference.bottleId),
+        columns: { fullName: true },
+      });
+      if (
+        sourceBottle?.fullName.toLowerCase() === reference.name.toLowerCase()
+      ) {
+        throw new CanonicalBottleReferenceCorrectionError(referenceId);
+      }
+    }
+
+    const previousBottleId = reference.bottleId;
+    const lookupName = reference.name.toLowerCase();
+    const priorPriceIdentity =
+      previousBottleId === null
+        ? isNull(storePrices.bottleId)
+        : or(
+            isNull(storePrices.bottleId),
+            eq(storePrices.bottleId, previousBottleId),
+          );
+    const priorReviewIdentity =
+      previousBottleId === null
+        ? isNull(externalReviews.bottleId)
+        : or(
+            isNull(externalReviews.bottleId),
+            eq(externalReviews.bottleId, previousBottleId),
+          );
+
+    await tx
+      .update(storePrices)
+      .set({ bottleId })
+      .where(
+        and(
+          eq(sql`LOWER(${storePrices.name})`, lookupName),
+          bottleId === null && previousBottleId !== null
+            ? eq(storePrices.bottleId, previousBottleId)
+            : priorPriceIdentity,
+        ),
+      );
+    await tx
+      .update(externalReviews)
+      .set({ bottleId })
+      .where(
+        and(
+          eq(sql`LOWER(${externalReviews.name})`, lookupName),
+          bottleId === null && previousBottleId !== null
+            ? eq(externalReviews.bottleId, previousBottleId)
+            : priorReviewIdentity,
+        ),
+      );
+
+    const [updatedReference] = await tx
+      .update(bottleReferences)
+      .set({
+        bottleId,
+        ignored,
+        embedding: null,
+        assignmentSource: "human_approved",
+        assignedByActorId,
+        reviewedAt: null,
+        reviewedByActorId: null,
+      })
+      .where(eq(bottleReferences.id, reference.id))
+      .returning({
+        id: bottleReferences.id,
+        name: bottleReferences.name,
+        createdAt: bottleReferences.createdAt,
+        bottleId: bottleReferences.bottleId,
+        ignored: bottleReferences.ignored,
+        assignmentSource: bottleReferences.assignmentSource,
+        assignedByActorId: bottleReferences.assignedByActorId,
+      });
+    if (!updatedReference) {
+      throw new FailedToSaveBottleReferenceError();
+    }
+
+    return {
+      reference: {
+        ...updatedReference,
+        ignored: updatedReference.ignored === true,
+      },
+      previousBottleId,
+      changed: true,
+    };
+  });
+
+  if (result.changed) {
+    try {
+      await pushJob("IndexBottleReference", { name: result.reference.name });
+    } catch (err) {
+      logError(err, contexts);
+    }
+
+    for (const changedBottleId of new Set(
+      [result.previousBottleId, result.reference.bottleId].filter(
+        (value): value is number => value !== null,
+      ),
+    )) {
+      try {
+        await pushUniqueJob("IndexBottleSearchVectors", {
+          bottleId: changedBottleId,
+        });
+      } catch (err) {
+        logError(err, contexts);
+      }
+    }
+  }
+
+  return result.reference;
 }

--- a/apps/server/src/openapi/spec.test.ts
+++ b/apps/server/src/openapi/spec.test.ts
@@ -555,6 +555,12 @@ describe("OpenAPI generation ($ref reuse)", () => {
     const upsertRequest = getJsonRequestSchema(
       spec.paths?.["/bottle-references"]?.put,
     );
+    const updateRequest = getJsonRequestSchema(
+      spec.paths?.["/bottle-references/{reference}"]?.patch,
+    );
+    const detailsResponse = getJsonResponseSchema(
+      spec.paths?.["/bottle-references/{reference}"]?.get,
+    );
 
     expect(Object.keys(listItem?.properties ?? {})).toEqual([
       "id",
@@ -578,6 +584,34 @@ describe("OpenAPI generation ($ref reuse)", () => {
     ]);
     expect(upsertRequest?.required).toEqual(["bottle", "name"]);
     expect(JSON.stringify(upsertRequest)).not.toContain("target");
+    expect(Object.keys(updateRequest?.properties ?? {})).toEqual([
+      "expectedBottle",
+      "expectedIgnored",
+      "bottle",
+      "ignored",
+    ]);
+    expect(updateRequest?.required).toEqual([
+      "expectedBottle",
+      "expectedIgnored",
+      "bottle",
+      "ignored",
+    ]);
+    expect(Object.keys(detailsResponse?.properties ?? {})).toEqual([
+      "id",
+      "name",
+      "createdAt",
+      "bottleId",
+      "ignored",
+      "assignmentSource",
+      "assignedByActorId",
+    ]);
+    expect(
+      spec.paths?.["/bottle-references/{reference}"]?.patch?.parameters,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "reference", in: "path" }),
+      ]),
+    );
   });
 
   it("publishes Bottle aliases as display records owned by one Bottle", async () => {

--- a/apps/server/src/orpc/routes/bottleReferences/details.ts
+++ b/apps/server/src/orpc/routes/bottleReferences/details.ts
@@ -1,0 +1,46 @@
+import { db } from "@peated/server/db";
+import { bottleReferences } from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import { requireMod } from "@peated/server/orpc/middleware";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { BottleReferenceDetailsSchema } from "./schemas";
+
+export default procedure
+  .use(requireMod)
+  .route({
+    method: "GET",
+    path: "/bottle-references/{reference}",
+    summary: "Get a Bottle reference",
+    description:
+      "Get the current assignment and moderation state for one Bottle reference. Requires a moderator.",
+    operationId: "getBottleReference",
+  })
+  .input(
+    z.object({
+      reference: z.coerce
+        .number()
+        .int()
+        .positive()
+        .describe("Stable ID of the Bottle reference"),
+    }),
+  )
+  .output(BottleReferenceDetailsSchema)
+  .handler(async ({ input, errors }) => {
+    const reference = await db.query.bottleReferences.findFirst({
+      where: eq(bottleReferences.id, input.reference),
+    });
+    if (!reference) {
+      throw errors.NOT_FOUND({ message: "Bottle reference not found." });
+    }
+
+    return {
+      id: reference.id,
+      name: reference.name,
+      createdAt: reference.createdAt.toISOString(),
+      bottleId: reference.bottleId,
+      ignored: reference.ignored === true,
+      assignmentSource: reference.assignmentSource,
+      assignedByActorId: reference.assignedByActorId,
+    };
+  });

--- a/apps/server/src/orpc/routes/bottleReferences/index.ts
+++ b/apps/server/src/orpc/routes/bottleReferences/index.ts
@@ -1,8 +1,12 @@
 import { base } from "@peated/server/orpc";
+import details from "./details";
 import list from "./list";
+import update from "./update";
 import upsert from "./upsert";
 
 export default base.tag("bottleReferences").router({
+  details,
   list,
+  update,
   upsert,
 });

--- a/apps/server/src/orpc/routes/bottleReferences/schemas.ts
+++ b/apps/server/src/orpc/routes/bottleReferences/schemas.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const BottleReferenceDetailsSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  createdAt: z.string(),
+  bottleId: z.number().nullable(),
+  ignored: z.boolean(),
+  assignmentSource: z.string(),
+  assignedByActorId: z.number(),
+});

--- a/apps/server/src/orpc/routes/bottleReferences/update.test.ts
+++ b/apps/server/src/orpc/routes/bottleReferences/update.test.ts
@@ -1,0 +1,432 @@
+import { db } from "@peated/server/db";
+import {
+  bottleReferences,
+  bottleTombstones,
+  externalReviews,
+  storePrices,
+} from "@peated/server/db/schema";
+import { getUserActor } from "@peated/server/lib/actors";
+import waitError from "@peated/server/lib/test/waitError";
+import * as workerClient from "@peated/server/lib/test/workerDispatch";
+import { routerClient } from "@peated/server/orpc/router";
+import { eq } from "drizzle-orm";
+import { beforeEach, vi } from "vitest";
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("PATCH /bottle-references/:reference", () => {
+  test("reassigns the reference and exact consumers using the old identity", async ({
+    fixtures,
+  }) => {
+    const source = await fixtures.Bottle({ name: "Wrong Bottle" });
+    const target = await fixtures.Bottle({ name: "Right Bottle" });
+    const unrelated = await fixtures.Bottle({ name: "Other Bottle" });
+    const user = await fixtures.User({ mod: true });
+    const actor = await getUserActor(user);
+    const name = "Verified Reference";
+    const reference = await fixtures.BottleReference({
+      bottleId: source.id,
+      name,
+      assignmentSource: "legacy",
+    });
+    const sourcePrice = await fixtures.StorePrice({
+      bottleId: source.id,
+      name,
+    });
+    const unresolvedPrice = await fixtures.StorePrice({
+      bottleId: null,
+      name: name.toLowerCase(),
+    });
+    const similarPrice = await fixtures.StorePrice({
+      bottleId: source.id,
+      name: `${name} 2025`,
+    });
+    const unrelatedPrice = await fixtures.StorePrice({
+      bottleId: unrelated.id,
+      name,
+    });
+    const sourceReview = await fixtures.ExternalReview({
+      bottleId: source.id,
+      name,
+    });
+    const unresolvedReview = await fixtures.ExternalReview({
+      bottleId: null,
+      name: name.toUpperCase(),
+    });
+    const unrelatedReview = await fixtures.ExternalReview({
+      bottleId: unrelated.id,
+      name,
+    });
+
+    const result = await routerClient.bottleReferences.update(
+      {
+        reference: reference.id,
+        expectedBottle: source.id,
+        expectedIgnored: false,
+        bottle: target.id,
+        ignored: false,
+      },
+      { context: { user } },
+    );
+
+    expect(result).toEqual({
+      id: reference.id,
+      name,
+      createdAt: reference.createdAt.toISOString(),
+      bottleId: target.id,
+      ignored: false,
+      assignmentSource: "human_approved",
+      assignedByActorId: actor.id,
+    });
+    await expect(
+      routerClient.bottleReferences.details(
+        { reference: reference.id },
+        { context: { user } },
+      ),
+    ).resolves.toEqual(result);
+    await expect(
+      db.query.bottleReferences.findFirst({
+        where: eq(bottleReferences.id, reference.id),
+      }),
+    ).resolves.toMatchObject({
+      bottleId: target.id,
+      ignored: false,
+      assignmentSource: "human_approved",
+      assignedByActorId: actor.id,
+      embedding: null,
+      reviewedAt: null,
+      reviewedByActorId: null,
+    });
+
+    for (const consumer of [sourcePrice, unresolvedPrice]) {
+      await expect(
+        db.query.storePrices.findFirst({
+          where: eq(storePrices.id, consumer.id),
+        }),
+      ).resolves.toMatchObject({ bottleId: target.id });
+    }
+    await expect(
+      db.query.storePrices.findFirst({
+        where: eq(storePrices.id, unrelatedPrice.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: unrelated.id });
+    await expect(
+      db.query.storePrices.findFirst({
+        where: eq(storePrices.id, similarPrice.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: source.id });
+
+    for (const consumer of [sourceReview, unresolvedReview]) {
+      await expect(
+        db.query.externalReviews.findFirst({
+          where: eq(externalReviews.id, consumer.id),
+        }),
+      ).resolves.toMatchObject({ bottleId: target.id });
+    }
+    await expect(
+      db.query.externalReviews.findFirst({
+        where: eq(externalReviews.id, unrelatedReview.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: unrelated.id });
+
+    expect(workerClient.pushJob).toHaveBeenCalledWith("IndexBottleReference", {
+      name,
+    });
+    expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
+      "IndexBottleSearchVectors",
+      { bottleId: source.id },
+    );
+    expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
+      "IndexBottleSearchVectors",
+      { bottleId: target.id },
+    );
+  });
+
+  test("unassigns the reference and exact consumers using the old identity", async ({
+    fixtures,
+  }) => {
+    const source = await fixtures.Bottle({ name: "Wrong Bottle" });
+    const unrelated = await fixtures.Bottle({ name: "Other Bottle" });
+    const user = await fixtures.User({ mod: true });
+    const actor = await getUserActor(user);
+    const name = "Ambiguous Reference";
+    const reference = await fixtures.BottleReference({
+      bottleId: source.id,
+      name,
+    });
+    const sourcePrice = await fixtures.StorePrice({
+      bottleId: source.id,
+      name,
+    });
+    const unrelatedPrice = await fixtures.StorePrice({
+      bottleId: unrelated.id,
+      name,
+    });
+    const sourceReview = await fixtures.ExternalReview({
+      bottleId: source.id,
+      name,
+    });
+    const unrelatedReview = await fixtures.ExternalReview({
+      bottleId: unrelated.id,
+      name,
+    });
+
+    const result = await routerClient.bottleReferences.update(
+      {
+        reference: reference.id,
+        expectedBottle: source.id,
+        expectedIgnored: false,
+        bottle: null,
+        ignored: true,
+      },
+      { context: { user } },
+    );
+
+    expect(result).toEqual({
+      id: reference.id,
+      name,
+      createdAt: reference.createdAt.toISOString(),
+      bottleId: null,
+      ignored: true,
+      assignmentSource: "human_approved",
+      assignedByActorId: actor.id,
+    });
+    await expect(
+      routerClient.bottleReferences.details(
+        { reference: reference.id },
+        { context: { user } },
+      ),
+    ).resolves.toEqual(result);
+    await expect(
+      db.query.bottleReferences.findFirst({
+        where: eq(bottleReferences.id, reference.id),
+      }),
+    ).resolves.toMatchObject({
+      bottleId: null,
+      ignored: true,
+      assignmentSource: "human_approved",
+      assignedByActorId: actor.id,
+    });
+    await expect(
+      db.query.storePrices.findFirst({
+        where: eq(storePrices.id, sourcePrice.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: null });
+    await expect(
+      db.query.storePrices.findFirst({
+        where: eq(storePrices.id, unrelatedPrice.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: unrelated.id });
+    await expect(
+      db.query.externalReviews.findFirst({
+        where: eq(externalReviews.id, sourceReview.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: null });
+    await expect(
+      db.query.externalReviews.findFirst({
+        where: eq(externalReviews.id, unrelatedReview.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: unrelated.id });
+  });
+
+  test("rejects a stale expected Bottle without changing data", async ({
+    fixtures,
+  }) => {
+    const source = await fixtures.Bottle();
+    const target = await fixtures.Bottle();
+    const user = await fixtures.User({ mod: true });
+    const reference = await fixtures.BottleReference({
+      bottleId: source.id,
+      name: "Stale Reference",
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: source.id,
+      name: reference.name,
+    });
+
+    const error = await waitError(
+      routerClient.bottleReferences.update(
+        {
+          reference: reference.id,
+          expectedBottle: null,
+          expectedIgnored: false,
+          bottle: target.id,
+          ignored: false,
+        },
+        { context: { user } },
+      ),
+    );
+
+    expect(error).toMatchObject({ status: 409 });
+    await expect(
+      waitError(
+        routerClient.bottleReferences.update(
+          {
+            reference: reference.id,
+            expectedBottle: source.id,
+            expectedIgnored: true,
+            bottle: null,
+            ignored: true,
+          },
+          { context: { user } },
+        ),
+      ),
+    ).resolves.toMatchObject({ status: 409 });
+    await expect(
+      db.query.bottleReferences.findFirst({
+        where: eq(bottleReferences.id, reference.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: source.id });
+    await expect(
+      db.query.storePrices.findFirst({
+        where: eq(storePrices.id, price.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: source.id });
+  });
+
+  test("prevents changing the current full-name reference", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle({ name: "Canonical Bottle" });
+    const user = await fixtures.User({ mod: true });
+    const reference = await db.query.bottleReferences.findFirst({
+      where: eq(bottleReferences.name, bottle.fullName),
+    });
+    expect(reference).toBeDefined();
+
+    const error = await waitError(
+      routerClient.bottleReferences.update(
+        {
+          reference: reference!.id,
+          expectedBottle: bottle.id,
+          expectedIgnored: false,
+          bottle: null,
+          ignored: false,
+        },
+        { context: { user } },
+      ),
+    );
+
+    expect(error).toMatchObject({
+      status: 400,
+      message:
+        "A Bottle's current full name cannot be reassigned or unassigned.",
+    });
+  });
+
+  test("rejects missing references and invalid target Bottles", async ({
+    fixtures,
+  }) => {
+    const source = await fixtures.Bottle();
+    const retired = await fixtures.Bottle();
+    const replacement = await fixtures.Bottle();
+    const user = await fixtures.User({ mod: true });
+    const reference = await fixtures.BottleReference({
+      bottleId: source.id,
+      name: "Target Validation Reference",
+    });
+    await db.insert(bottleTombstones).values({
+      bottleId: retired.id,
+      newBottleId: replacement.id,
+    });
+
+    await expect(
+      waitError(
+        routerClient.bottleReferences.update(
+          {
+            reference: 2_147_483_647,
+            expectedBottle: null,
+            expectedIgnored: false,
+            bottle: null,
+            ignored: false,
+          },
+          { context: { user } },
+        ),
+      ),
+    ).resolves.toMatchObject({ status: 404 });
+    await expect(
+      waitError(
+        routerClient.bottleReferences.update(
+          {
+            reference: reference.id,
+            expectedBottle: source.id,
+            expectedIgnored: false,
+            bottle: 2_147_483_647,
+            ignored: false,
+          },
+          { context: { user } },
+        ),
+      ),
+    ).resolves.toMatchObject({ status: 404 });
+    await expect(
+      waitError(
+        routerClient.bottleReferences.update(
+          {
+            reference: reference.id,
+            expectedBottle: source.id,
+            expectedIgnored: false,
+            bottle: retired.id,
+            ignored: false,
+          },
+          { context: { user } },
+        ),
+      ),
+    ).resolves.toMatchObject({ status: 409 });
+    await expect(
+      waitError(
+        routerClient.bottleReferences.update(
+          {
+            reference: reference.id,
+            expectedBottle: source.id,
+            expectedIgnored: false,
+            bottle: replacement.id,
+            ignored: true,
+          },
+          { context: { user } },
+        ),
+      ),
+    ).resolves.toMatchObject({ status: 400 });
+    await expect(
+      waitError(
+        routerClient.bottleReferences.details(
+          { reference: 2_147_483_647 },
+          { context: { user } },
+        ),
+      ),
+    ).resolves.toMatchObject({ status: 404 });
+  });
+
+  test("requires moderator access", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle();
+    const reference = await fixtures.BottleReference({
+      bottleId: bottle.id,
+      name: "Protected Reference",
+    });
+    const user = await fixtures.User({ mod: false });
+
+    await expect(
+      waitError(
+        routerClient.bottleReferences.update(
+          {
+            reference: reference.id,
+            expectedBottle: bottle.id,
+            expectedIgnored: false,
+            bottle: null,
+            ignored: false,
+          },
+          { context: { user } },
+        ),
+      ),
+    ).resolves.toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+    await expect(
+      waitError(
+        routerClient.bottleReferences.details(
+          { reference: reference.id },
+          { context: { user } },
+        ),
+      ),
+    ).resolves.toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+});

--- a/apps/server/src/orpc/routes/bottleReferences/update.ts
+++ b/apps/server/src/orpc/routes/bottleReferences/update.ts
@@ -1,0 +1,112 @@
+import { getUserActor } from "@peated/server/lib/actors";
+import {
+  BottleReferenceBottleInactiveError,
+  BottleReferenceBottleNotFoundError,
+  BottleReferenceBottleRetiredError,
+  BottleReferenceNotFoundError,
+  CanonicalBottleReferenceCorrectionError,
+  correctBottleReference,
+  FailedToSaveBottleReferenceError,
+  StaleBottleReferenceCorrectionError,
+} from "@peated/server/lib/bottleReferences";
+import { procedure } from "@peated/server/orpc";
+import { requireMod } from "@peated/server/orpc/middleware";
+import { z } from "zod";
+import { BottleReferenceDetailsSchema } from "./schemas";
+
+export default procedure
+  .use(requireMod)
+  .route({
+    method: "PATCH",
+    path: "/bottle-references/{reference}",
+    summary: "Correct a Bottle reference",
+    description:
+      "Reassign, unassign, or ignore one exact Bottle reference and update matching imported prices and reviews. Requires a moderator.",
+    operationId: "updateBottleReference",
+  })
+  .input(
+    z
+      .object({
+        reference: z.coerce
+          .number()
+          .int()
+          .positive()
+          .describe("Stable ID of the Bottle reference to correct"),
+        expectedBottle: z
+          .number()
+          .int()
+          .positive()
+          .nullable()
+          .describe(
+            "Bottle ID currently assigned to the reference, or `null` when unresolved",
+          ),
+        expectedIgnored: z
+          .boolean()
+          .describe("Whether the reference is currently ignored"),
+        bottle: z
+          .number()
+          .int()
+          .positive()
+          .nullable()
+          .describe(
+            "Verified replacement Bottle ID, or `null` to leave the reference unresolved",
+          ),
+        ignored: z
+          .boolean()
+          .describe(
+            "Exclude an unassigned reference from automatic matching and maintenance",
+          ),
+      })
+      .strict()
+      .superRefine((input, ctx) => {
+        if (input.bottle !== null && input.ignored) {
+          ctx.addIssue({
+            code: "custom",
+            path: ["ignored"],
+            message: "An assigned Bottle reference cannot be ignored.",
+          });
+        }
+      }),
+  )
+  .output(BottleReferenceDetailsSchema)
+  .handler(async ({ input, context, errors }) => {
+    try {
+      const actor = await getUserActor(context.user);
+      const reference = await correctBottleReference(
+        {
+          referenceId: input.reference,
+          expectedBottleId: input.expectedBottle,
+          expectedIgnored: input.expectedIgnored,
+          bottleId: input.bottle,
+          ignored: input.ignored,
+          assignedByActorId: actor.id,
+        },
+        { bottleReference: { id: input.reference } },
+      );
+      return {
+        ...reference,
+        createdAt: reference.createdAt.toISOString(),
+      };
+    } catch (err) {
+      if (
+        err instanceof BottleReferenceNotFoundError ||
+        err instanceof BottleReferenceBottleNotFoundError
+      ) {
+        throw errors.NOT_FOUND({ message: err.message });
+      }
+      if (err instanceof CanonicalBottleReferenceCorrectionError) {
+        throw errors.BAD_REQUEST({ message: err.message });
+      }
+      if (
+        err instanceof StaleBottleReferenceCorrectionError ||
+        err instanceof BottleReferenceBottleInactiveError ||
+        err instanceof BottleReferenceBottleRetiredError
+      ) {
+        throw errors.CONFLICT({ message: err.message });
+      }
+      if (err instanceof FailedToSaveBottleReferenceError) {
+        throw errors.INTERNAL_SERVER_ERROR({ message: err.message });
+      }
+      throw err;
+    }
+  });

--- a/docs/architecture/bottle-reference-resolution.md
+++ b/docs/architecture/bottle-reference-resolution.md
@@ -127,6 +127,18 @@ customer search. It does not resolve ingestion or move existing consumers. The
 same alias text can belong to more than one Bottle. Bottle details show these
 names as “Also known as.”
 
+A moderator may correct an accepted reference by its stable reference ID. The
+write must include the Bottle ID and ignored state observed before the
+correction, including `null` for an unresolved reference. A stale value fails
+instead of overwriting another decision. Reassignment moves exact-name prices
+and reviews still using the observed Bottle, plus unresolved exact-name
+consumers. Unassignment moves only exact-name consumers still using the
+observed Bottle back to `null`. An intentionally ambiguous or invalid reference
+may also be marked ignored so automated maintenance does not reconsider it.
+Consumers assigned to any other Bottle stay unchanged. An ignored reference
+cannot remain assigned, and a current Bottle full name cannot be reassigned or
+unassigned.
+
 ## Resolution Pipeline
 
 All source-reference workflows follow the same conceptual pipeline:
@@ -238,6 +250,8 @@ separate inventory, migration plan, and database verification.
 Deterministic coverage should prove:
 
 - exact accepted references resolve one Bottle;
+- moderator corrections reject stale state, preserve unrelated assignments,
+  and protect current Bottle names;
 - the shared server classifier entry point returns that accepted Bottle without
   a model call;
 - general references resolve the retained general Bottle without selecting a

--- a/docs/operations/catalog-maintenance.md
+++ b/docs/operations/catalog-maintenance.md
@@ -214,6 +214,27 @@ pnpm cli api get '/bottles/123/aliases'
 pnpm cli api get '/bottle-references?bottle=123&limit=100'
 ```
 
+When evidence proves an existing Bottle reference is wrong, correct it by its
+stable reference ID. First read `GET /bottle-references/789`, then include its
+current `bottleId` and `ignored` values as `expectedBottle` and
+`expectedIgnored`. Set `bottle` to the verified replacement, or to `null` when
+the name is ambiguous. Set `ignored` to `true` only for an unassigned name that
+automated maintenance should not reconsider. The server rejects stale state and
+preserves consumers assigned to another Bottle.
+
+```json
+{
+  "expectedBottle": 123,
+  "expectedIgnored": false,
+  "bottle": 456,
+  "ignored": false
+}
+```
+
+Send that body with `PATCH /bottle-references/789`. Re-fetch the reference and
+both Bottle reference lists after the write. Also verify exact-name prices and
+reviews when any exist.
+
 Follow `rel.nextCursor` until every page is loaded. Before a write, check the
 live [full OpenAPI specification](https://api.peated.com/spec-full.json). Do not
 rely on a stale checkout or an old request shape.


### PR DESCRIPTION
Moderators can now inspect a Bottle reference by stable ID and correct its assignment through a dedicated `PATCH /bottle-references/{reference}` contract. The write carries the previously observed Bottle and ignored state, rejects stale changes, prevents assigned references from being ignored, and protects current canonical Bottle names.

Corrections run transactionally with exact-name store prices and external reviews: reassignment moves consumers still using the old Bottle plus unresolved matches, while unassignment leaves unrelated Bottle assignments untouched. The existing reference upsert remains conflict-safe and unchanged. Successful corrections record human-approved actor provenance and reindex the reference and affected Bottles; no schema migration is required.

The operational guide now documents the read-before-write flow. Review should focus on the optimistic-state check and the bounded consumer selection in the correction transaction.
