### PR TITLE
feat(web): show bottle images on tasting and review pages

### DIFF
--- a/apps/web/src/app/(app)/reviews/[reviewId]/reviewDetail.stylex.tsx
+++ b/apps/web/src/app/(app)/reviews/[reviewId]/reviewDetail.stylex.tsx
@@ -17,6 +17,7 @@ export function ReviewDetail({ review }: { review: Review }) {
       createdAt={review.createdAt}
       friends={review.friends}
       notes={review.notes}
+      photoUrl={review.imageUrl}
       rating={{ kind: "review", score: review.score }}
       servingStyle={review.servingStyle}
       tags={review.tags}

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
@@ -26,6 +26,7 @@ export function TastingDetail({ tasting }: { tasting: Tasting }) {
       }
       friends={tasting.friends}
       notes={tasting.notes}
+      photoUrl={tasting.imageUrl}
       rating={{ kind: "tasting", ratingBand: tasting.ratingBand }}
       servingStyle={tasting.servingStyle}
       tags={tasting.tags}

--- a/apps/web/src/components/pages/tastingReviewBottleSummary.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewBottleSummary.stylex.tsx
@@ -1,0 +1,83 @@
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
+import type { Outputs } from "@peated/server/orpc/router";
+import * as stylex from "@stylexjs/stylex";
+
+import { BottleList, BottleVisual } from "@peated/web/components";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
+import { space } from "../../styles/tokens.stylex";
+
+const NARROW = "@media (max-width: 759px)";
+
+type Bottle = Outputs["tastings"]["details"]["bottle"];
+
+export type TastingReviewBottleSummaryProps = {
+  bottle: Bottle;
+  photoUrl?: string | null;
+  placement: "desktop" | "mobile";
+};
+
+/** Uses the tasting or review photo when present; otherwise uses the Bottle image. */
+export function TastingReviewBottleSummary({
+  bottle,
+  photoUrl,
+  placement,
+}: TastingReviewBottleSummaryProps) {
+  const bottleName = formatBottleDisplayName(bottle);
+  const imageUrl = photoUrl ?? bottle.imageUrl;
+
+  return (
+    <div
+      {...stylex.props(
+        styles.media,
+        placement === "desktop" ? styles.desktop : styles.mobile,
+      )}
+    >
+      {imageUrl ? (
+        <figure {...stylex.props(styles.photo)}>
+          <BottleVisual
+            expandable
+            imageUrl={imageUrl}
+            label={`${bottleName} image`}
+            size="xl"
+          />
+        </figure>
+      ) : null}
+
+      <BottleList
+        ariaLabel="Bottle"
+        items={[{ ...toBottleListItem(bottle), variant: "sidebar" }]}
+      />
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  media: {
+    minWidth: 0,
+  },
+  desktop: {
+    display: {
+      default: "block",
+      [NARROW]: "none",
+    },
+  },
+  mobile: {
+    display: {
+      default: "none",
+      [NARROW]: "block",
+    },
+    marginTop: space.x6,
+    marginBottom: space.x2,
+  },
+  photo: {
+    width: "100%",
+    maxWidth: {
+      default: "100%",
+      [NARROW]: "440px",
+    },
+    marginTop: 0,
+    marginRight: "auto",
+    marginBottom: 0,
+    marginLeft: "auto",
+  },
+});

--- a/apps/web/src/components/pages/tastingReviewBottleSummary.test.tsx
+++ b/apps/web/src/components/pages/tastingReviewBottleSummary.test.tsx
@@ -1,0 +1,47 @@
+import { mockBottle } from "@peated/server/orpc/mock/fixtures";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { TastingReviewBottleSummary } from "./tastingReviewBottleSummary.stylex";
+
+describe("TastingReviewBottleSummary", () => {
+  it("prefers the tasting or review photo over the catalog image", () => {
+    const html = renderToStaticMarkup(
+      <TastingReviewBottleSummary
+        bottle={{ ...mockBottle, imageUrl: "/catalog.webp" }}
+        photoUrl="/tasting.webp"
+        placement="desktop"
+      />,
+    );
+
+    expect(html).toContain('src="/tasting.webp"');
+    expect(html.indexOf('src="/tasting.webp"')).toBeLessThan(
+      html.indexOf('src="/catalog.webp"'),
+    );
+  });
+
+  it("uses the catalog image when the tasting or review has no photo", () => {
+    const html = renderToStaticMarkup(
+      <TastingReviewBottleSummary
+        bottle={{ ...mockBottle, imageUrl: "/catalog.webp" }}
+        photoUrl={null}
+        placement="desktop"
+      />,
+    );
+
+    expect(html.match(/src="\/catalog\.webp"/g)).toHaveLength(2);
+  });
+
+  it("does not show a large image when neither image exists", () => {
+    const html = renderToStaticMarkup(
+      <TastingReviewBottleSummary
+        bottle={mockBottle}
+        photoUrl={null}
+        placement="mobile"
+      />,
+    );
+
+    expect(html).not.toContain("at full size");
+    expect(html).toContain("Lagavulin 16-year-old");
+  });
+});

--- a/apps/web/src/components/pages/tastingReviewDetail.stories.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stories.tsx
@@ -1,9 +1,11 @@
-import { mockTasting } from "@peated/server/orpc/mock/fixtures";
+import { mockTastings } from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import { ButtonLink } from "../button.stylex";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import { TastingReviewDetail } from "./tastingReviewDetail.stylex";
+
+const photoTasting = mockTastings[6]!;
 
 const meta = {
   title: "Pages/Tasting and Review Detail",
@@ -16,20 +18,21 @@ const meta = {
     ),
   ],
   args: {
-    author: mockTasting.createdBy,
-    bottle: mockTasting.bottle,
-    color: mockTasting.color,
-    createdAt: mockTasting.createdAt,
+    author: photoTasting.createdBy,
+    bottle: photoTasting.bottle,
+    color: photoTasting.color,
+    createdAt: photoTasting.createdAt,
     footer: (
       <ButtonLink href="/login" size="sm" variant="tonal">
         Toast
       </ButtonLink>
     ),
-    friends: mockTasting.friends,
-    notes: mockTasting.notes,
-    rating: { kind: "tasting", ratingBand: mockTasting.ratingBand },
-    servingStyle: mockTasting.servingStyle,
-    tags: mockTasting.tags,
+    friends: photoTasting.friends,
+    notes: photoTasting.notes,
+    photoUrl: photoTasting.imageUrl,
+    rating: { kind: "tasting", ratingBand: photoTasting.ratingBand },
+    servingStyle: photoTasting.servingStyle,
+    tags: photoTasting.tags,
   },
   argTypes: {
     footer: { control: false },

--- a/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
@@ -16,6 +16,7 @@ import {
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 import { PageHeader } from "./pageLayout.stylex";
+import { TastingReviewBottleSummary } from "./tastingReviewBottleSummary.stylex";
 
 type Bottle = Outputs["tastings"]["details"]["bottle"];
 type Member = Outputs["tastings"]["details"]["createdBy"];
@@ -39,6 +40,7 @@ export function TastingReviewDetail({
   footer,
   friends,
   notes,
+  photoUrl,
   rating,
   servingStyle,
   tags,
@@ -50,6 +52,7 @@ export function TastingReviewDetail({
   footer?: ReactNode;
   friends: readonly Member[];
   notes?: string | null;
+  photoUrl?: string | null;
   rating: Rating;
   servingStyle?: ServingStyle;
   tags: readonly string[];
@@ -103,6 +106,12 @@ export function TastingReviewDetail({
             </span>
           )}
         </header>
+
+        <TastingReviewBottleSummary
+          bottle={bottle}
+          photoUrl={photoUrl}
+          placement="mobile"
+        />
 
         {facts.length ? (
           <div {...stylex.props(styles.facts)}>

--- a/apps/web/src/components/pages/tastingReviewRail.stories.tsx
+++ b/apps/web/src/components/pages/tastingReviewRail.stories.tsx
@@ -1,4 +1,8 @@
-import { mockBottle, mockTasting } from "@peated/server/orpc/mock/fixtures";
+import {
+  mockBottle,
+  mockTasting,
+  mockTastings,
+} from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import * as stylex from "@stylexjs/stylex";
 
@@ -13,6 +17,7 @@ const longNameBottle = {
   series: null,
   imageUrl: null,
 };
+const photoTasting = mockTastings[6]!;
 
 const meta = {
   title: "Components/Reviews & Tastings/Tasting Review Rail",
@@ -25,9 +30,9 @@ const meta = {
     ),
   ],
   args: {
-    author: mockTasting.createdBy,
-    bottle: mockBottle,
-    currentTastingId: mockTasting.id,
+    author: photoTasting.createdBy,
+    bottle: photoTasting.bottle,
+    currentTastingId: photoTasting.id,
     externalReviews: [],
     memberReviews: [],
     memberTastings: [
@@ -49,12 +54,13 @@ const meta = {
       },
       { ...mockTasting, id: 9613 },
     ],
+    photoUrl: photoTasting.imageUrl,
   },
   parameters: {
     docs: {
       description: {
         component:
-          "The sidebar used by tasting and review pages, shown at its 336px desktop width. Long names retain a full accessible label and title, with a two-line visual limit. Dates and optional ratings share one line below the name. Includes long names, missing images, and an unrated tasting using fixture data.",
+          "The sidebar used by tasting and review pages, shown at its 336px desktop width. The large image uses the tasting or review photo when present; otherwise it uses the catalog Bottle image. The Bottle link uses the shared sidebar identity without a repeated heading. Long names retain a full accessible label and title, with a two-line visual limit. Dates and optional ratings share one line below the name.",
       },
     },
   },
@@ -64,6 +70,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Overview: Story = {};
+
+export const BottleImage: Story = {
+  args: { photoUrl: null },
+};
+
+export const WithoutImage: Story = {
+  args: { bottle: mockBottle, photoUrl: null },
+};
 
 export const Empty: Story = {
   args: { memberTastings: [] },

--- a/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
@@ -1,19 +1,14 @@
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 
-import {
-  BottleVisual,
-  RailList,
-  RailListItem,
-  TastingRating,
-} from "@peated/web/components";
+import { RailList, RailListItem, TastingRating } from "@peated/web/components";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getTastingUrl } from "@peated/web/lib/urls";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 import { BottleRailSection } from "./bottleRailSection.stylex";
 import { RailListSection } from "./railListSection.stylex";
+import { TastingReviewBottleSummary } from "./tastingReviewBottleSummary.stylex";
 
 type Bottle = Outputs["tastings"]["details"]["bottle"];
 type Member = Outputs["tastings"]["details"]["createdBy"];
@@ -47,7 +42,6 @@ export function TastingReviewRail({
   memberReviews: readonly MemberReview[];
   memberTastings: readonly Tasting[];
 }) {
-  const bottleName = formatBottleDisplayName(bottle);
   const moreFromMember = memberTastings
     .filter((tasting) => tasting.id !== currentTastingId)
     .slice(0, 4);
@@ -61,20 +55,10 @@ export function TastingReviewRail({
 
   return (
     <>
-      {photoUrl ? (
-        <figure {...stylex.props(styles.photo)}>
-          <BottleVisual
-            expandable
-            imageUrl={photoUrl}
-            label={`${bottleName} photo`}
-            size="xl"
-          />
-        </figure>
-      ) : null}
-
-      <BottleRailSection
-        heading="This bottle"
-        items={[toBottleListItem(bottle)]}
+      <TastingReviewBottleSummary
+        bottle={bottle}
+        photoUrl={photoUrl}
+        placement="desktop"
       />
 
       <BottleRailSection
@@ -165,10 +149,6 @@ const styles = stylex.create({
   tastingDate: {
     color: colors.inkMuted,
     whiteSpace: "nowrap",
-  },
-  photo: {
-    minWidth: 0,
-    margin: 0,
   },
   empty: {
     margin: 0,


### PR DESCRIPTION
Tasting and member-review pages now show a prominent image beside the review on desktop and between the rating and details on mobile. The page uses the tasting or review photo when available, falls back to the Bottle image, and omits the large frame when neither exists.

The Bottle link remains directly below the image using the shared Bottle identity row. Related tastings and reviews keep their existing rail placement.

Refs #1064.
