### PR TITLE
feat(web): restore tasting detail actions

### DIFF
--- a/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
@@ -2,6 +2,7 @@ import {
   PageColumns,
   PageSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
+import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { getTastingPage } from "@peated/web/lib/tastingPage.server";
 import {
@@ -27,11 +28,13 @@ export default async function TastingPage(props: {
   const tasting = await getTastingPage(tastingId);
   const structuredData = serializeTastingStructuredData(tasting);
   const { client } = await getPublicPageServerClient();
-  const [memberTastings, memberReviews, externalReviews] = await Promise.all([
-    client.tastings.list({ user: tasting.createdBy.id, limit: 5 }),
-    client.memberReviews.list({ bottle: tasting.bottle.id, limit: 4 }),
-    client.externalReviews.list({ bottle: tasting.bottle.id, limit: 4 }),
-  ]);
+  const [currentUser, memberTastings, memberReviews, externalReviews] =
+    await Promise.all([
+      getCurrentUser(),
+      client.tastings.list({ user: tasting.createdBy.id, limit: 5 }),
+      client.memberReviews.list({ bottle: tasting.bottle.id, limit: 4 }),
+      client.externalReviews.list({ bottle: tasting.bottle.id, limit: 4 }),
+    ]);
 
   return (
     <PageColumns
@@ -51,7 +54,13 @@ export default async function TastingPage(props: {
           dangerouslySetInnerHTML={{ __html: structuredData }}
         />
       )}
-      <TastingDetail tasting={tasting} />
+      <TastingDetail
+        canManage={
+          currentUser?.id === tasting.createdBy.id ||
+          Boolean(currentUser?.admin)
+        }
+        tasting={tasting}
+      />
       <div id="comments">
         <PageSection heading="Comments">
           <TastingComments tastingId={tasting.id} />

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingActions.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingActions.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+import { RowMenu } from "@peated/web/components";
+import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import useAuth from "@peated/web/hooks/useAuth";
+import { useORPC } from "@peated/web/lib/orpc/context";
+
+type Tasting = Outputs["tastings"]["details"];
+
+export function TastingActions({ tasting }: { tasting: Tasting }) {
+  const { user } = useAuth();
+  const orpc = useORPC();
+  const router = useRouter();
+  const { flash } = useFlashMessages();
+  const deleteMutation = useMutation(orpc.tastings.delete.mutationOptions());
+
+  const isOwner = user?.id === tasting.createdBy.id;
+  if (!isOwner && !user?.admin) return null;
+
+  return (
+    <RowMenu
+      groups={[
+        ...(isOwner
+          ? [
+              [
+                {
+                  href: `/tastings/${tasting.id}/edit`,
+                  label: "Edit tasting",
+                },
+              ],
+            ]
+          : []),
+        [
+          {
+            disabled: deleteMutation.isPending,
+            label: deleteMutation.isPending
+              ? "Deleting tasting…"
+              : "Delete tasting",
+            onSelect: () => {
+              if (
+                !window.confirm(
+                  "Permanently delete this tasting? This cannot be undone.",
+                )
+              ) {
+                return;
+              }
+              void deleteMutation
+                .mutateAsync({ tasting: tasting.id })
+                .then(() =>
+                  router.replace(
+                    `/users/${tasting.createdBy.username}/tastings`,
+                  ),
+                )
+                .catch((error) => {
+                  flash(
+                    error instanceof Error
+                      ? error.message
+                      : "Unable to delete this tasting.",
+                    "error",
+                  );
+                });
+            },
+          },
+        ],
+      ]}
+      label="Tasting"
+      triggerVariant="text"
+    />
+  );
+}

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
@@ -4,12 +4,20 @@ import { TastingToastSummary } from "@peated/web/components";
 import { TastingReviewDetail } from "@peated/web/components/pages/tastingReviewDetail.stylex";
 import { TastingReviewRail } from "@peated/web/components/pages/tastingReviewRail.stylex";
 
+import { TastingActions } from "./tastingActions";
+
 type Tasting = Outputs["tastings"]["details"];
 type TastingList = Outputs["tastings"]["list"]["results"];
 type MemberReviewList = Outputs["memberReviews"]["list"]["results"];
 type ExternalReviewList = Outputs["externalReviews"]["list"]["results"];
 
-export function TastingDetail({ tasting }: { tasting: Tasting }) {
+export function TastingDetail({
+  canManage,
+  tasting,
+}: {
+  canManage: boolean;
+  tasting: Tasting;
+}) {
   return (
     <TastingReviewDetail
       author={tasting.createdBy}
@@ -25,6 +33,7 @@ export function TastingDetail({ tasting }: { tasting: Tasting }) {
         />
       }
       friends={tasting.friends}
+      menu={canManage ? <TastingActions tasting={tasting} /> : undefined}
       notes={tasting.notes}
       photoUrl={tasting.imageUrl}
       rating={{ kind: "tasting", ratingBand: tasting.ratingBand }}

--- a/apps/web/src/components/button.stylex.tsx
+++ b/apps/web/src/components/button.stylex.tsx
@@ -256,8 +256,14 @@ const styles = stylex.create({
     padding: 0,
   },
   controlSmall: {
+    position: "relative",
     height: controlMetrics.controlHeightSmall,
     fontSize: "13px",
+    "::after": {
+      position: "absolute",
+      inset: "-2px",
+      content: '""',
+    },
   },
   controlMedium: {
     height: controlMetrics.controlHeight,

--- a/apps/web/src/components/pages/tastingReviewDetail.stories.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stories.tsx
@@ -2,6 +2,7 @@ import { mockTastings } from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import { ButtonLink } from "../button.stylex";
+import { RowMenu } from "../rowMenu.stylex";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import { TastingReviewDetail } from "./tastingReviewDetail.stylex";
 
@@ -28,6 +29,16 @@ const meta = {
       </ButtonLink>
     ),
     friends: photoTasting.friends,
+    menu: (
+      <RowMenu
+        groups={[
+          [{ href: "/tastings/1/edit", label: "Edit tasting" }],
+          [{ label: "Delete tasting", onSelect: () => undefined }],
+        ]}
+        label="Tasting"
+        triggerVariant="text"
+      />
+    ),
     notes: photoTasting.notes,
     photoUrl: photoTasting.imageUrl,
     rating: { kind: "tasting", ratingBand: photoTasting.ratingBand },
@@ -36,6 +47,7 @@ const meta = {
   },
   argTypes: {
     footer: { control: false },
+    menu: { control: false },
   },
 } satisfies Meta<typeof TastingReviewDetail>;
 

--- a/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
@@ -39,6 +39,7 @@ export function TastingReviewDetail({
   createdAt,
   footer,
   friends,
+  menu,
   notes,
   photoUrl,
   rating,
@@ -51,6 +52,7 @@ export function TastingReviewDetail({
   createdAt: string;
   footer?: ReactNode;
   friends: readonly Member[];
+  menu?: ReactNode;
   notes?: string | null;
   photoUrl?: string | null;
   rating: Rating;
@@ -59,6 +61,7 @@ export function TastingReviewDetail({
 }) {
   const bottleName = formatBottleDisplayName(bottle);
   const bottleTitle = bottleName.replaceAll(" - ", "\u00a0- ");
+  const metadata = `${rating.kind === "review" ? "Review" : "Tasting"} · ${fullDateFormatter.format(new Date(createdAt))}`;
   const facts = [
     servingStyle
       ? { label: "Serving", value: formatServingStyle(servingStyle) }
@@ -69,7 +72,16 @@ export function TastingReviewDetail({
   return (
     <article {...stylex.props(styles.detail)}>
       <PageHeader
-        metadata={`${rating.kind === "review" ? "Review" : "Tasting"} · ${fullDateFormatter.format(new Date(createdAt))}`}
+        metadata={
+          menu ? (
+            <div {...stylex.props(styles.metadataRow)}>
+              <span>{metadata}</span>
+              {menu}
+            </div>
+          ) : (
+            metadata
+          )
+        }
         title={bottleTitle}
       />
 
@@ -186,6 +198,12 @@ const styles = stylex.create({
   },
   body: {
     paddingTop: space.x4,
+  },
+  metadataRow: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: space.x3,
   },
   recordHeader: {
     display: "flex",

--- a/apps/web/src/styles/tokens.stylex.ts
+++ b/apps/web/src/styles/tokens.stylex.ts
@@ -204,7 +204,7 @@ export const controlMetrics = stylex.defineVars({
   controlHeightSmall: {
     default: "34px",
     [COARSE_POINTER]: "44px",
-    [NARROW]: "44px",
+    [NARROW]: "40px",
   },
   controlHeight: {
     default: "40px",


### PR DESCRIPTION
Tasting detail pages now give the tasting owner a compact, frameless action menu beside the tasting date. Owners can edit or delete their tasting, administrators can delete it, and other visitors do not see an empty control. Deletion requires confirmation and returns to the member's tasting list.

Small controls now use a 40px visual footprint on narrow screens while retaining an expanded interaction area. This keeps the metadata row compact without reducing the touch target.
