### PR TITLE
docs(catalog): record Bruichladdich research

### DIFF
--- a/docs/research/catalog-research-examples-2026-09.md
+++ b/docs/research/catalog-research-examples-2026-09.md
@@ -27,3 +27,55 @@ Sources found in earlier Peated catalog tasks. Recheck each site before use.
 | St. George Spirits   | [Single Malt](https://stgeorgespirits.com/spirits/single-malt-whiskey), [trade support](https://stgeorgespirits.com/trade-support), Whiskybase, exact old shops and auctions                                                                                                                                                                                                                       | Annual Lot releases were clear; private picks were not                     |
 | Suntory and Yamazaki | [Essence](https://www.suntory.co.jp/whisky/essence/), [Hibiki](https://www.suntory.co.jp/whisky/hibiki/portfolio/), [Hakushu](https://www.suntory.co.jp/whisky/hakushu/lineup/), [global news](https://www.suntoryglobalspirits.com/news), Whisky Auctioneer                                                                                                                                       | Japanese pages listed more than global pages                               |
 | Wolves Whiskey       | [Producer archive](https://wolveswhiskeyca.com/collections/archive), Shopify product data, [TTB COLA](https://www.ttbonline.gov/colasonline/publicSearchColasBasic.do), PR Newswire, venue shops                                                                                                                                                                                                   | Venue releases and collaborations were missing from the main archive       |
+
+## Bruichladdich — September 5, 2026
+
+The production review covered the 198 active Bottles attached to Bruichladdich
+after duplicate merges. It checked current and historical official releases,
+independent bottlings already attached to the Brand, the modern era from the
+2001 reopening through 2026, and country-specific and travel-retail leads. No
+single source proved that every private cask or visitor-centre Valinch ever
+marketed has a public record, so those families remain limited to releases with
+exact evidence.
+
+- The [current collection](https://www.bruichladdich.com/collections/bruichladdich),
+  [FAQ](https://www.bruichladdich.com/pages/faqs), and individual producer pages
+  for [Ternary](https://www.bruichladdich.com/products/the-ternary-project),
+  [Biodynamic](https://www.bruichladdich.com/products/the-biodynamic-project),
+  [Regeneration](https://www.bruichladdich.com/products/the-regeneration-project),
+  and [Greener Still](https://www.bruichladdich.com/products/bruichladdich-greener-still)
+  established current names, range membership, barley, maturation, age, strength,
+  and the 2021–2026 release facts. Current pages did not cover the historical
+  catalog.
+- The preserved producer site pages for the [new era](https://oldbruichladdich.com/the-new-era/),
+  [Italian releases](https://oldbruichladdich.com/old-italian/),
+  [early 1980s](https://oldbruichladdich.com/early-1980s-2/),
+  [late 1980s](https://oldbruichladdich.com/late-1980s-2/),
+  [early 10-year-old releases](https://oldbruichladdich.com/10-year-old-no-age-statement-on-main-label/),
+  and [15-year-old releases](https://oldbruichladdich.com/15-year-old-3/)
+  supplied historical families and old naming context. These narrative pages
+  were used with exact labels or catalog entries rather than as complete lists.
+- [Whisky Auctioneer's Links guide](https://whiskyauctioneer.com/learn/explore-whisky/series/bruichladdich-links)
+  and [Bordeaux First Growth guide](https://whiskyauctioneer.com/learn/explore-whisky/series/bruichladdich-bordeaux-first-growth-series)
+  established the numbered Links I–IX and Sixteens Cuvée A–F sets. A
+  [complete Legacy set](https://www.bidforwine.co.uk/auction/the-complete-bruichladdich-legacy-series-229515)
+  established Legacy One–Six. Exact lots and Whiskybase records supplied the
+  age, strength, cask, year, and outturn checks that the range guides omitted.
+- The [Rare Whisky 101 Bruichladdich index](https://www.rarewhisky101.com/index.php/indices/distillery-specific-indices/bruichladdich-index)
+  and [Whiskybase distillery list](https://www.whiskybase.com/whiskies/distillery/57/whiskies)
+  were productive gap finders across discontinued, experimental, Port Charlotte,
+  and Octomore releases. They were treated as leads, not as authority or proof
+  of completeness. The exact [Organic Barley 16-year record](https://www.whiskybase.com/whiskies/whisky/276538),
+  checked against [Heathrow's travel-retail listing](https://boutique.heathrow.com/en/organic-16yo-travel-exclusive/world-duty-free_6912650.html),
+  established the 2025 travel-exclusive release; documented 2024 and 2025
+  bottlings meant no single bottling year was stored.
+- Searches of producer pages, those historical indexes, exact auction lots, and
+  Peated aliases and import references did not identify which edition is meant
+  by the generic “Links 14-year-old”, “The Italian Collection”, or “Port
+  Charlotte 10-year-old” records. Shared facts were retained, but no edition was
+  guessed and no merge was made.
+- Producer, retailer, and auction images were useful identity evidence but did
+  not state reusable Bottle-image terms. No new external Bottle image was copied.
+  A pre-existing Peated-hosted Laddie Eight image was restored to the surviving
+  Bottle after its duplicate merge. The Brand image remained the separately
+  reviewed, licensed Wikimedia image.


### PR DESCRIPTION
Records the sources and evidence boundaries from the September 2026 Bruichladdich production catalog review. The note covers the producer and archive sources used across modern, historical, travel-retail, Links, Sixteens, Legacy, Port Charlotte, and Octomore releases, along with the three unresolved generic records and image-reuse findings.

This preserves the catalog findings required by the current maintenance guidance without retaining raw API responses, downloaded images, or request payloads. Review should focus on the source links and the stated coverage limits for private-cask and visitor-centre Valinch releases.
