### PR TITLE
ref(scrapers): retire Cadenhead's registration

### DIFF
--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -21,7 +21,6 @@ const registeredSources = [
   "astorwines",
   "berrybrosrudd",
   "bruichladdich",
-  "cadenheads",
   "decadentdrinks",
   "douglaslaing",
   "dramface",
@@ -56,6 +55,7 @@ const registeredReviewSources = [
 
 const configuredSources = [
   "bourbonculture",
+  "cadenheads",
   "compassbox",
   "gordonmacphail",
   "kilchoman",

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -12,7 +12,6 @@ import {
 import scrapeAstorWines from "./adapters/legacy/scrapeAstorWines";
 import scrapeBerryBrosRudd from "./adapters/legacy/scrapeBerryBrosRudd";
 import scrapeBruichladdich from "./adapters/legacy/scrapeBruichladdich";
-import scrapeCadenheads from "./adapters/legacy/scrapeCadenheads";
 import scrapeDecadentDrinks from "./adapters/legacy/scrapeDecadentDrinks";
 import scrapeDouglasLaing from "./adapters/legacy/scrapeDouglasLaing";
 import scrapeDramfool from "./adapters/legacy/scrapeDramfool";
@@ -79,11 +78,6 @@ const legacyPriceSources = [
     type: "bruichladdich",
     origin: "https://www.bruichladdich.com",
     scrape: scrapeBruichladdich,
-  },
-  {
-    type: "cadenheads",
-    origin: "https://www.cadenhead.shop",
-    scrape: scrapeCadenheads,
   },
   {
     type: "decadentdrinks",
@@ -234,6 +228,15 @@ export const scraperRegistry = createScraperRegistry({
       origins: [
         {
           origin: "https://thebourbonculture.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
+      key: "cadenheads",
+      origins: [
+        {
+          origin: "https://www.cadenhead.shop",
           robots: { mode: "enforce" },
         },
       ],


### PR DESCRIPTION
## Summary

- remove the obsolete code-owned Cadenhead's source registration after its saved rules passed production acceptance
- keep the Cadenhead's request target and robots policy for the configured runtime
- update registry coverage to treat Cadenhead's as a configured source

## Verification

- `pnpm --filter @peated/server test -- src/scraper/registry.test.ts`
- `pnpm --filter @peated/server typecheck`
- Prettier, oxlint, and `git diff --check`