### PR TITLE
style(web): use Hanken Grotesk for display type

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -35,31 +35,31 @@ colors:
   section-rule-dark: "rgb(232 234 227 / 0.16)"
 typography:
   page-title:
-    fontFamily: Space Grotesk
+    fontFamily: Hanken Grotesk
     fontSize: 72px
     fontWeight: 700
     lineHeight: 0.95
-    letterSpacing: -0.05em
+    letterSpacing: -0.045em
   compact-page-title:
-    fontFamily: Space Grotesk
+    fontFamily: Hanken Grotesk
     fontSize: 40px
     fontWeight: 700
     lineHeight: 1.1
     letterSpacing: -0.04em
   section-heading:
-    fontFamily: Space Grotesk
+    fontFamily: Hanken Grotesk
     fontSize: 20px
     fontWeight: 700
     lineHeight: 1.2
     letterSpacing: -0.025em
   row-title:
-    fontFamily: Space Grotesk
+    fontFamily: Hanken Grotesk
     fontSize: 18px
     fontWeight: 700
     lineHeight: 1.25
     letterSpacing: -0.025em
   compact-row-title:
-    fontFamily: Space Grotesk
+    fontFamily: Hanken Grotesk
     fontSize: 15px
     fontWeight: 700
     lineHeight: 1.25
@@ -227,7 +227,7 @@ sentiment poles.
 
 ## Typography
 
-- **Space Grotesk** is the display face for names, headings, and meaningful
+- **Hanken Grotesk** is the display face for names, headings, and meaningful
   figures.
 - **Karla** is the reading face for prose, labels, and member input.
 - **IBM Plex Mono** is available for rare values that must align as code-like
@@ -244,7 +244,7 @@ sentiment poles.
 
 | Role                | Family  | Weight | Size and line height | Tracking |
 | ------------------- | ------- | ------ | -------------------- | -------- |
-| Page title          | Display | 700    | 40–72px / 0.95       | -0.05em  |
+| Page title          | Display | 700    | 40–72px / 0.95       | -0.045em |
 | Compact page title  | Display | 700    | 32–40px / 1.1        | -0.04em  |
 | Section heading     | Display | 700    | 20px / 1.2           | -0.025em |
 | Row title           | Display | 700    | 18px / 1.25          | -0.025em |

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -1,5 +1,5 @@
+import "@fontsource-variable/hanken-grotesk";
 import "@fontsource-variable/karla";
-import "@fontsource-variable/space-grotesk";
 import "@fontsource/ibm-plex-mono/400.css";
 import "@fontsource/ibm-plex-mono/500.css";
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,8 +25,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fontsource-variable/hanken-grotesk": "^5.3.0",
     "@fontsource-variable/karla": "^5.3.0",
-    "@fontsource-variable/space-grotesk": "^5.3.0",
     "@fontsource/ibm-plex-mono": "^5.3.0",
     "@headlessui/react": "^2.2.10",
     "@hookform/resolvers": "^5.4.0",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,5 @@
+import "@fontsource-variable/hanken-grotesk";
 import "@fontsource-variable/karla";
-import "@fontsource-variable/space-grotesk";
 import "@fontsource/ibm-plex-mono/400.css";
 import "@fontsource/ibm-plex-mono/500.css";
 import Fathom from "@peated/web/components/fathom";

--- a/apps/web/src/components/foundations.stylex.tsx
+++ b/apps/web/src/components/foundations.stylex.tsx
@@ -169,7 +169,7 @@ export default function Foundations({
                 />
               </ItemList>
               <p {...stylex.props(foundationStyles.metadata, styles.muted)}>
-                Space Grotesk: page titles, section headings, and names.
+                Hanken Grotesk: page titles, section headings, and names.
                 Sections use 20px; rows use 18px or 15px in compact lists.
               </p>
             </article>

--- a/apps/web/src/styles/foundations.stylex.ts
+++ b/apps/web/src/styles/foundations.stylex.ts
@@ -21,7 +21,7 @@ export const foundationStyles = stylex.create({
     fontFamily: fonts.display,
     fontSize: "clamp(40px, 5vw, 72px)",
     fontWeight: 700,
-    letterSpacing: "-0.05em",
+    letterSpacing: "-0.045em",
     lineHeight: 0.95,
   },
   pageTitleCompact: {

--- a/apps/web/src/styles/tokens.stylex.ts
+++ b/apps/web/src/styles/tokens.stylex.ts
@@ -161,7 +161,7 @@ export const darkColorTheme = stylex.createTheme(colors, {
 });
 
 export const fonts = stylex.defineVars({
-  display: '"Space Grotesk Variable", sans-serif',
+  display: '"Hanken Grotesk Variable", sans-serif',
   reading: '"Karla Variable", sans-serif',
   data: '"IBM Plex Mono", monospace',
 });

--- a/openspec/changes/improve-company-pages/company-page-prototype.html
+++ b/openspec/changes/improve-company-pages/company-page-prototype.html
@@ -15,7 +15,7 @@
         --hairline: rgb(232 234 227 / 0.1);
         --rule: rgb(232 234 227 / 0.16);
         --accent: #d9922f;
-        --display: "Space Grotesk", "Arial Narrow", sans-serif;
+        --display: "Hanken Grotesk", "Arial Narrow", sans-serif;
         --reading: Karla, system-ui, sans-serif;
       }
       * {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -430,10 +430,10 @@ importers:
 
   apps/web:
     dependencies:
-      '@fontsource-variable/karla':
+      '@fontsource-variable/hanken-grotesk':
         specifier: ^5.3.0
         version: 5.3.0
-      '@fontsource-variable/space-grotesk':
+      '@fontsource-variable/karla':
         specifier: ^5.3.0
         version: 5.3.0
       '@fontsource/ibm-plex-mono':
@@ -2198,11 +2198,11 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@fontsource-variable/hanken-grotesk@5.3.0':
+    resolution: {integrity: sha512-DOd0FqL+3cH2dfNy0JtSq9tUfxBz5mLmHMjTU0DOr3E9Zo6wxuatCl53DIPNrSPgCsnuKyM739BTIG5glCLirw==}
+
   '@fontsource-variable/karla@5.3.0':
     resolution: {integrity: sha512-CypH/IGhvpU0I4sue6YG+ZDyx5heglFJAiU2NClTkKOh+jsqjZ7AAgWKGG59+X1dGCN/9L4BLLacCXD7TBBETA==}
-
-  '@fontsource-variable/space-grotesk@5.3.0':
-    resolution: {integrity: sha512-2IxmvfB08i9vnGB3Ym/AXvhRE+8XOjWMXIyDum03c+tPwH0FUoMNQfGpU8NXPxjbws0Vvss3AH0Zqt4oJBBAdw==}
 
   '@fontsource/ibm-plex-mono@5.3.0':
     resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
@@ -12301,9 +12301,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@fontsource-variable/karla@5.3.0': {}
+  '@fontsource-variable/hanken-grotesk@5.3.0': {}
 
-  '@fontsource-variable/space-grotesk@5.3.0': {}
+  '@fontsource-variable/karla@5.3.0': {}
 
   '@fontsource/ibm-plex-mono@5.3.0': {}
 


### PR DESCRIPTION
Peated now uses Hanken Grotesk for names, headings, and meaningful figures across the app and Storybook. This replaces the Space Grotesk Fontsource dependency while leaving Karla and IBM Plex Mono unchanged. Large page-title tracking moves from `-0.05em` to `-0.045em` to preserve the selected Hanken spacing, and the design reference and active company-page prototype stay aligned with the shipped system.

The shared typography foundation, catalog detail composition, and long bottle-row layouts were reviewed in light and dark themes at desktop and 390px widths. Hanken loaded at every display size, long names wrapped without horizontal overflow, and the foundation accessibility audit reported no violations.
