### PR TITLE
feat(scrapers): prepare Bruichladdich for saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -115,6 +115,15 @@ function prepareCadenheads(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareBruichladdich(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "bruichladdich", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareGordonMacphail(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "gordonmacphail", ...input },
@@ -139,6 +148,7 @@ const canonicalUrl =
 function codeOwnedSource(
   key:
     | "bourbonculture"
+    | "bruichladdich"
     | "cadenheads"
     | "compassbox"
     | "gordonmacphail"
@@ -208,6 +218,11 @@ const compassBoxRegistry = createScraperRegistry({
 const cadenheadsRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("cadenheads")!],
   sources: [codeOwnedSource("cadenheads")],
+});
+
+const bruichladdichRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("bruichladdich")!],
+  sources: [codeOwnedSource("bruichladdich")],
 });
 
 const gordonMacphailRegistry = createScraperRegistry({
@@ -618,6 +633,25 @@ async function setupCadenheadsMigration() {
     })
     .returning();
   await syncScraperDefinitions(cadenheadsRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
+}
+
+async function setupBruichladdichMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "bruichladdich",
+      name: "Bruichladdich",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(bruichladdichRegistry);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "succeeded",
@@ -1388,6 +1422,98 @@ describe("POST /admin/scrape-sources/prepare", () => {
     await expect(prepareCadenheads({ apply: true })).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: expect.stringContaining("Check Cadenhead's price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares Bruichladdich without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupBruichladdichMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "8468808368301",
+      name: "Bruichladdich The Classic Laddie 10 Aged Years",
+      price: 4600,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.bruichladdich.com/products/bruichladdich-the-classic-laddie",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "7420351381677",
+      name: "Bruichladdich Black Art Edition 11",
+      price: 39500,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.bruichladdich.com/products/bruichladdich-black-art-edition-11",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareBruichladdich()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareBruichladdich({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(bruichladdichRegistry);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl:
+          "https://www.bruichladdich.com/collections/all?filter.v.availability=1",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+  });
+
+  test("refuses an unexpected Bruichladdich price", async ({ fixtures }) => {
+    const site = await setupBruichladdichMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "not-a-number",
+      name: "Unknown release",
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.bruichladdich.com/products/unknown-release",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+
+    await expect(prepareBruichladdich({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check Bruichladdich price"),
     });
     expect(await db.select().from(storePrices)).toEqual(prices);
     expect(await db.select().from(scrapeSources)).toEqual([]);

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -2,6 +2,7 @@ import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import { ExternalSiteKeySchema } from "@peated/server/schemas";
 import { prepareBourbonCultureSource } from "@peated/server/scraper/configured/prepareBourbonCulture";
+import { prepareBruichladdichSource } from "@peated/server/scraper/configured/prepareBruichladdich";
 import { prepareCadenheadsSource } from "@peated/server/scraper/configured/prepareCadenheads";
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
 import { prepareGordonMacphailSource } from "@peated/server/scraper/configured/prepareGordonMacphail";
@@ -35,7 +36,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, cadenheads, compassbox, gordonmacphail, kilchoman, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
+          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, gordonmacphail, kilchoman, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -67,6 +68,7 @@ export default procedure
   .handler(async ({ input, context, errors }) => {
     const prepareSource = {
       bourbonculture: prepareBourbonCultureSource,
+      bruichladdich: prepareBruichladdichSource,
       cadenheads: prepareCadenheadsSource,
       compassbox: prepareCompassBoxSource,
       gordonmacphail: prepareGordonMacphailSource,

--- a/apps/server/src/orpc/routes/prices/create-batch.test.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.test.ts
@@ -332,6 +332,51 @@ describe("POST /external-sites/:site/prices", () => {
     });
   });
 
+  test("keeps a stored product ID when a URL-matched listing omits it", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({
+      type: "bruichladdich",
+    });
+    const bottle = await fixtures.Bottle();
+    const existing = await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "8468808368301",
+      bottleId: bottle.id,
+      name: "Bruichladdich The Classic Laddie 10 Aged Years",
+      price: 4600,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.bruichladdich.com/products/bruichladdich-the-classic-laddie",
+    });
+
+    await createStorePricesAsPeated({
+      site: site.type,
+      prices: [
+        {
+          name: existing.name,
+          price: 4700,
+          currency: existing.currency,
+          volume: existing.volume,
+          url: existing.url,
+        },
+      ],
+    });
+
+    expect(
+      await db.query.storePrices.findMany({
+        where: eq(storePrices.externalSiteId, site.id),
+      }),
+    ).toMatchObject([
+      {
+        id: existing.id,
+        externalProductId: existing.externalProductId,
+        bottleId: bottle.id,
+        price: 4700,
+      },
+    ]);
+  });
+
   test("reuses an exact Bottle assignment for unchanged source identity", async ({
     fixtures,
   }) => {

--- a/apps/server/src/scraper/configured/prepareBruichladdich.ts
+++ b/apps/server/src/scraper/configured/prepareBruichladdich.ts
@@ -1,0 +1,26 @@
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks Bruichladdich by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareBruichladdichSource(
+  input: PreparePriceSourceInput,
+) {
+  return preparePriceSource(input, {
+    siteKey: "bruichladdich",
+    siteName: "Bruichladdich",
+    targetKey: "bruichladdich",
+    origin: "https://www.bruichladdich.com",
+    listUrl:
+      "https://www.bruichladdich.com/collections/all?filter.v.availability=1",
+    isExpectedPrice: (price) =>
+      /^https:\/\/www\.bruichladdich\.com\/products\/[a-z0-9][a-z0-9-]*$/.test(
+        price.url,
+      ) &&
+      /^\d+$/.test(price.externalProductId ?? "") &&
+      price.name.trim().length > 0 &&
+      price.currency === "gbp" &&
+      price.volume === 700,
+  });
+}

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -212,6 +212,31 @@ preview. Activate only exact output, trigger one manual collection, and confirm
 that it updates the same price IDs and Bottle matches. Check the run and Sentry
 before restoring the saved schedule.
 
+## Bruichladdich
+
+Use the preparation endpoint with `{"site": "bruichladdich"}`. The check-only
+request inventories every stored price and stops if a row does not have the
+expected Bruichladdich product URL, numeric Shopify product ID, name, GBP
+currency, or 700 ml volume. Applying transfers the request settings and adds a
+paused source for
+`https://www.bruichladdich.com/collections/all?filter.v.availability=1`. It does
+not change price rows or history.
+
+Before applying, stop the `bruichladdich` schedule and wait for active runs.
+Save the same price and run records listed for Compass Box. Run the version 6
+rules through the local no-write preview without an item limit. The list rules
+must exclude Accessories, Clothing, and Glassware. The detail rules must read
+the product name, active 70 cl variant's GBP price and volume, product URL, and
+image. Keep the `Bruichladdich` prefix on The Biodynamic Project.
+
+Do not save the visible Shopify variant ID as `externalProductId`. Existing
+rows use Shopify product IDs, which are different. Leave that rule empty so
+collection finds each existing row by its exact product URL and keeps its
+stored product ID. After applying, save and preview the reviewed revision.
+Activate only exact output, trigger one manual collection, and confirm that it
+updates the same price IDs and Bottle matches before restoring the schedule.
+Check the run and Sentry.
+
 ## Kilchoman
 
 Use the preparation endpoint with `{"site": "kilchoman"}`. The check-only
@@ -244,9 +269,10 @@ handles reviews added after the switch. Do not delete source or run history.
 
 ## Other sources
 
-The preparation API is shared. It currently supports Bourbon Culture, Compass
-Box, Kilchoman, The Whiskey Reviewer, Whisky Saga, The Whisky Study, and Words
-of Whisky. Other sites are rejected without changing records. Add each site's
+The preparation API is shared. It currently supports Bourbon Culture,
+Bruichladdich, Cadenhead's, Compass Box, Gordon & MacPhail, Kilchoman, The
+Whiskey Reviewer, WhiskyNotes, Whisky Saga, The Whisky Study, and Words of
+Whisky. Other sites are rejected without changing records. Add each site's
 conversion behind this route as its existing records are reviewed.
 
 Prepare each source using its own rules for recognizing existing records.


### PR DESCRIPTION
Adds Bruichladdich to the guarded saved-rules migration path. Preparation checks every stored price, preserves price/history/Bottle records, transfers only the existing request settings, and creates the replacement source paused for review.

The proposed version 6 rules passed a full local preview against all 21 current whisky products with no parser or request issues. They intentionally omit Shopify's visible variant ID: existing rows use a different product ID, so URL matching updates the same rows while retaining their stored IDs. A focused ingestion test locks in that compatibility behavior, and the operator guide records the required catalogue filters and rollout checks.
