### PR TITLE
feat(bottles): redesign bottle entry workflow

### DIFF
--- a/apps/server/src/lib/bottleCreateCandidates.test.ts
+++ b/apps/server/src/lib/bottleCreateCandidates.test.ts
@@ -1,0 +1,137 @@
+import {
+  buildBottleCreateCandidateQueries,
+  rankBottleCreateCandidates,
+  type BottleCreateCandidate,
+  type BottleCreateCandidateInput,
+} from "./bottleCreateCandidates";
+
+const yamazaki = { id: 2, name: "Yamazaki" };
+
+function candidate(
+  overrides: Partial<BottleCreateCandidate> = {},
+): BottleCreateCandidate {
+  return {
+    id: 1,
+    fullName: "Yamazaki Peated Malt Spanish Oak",
+    name: "Peated Malt Spanish Oak",
+    brand: yamazaki,
+    distillers: [yamazaki],
+    ...overrides,
+  };
+}
+
+const regressionInput: BottleCreateCandidateInput = {
+  name: "The Yamazaki Peated Malt Spanish Oak - Kogei Collection",
+  brand: { id: 1, name: "Suntory" },
+  distillers: [yamazaki],
+};
+
+describe("Bottle create candidate discovery", () => {
+  test("builds search-only variants for repeated identity and collection text", () => {
+    expect(buildBottleCreateCandidateQueries(regressionInput)).toEqual([
+      "the yamazaki peated malt spanish oak kogei collection",
+      "the yamazaki peated malt spanish oak",
+      "peated malt spanish oak kogei collection",
+      "peated malt spanish oak",
+    ]);
+  });
+
+  test("suppresses a generic name without supporting identity facts", () => {
+    expect(buildBottleCreateCandidateQueries({ name: "12-year-old" })).toEqual(
+      [],
+    );
+  });
+
+  test("ranks the core product above a weaker name match despite a wrong Brand", () => {
+    const results = rankBottleCreateCandidates(
+      regressionInput,
+      [
+        candidate({
+          id: 3,
+          fullName: "Yamazaki Peated Malt",
+          name: "Peated Malt",
+        }),
+        candidate({ id: 2 }),
+      ],
+      3,
+    );
+
+    expect(results.map(({ id }) => id)).toEqual([2, 3]);
+  });
+
+  test("deduplicates candidates returned by several discovery queries", () => {
+    const duplicate = candidate();
+    expect(
+      rankBottleCreateCandidates(regressionInput, [duplicate, duplicate], 3),
+    ).toEqual([duplicate]);
+  });
+
+  test("uses release facts to order otherwise identical names", () => {
+    const input = { ...regressionInput, releaseYear: 2024 };
+    const results = rankBottleCreateCandidates(
+      input,
+      [
+        candidate({ id: 2, releaseYear: 2023 }),
+        candidate({ id: 3, releaseYear: 2024 }),
+      ],
+      3,
+    );
+
+    expect(results.map(({ id }) => id)).toEqual([3, 2]);
+  });
+
+  test("does not use malt phenol level to rank possible duplicates", () => {
+    const input = { ...regressionInput, maltPhenolPpm: 50 };
+    const results = rankBottleCreateCandidates(
+      input,
+      [
+        candidate({ id: 2, maltPhenolPpm: 20 }),
+        candidate({ id: 3, maltPhenolPpm: 50 }),
+      ],
+      3,
+    );
+
+    expect(results.map(({ id }) => id)).toEqual([2, 3]);
+  });
+
+  test("uses distinguishing production and cask facts from the full draft", () => {
+    const input: BottleCreateCandidateInput = {
+      ...regressionInput,
+      category: "single_malt",
+      noAgeStatement: true,
+      singleCask: true,
+      caskStrength: true,
+      maturation: "Mizunara oak",
+      caskNumber: "35.401",
+      outturn: 240,
+    };
+    const results = rankBottleCreateCandidates(
+      input,
+      [
+        candidate({
+          id: 2,
+          category: "single_malt",
+          noAgeStatement: false,
+          singleCask: false,
+          caskStrength: false,
+          maturation: "Ex-bourbon barrels",
+          caskNumber: "18",
+          outturn: 480,
+        }),
+        candidate({
+          id: 3,
+          category: "single_malt",
+          noAgeStatement: true,
+          singleCask: true,
+          caskStrength: true,
+          maturation: "mizunara oak",
+          caskNumber: "35.401",
+          outturn: 240,
+        }),
+      ],
+      3,
+    );
+
+    expect(results.map(({ id }) => id)).toEqual([3, 2]);
+  });
+});

--- a/apps/server/src/lib/bottleCreateCandidates.ts
+++ b/apps/server/src/lib/bottleCreateCandidates.ts
@@ -1,0 +1,342 @@
+import type { Bottle } from "@peated/server/types";
+
+type IdentityChoice = {
+  id?: number | null;
+  name: string;
+};
+
+type BottleCreateCandidateFacts = Pick<
+  Bottle,
+  | "abv"
+  | "bottlingYear"
+  | "caskNumber"
+  | "caskStrength"
+  | "category"
+  | "description"
+  | "descriptionSrc"
+  | "edition"
+  | "flavorProfile"
+  | "maltPhenolPpm"
+  | "maturation"
+  | "naturalColor"
+  | "noAgeStatement"
+  | "nonChillFiltered"
+  | "outturn"
+  | "releaseDay"
+  | "releaseMonth"
+  | "releaseYear"
+  | "singleCask"
+  | "statedAge"
+  | "tastingNotes"
+  | "vintageYear"
+>;
+
+export type BottleCreateCandidateInput = Partial<BottleCreateCandidateFacts> & {
+  name: string;
+  brand?: IdentityChoice | null;
+  distillers?: readonly IdentityChoice[];
+  bottler?: IdentityChoice | null;
+  series?: IdentityChoice | null;
+};
+
+export type BottleCreateCandidate = Pick<Bottle, "fullName" | "id" | "name"> &
+  Partial<BottleCreateCandidateFacts> & {
+    brand: IdentityChoice;
+    distillers: readonly IdentityChoice[];
+    bottler?: IdentityChoice | null;
+    series?: IdentityChoice | null;
+  };
+
+const GENERIC_NAME_WORDS = new Set([
+  "aged",
+  "bottle",
+  "old",
+  "scotch",
+  "the",
+  "whiskey",
+  "whisky",
+  "year",
+  "years",
+  "yo",
+]);
+
+const TRAILING_QUALIFIERS = new Set([
+  "batch",
+  "collection",
+  "edition",
+  "release",
+  "series",
+]);
+
+function words(value: string): string[] {
+  return (
+    value
+      .normalize("NFKD")
+      .replace(/\p{Mark}/gu, "")
+      .toLocaleLowerCase()
+      .match(/[\p{Letter}\p{Number}]+/gu) ?? []
+  );
+}
+
+function normalized(value: string): string {
+  return words(value).join(" ");
+}
+
+function identityChoices(input: BottleCreateCandidateInput): IdentityChoice[] {
+  return [
+    ...(input.brand ? [input.brand] : []),
+    ...(input.distillers ?? []),
+    ...(input.bottler ? [input.bottler] : []),
+    ...(input.series ? [input.series] : []),
+  ];
+}
+
+function withoutLeadingIdentity(
+  nameWords: readonly string[],
+  choices: readonly IdentityChoice[],
+): string[] {
+  let result = [...nameWords];
+  if (result[0] === "the") result = result.slice(1);
+
+  const identityNames = choices
+    .map((choice) => words(choice.name))
+    .filter((choiceWords) => choiceWords.length)
+    .sort((left, right) => right.length - left.length);
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const identityName of identityNames) {
+      if (identityName.every((word, index) => result[index] === word)) {
+        result = result.slice(identityName.length);
+        if (result[0] === "the") result = result.slice(1);
+        changed = true;
+        break;
+      }
+    }
+  }
+  return result;
+}
+
+function withoutTrailingQualifier(nameWords: readonly string[]): string[] {
+  const lastWord = nameWords.at(-1);
+  const secondLastWord = nameWords.at(-2);
+  if (lastWord && TRAILING_QUALIFIERS.has(lastWord)) {
+    return nameWords.slice(0, Math.max(0, nameWords.length - 2));
+  }
+  if (secondLastWord && TRAILING_QUALIFIERS.has(secondLastWord)) {
+    return nameWords.slice(0, Math.max(0, nameWords.length - 2));
+  }
+  return [...nameWords];
+}
+
+function distinctiveWords(nameWords: readonly string[]): string[] {
+  return nameWords.filter(
+    (word) => !GENERIC_NAME_WORDS.has(word) && !/^\d+$/.test(word),
+  );
+}
+
+function nameVariants(
+  name: string,
+  choices: readonly IdentityChoice[],
+): string[][] {
+  const original = words(name);
+  const withoutIdentity = withoutLeadingIdentity(original, choices);
+  return [
+    original,
+    withoutTrailingQualifier(original),
+    withoutIdentity,
+    withoutTrailingQualifier(withoutIdentity),
+  ].filter((variant) => variant.length > 0);
+}
+
+/**
+ * Builds bounded discovery queries only. These variants are evidence for the
+ * picker and never replace the marketed name submitted by the member.
+ */
+export function buildBottleCreateCandidateQueries(
+  input: BottleCreateCandidateInput,
+): string[] {
+  const choices = identityChoices(input);
+  const variants = nameVariants(input.name, choices);
+  const usefulName = variants.some(
+    (variant) => distinctiveWords(variant).length >= 2,
+  );
+  const supportedShortName =
+    choices.length > 0 &&
+    variants.some((variant) => distinctiveWords(variant).length >= 1);
+  const supportedGenericName =
+    choices.length > 0 &&
+    variants.some((variant) => variant.length > 0) &&
+    (input.statedAge != null || /\d/.test(input.name));
+
+  if (!usefulName && !supportedShortName && !supportedGenericName) return [];
+
+  return Array.from(
+    new Set(variants.map((variant) => variant.join(" "))),
+  ).slice(0, 4);
+}
+
+function sameChoice(
+  input: IdentityChoice | null | undefined,
+  candidate: IdentityChoice | null | undefined,
+): boolean {
+  if (!input || !candidate) return false;
+  if (input.id && candidate.id) return input.id === candidate.id;
+  return normalized(input.name) === normalized(candidate.name);
+}
+
+function hasChoiceOverlap(
+  input: readonly IdentityChoice[] | undefined,
+  candidates: readonly IdentityChoice[] | undefined,
+): boolean {
+  return Boolean(
+    input?.some((inputChoice) =>
+      candidates?.some((candidate) => sameChoice(inputChoice, candidate)),
+    ),
+  );
+}
+
+function textSimilarity(left: readonly string[], right: readonly string[]) {
+  if (!left.length || !right.length) return 0;
+  if (left.join(" ") === right.join(" ")) return 1;
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+  const intersection = [...leftSet].filter((word) => rightSet.has(word)).length;
+  return (2 * intersection) / (leftSet.size + rightSet.size);
+}
+
+function exactValueScore<T>(
+  input: T | null | undefined,
+  candidate: T | null | undefined,
+  matchScore: number,
+  mismatchScore: number,
+) {
+  if (input == null || candidate == null) return 0;
+  return input === candidate ? matchScore : mismatchScore;
+}
+
+function exactTextScore(
+  input: string | null | undefined,
+  candidate: string | null | undefined,
+  matchScore: number,
+  mismatchScore: number,
+) {
+  if (!input || !candidate) return 0;
+  return normalized(input) === normalized(candidate)
+    ? matchScore
+    : mismatchScore;
+}
+
+function candidateScore(
+  input: BottleCreateCandidateInput,
+  candidate: BottleCreateCandidate,
+): number | null {
+  const inputChoices = identityChoices(input);
+  const inputVariants = nameVariants(input.name, inputChoices);
+  const candidateChoices = [
+    candidate.brand,
+    ...candidate.distillers,
+    ...(candidate.bottler ? [candidate.bottler] : []),
+    ...(candidate.series ? [candidate.series] : []),
+  ];
+  const candidateVariants = [
+    ...nameVariants(candidate.name, candidateChoices),
+    ...nameVariants(candidate.fullName, candidateChoices),
+  ];
+  const similarity = Math.max(
+    ...inputVariants.flatMap((inputVariant) =>
+      candidateVariants.map((candidateVariant) =>
+        textSimilarity(inputVariant, candidateVariant),
+      ),
+    ),
+  );
+  const inputDistinctive = new Set(
+    inputVariants.flatMap((variant) => distinctiveWords(variant)),
+  );
+  const candidateDistinctive = new Set(
+    candidateVariants.flatMap((variant) => distinctiveWords(variant)),
+  );
+  const distinctiveOverlap = [...inputDistinctive].filter((word) =>
+    candidateDistinctive.has(word),
+  ).length;
+  const brandMatch = sameChoice(input.brand, candidate.brand);
+  const distillerMatch = hasChoiceOverlap(
+    input.distillers,
+    candidate.distillers,
+  );
+  const identityMatch =
+    brandMatch ||
+    distillerMatch ||
+    sameChoice(input.bottler, candidate.bottler) ||
+    sameChoice(input.series, candidate.series);
+
+  // A generic age-only name needs a matching stored identity anchor.
+  if (inputDistinctive.size === 0 && !identityMatch) return null;
+  if (similarity < 0.45 && distinctiveOverlap < 2) return null;
+
+  let score = similarity * 100;
+  if (brandMatch) score += 24;
+  if (distillerMatch) score += 28;
+  if (sameChoice(input.series, candidate.series)) score += 16;
+  if (sameChoice(input.bottler, candidate.bottler)) score += 8;
+  score += exactValueScore(input.category, candidate.category, 2, -2);
+  score += exactValueScore(input.statedAge, candidate.statedAge, 8, -10);
+  score += exactValueScore(
+    input.noAgeStatement,
+    candidate.noAgeStatement,
+    8,
+    -10,
+  );
+  score += exactValueScore(input.vintageYear, candidate.vintageYear, 8, -12);
+  score += exactValueScore(input.bottlingYear, candidate.bottlingYear, 5, -8);
+  score += exactValueScore(input.releaseYear, candidate.releaseYear, 8, -12);
+  score += exactValueScore(input.releaseMonth, candidate.releaseMonth, 3, -4);
+  score += exactValueScore(input.releaseDay, candidate.releaseDay, 2, -3);
+  score += exactValueScore(input.singleCask, candidate.singleCask, 3, -3);
+  score += exactValueScore(input.caskStrength, candidate.caskStrength, 3, -3);
+  score += exactValueScore(input.naturalColor, candidate.naturalColor, 1, -1);
+  score += exactValueScore(
+    input.nonChillFiltered,
+    candidate.nonChillFiltered,
+    1,
+    -1,
+  );
+  score += exactTextScore(input.maturation, candidate.maturation, 4, -4);
+  score += exactTextScore(input.caskNumber, candidate.caskNumber, 16, -18);
+  score += exactValueScore(input.outturn, candidate.outturn, 3, -3);
+  if (input.abv != null && candidate.abv != null) {
+    score += Math.abs(input.abv - candidate.abv) <= 0.1 ? 8 : -10;
+  }
+  if (input.edition && candidate.edition) {
+    score +=
+      normalized(input.edition) === normalized(candidate.edition) ? 12 : -14;
+  }
+  return score;
+}
+
+/** Ranks and deduplicates advisory candidates without deciding Bottle identity. */
+export function rankBottleCreateCandidates<
+  Candidate extends BottleCreateCandidate,
+>(
+  input: BottleCreateCandidateInput,
+  candidates: readonly Candidate[],
+  limit: number,
+): Candidate[] {
+  const bestById = new Map<number, { candidate: Candidate; score: number }>();
+  for (const candidate of candidates) {
+    const score = candidateScore(input, candidate);
+    if (score == null) continue;
+    const current = bestById.get(candidate.id);
+    if (!current || score > current.score) {
+      bestById.set(candidate.id, { candidate, score });
+    }
+  }
+  return [...bestById.values()]
+    .sort(
+      (left, right) =>
+        right.score - left.score || left.candidate.id - right.candidate.id,
+    )
+    .slice(0, limit)
+    .map(({ candidate }) => candidate);
+}

--- a/apps/server/src/orpc/routes/bottles/create-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/create-candidates.test.ts
@@ -1,0 +1,120 @@
+import { routerClient } from "@peated/server/orpc/router";
+
+describe("GET /bottles/create-candidates", () => {
+  test("finds the Yamazaki regression despite the wrong Brand and collection suffix", async ({
+    fixtures,
+  }) => {
+    const suntory = await fixtures.Entity({ name: "Suntory" });
+    const yamazaki = await fixtures.Entity({
+      name: "Yamazaki",
+      kind: "distillery",
+    });
+    const existing = await fixtures.Bottle({
+      name: "Peated Malt Spanish Oak",
+      brandId: yamazaki.id,
+      distillerIds: [yamazaki.id],
+    });
+    await fixtures.Bottle({
+      name: "Peated Malt",
+      brandId: yamazaki.id,
+      distillerIds: [yamazaki.id],
+    });
+
+    const { results } = await routerClient.bottles.createCandidates({
+      name: "The Yamazaki Peated Malt Spanish Oak - Kogei Collection",
+      brand: { id: suntory.id, name: suntory.name },
+      distillers: [{ id: yamazaki.id, name: yamazaki.name }],
+    });
+
+    expect(results[0]?.id).toBe(existing.id);
+  });
+
+  test("does not search a generic name without supporting identity facts", async ({
+    fixtures,
+  }) => {
+    await fixtures.Bottle({ name: "12-year-old", statedAge: 12 });
+
+    const { results } = await routerClient.bottles.createCandidates({
+      name: "12-year-old",
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  test("returns only active Bottles", async ({ fixtures }) => {
+    const brand = await fixtures.Entity({ name: "Candidate Brand" });
+    const active = await fixtures.Bottle({
+      name: "Distinctive Orchard Reserve",
+      brandId: brand.id,
+    });
+    await fixtures.LegacyBottle({
+      name: "Distinctive Orchard Reserve",
+      brandId: brand.id,
+    });
+
+    const { results } = await routerClient.bottles.createCandidates({
+      name: "Distinctive Orchard Reserve",
+      brand: { id: brand.id, name: brand.name },
+    });
+
+    expect(results.map(({ id }) => id)).toEqual([active.id]);
+  });
+
+  test("accepts the normalized Bottle draft and ranks distinguishing facts", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Draft Match Brand" });
+    await fixtures.Bottle({
+      name: "Distinctive Harbor Ember",
+      brandId: brand.id,
+      noAgeStatement: false,
+      singleCask: false,
+      caskStrength: false,
+      maturation: "Ex-bourbon barrels",
+      caskNumber: "18",
+      outturn: 480,
+    });
+    const matching = await fixtures.Bottle({
+      name: "Distinctive Harbor Ember",
+      brandId: brand.id,
+      noAgeStatement: true,
+      singleCask: true,
+      caskStrength: true,
+      maturation: "Mizunara oak",
+      caskNumber: "35.401",
+      outturn: 240,
+    });
+
+    const { results } = await routerClient.bottles.createCandidates({
+      name: "Distinctive Harbor Ember",
+      brand: { id: brand.id, name: brand.name },
+      distillers: [],
+      bottler: null,
+      series: null,
+      category: "single_malt",
+      edition: null,
+      statedAge: null,
+      noAgeStatement: true,
+      caskStrength: true,
+      singleCask: true,
+      naturalColor: null,
+      nonChillFiltered: null,
+      maltPhenolPpm: null,
+      abv: null,
+      vintageYear: null,
+      bottlingYear: null,
+      releaseYear: null,
+      releaseMonth: null,
+      releaseDay: null,
+      maturation: "Mizunara oak",
+      caskNumber: "35.401",
+      outturn: 240,
+      description: null,
+      descriptionSrc: null,
+      flavorProfile: null,
+      tastingNotes: null,
+    });
+
+    expect(results[0]?.id).toBe(matching.id);
+  });
+});

--- a/apps/server/src/orpc/routes/bottles/create-candidates.ts
+++ b/apps/server/src/orpc/routes/bottles/create-candidates.ts
@@ -1,0 +1,106 @@
+import { db } from "@peated/server/db";
+import { bottles, bottleTombstones } from "@peated/server/db/schema";
+import {
+  buildBottleCreateCandidateQueries,
+  rankBottleCreateCandidates,
+} from "@peated/server/lib/bottleCreateCandidates";
+import { plainTextSearchQuery } from "@peated/server/lib/search";
+import { procedure } from "@peated/server/orpc";
+import {
+  BottleInputFields,
+  BottleSchema,
+  listResponse,
+} from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { BottleSerializer } from "@peated/server/serializers/bottle";
+import { and, desc, isNotNull, or, sql } from "drizzle-orm";
+import { z } from "zod";
+
+const IdentityChoiceSchema = z.object({
+  id: z.number().int().positive().nullish(),
+  name: z.string().trim().min(1).max(255),
+});
+
+const InputSchema = z.object({
+  name: z.string().trim().min(1).max(255),
+  brand: IdentityChoiceSchema.nullish(),
+  distillers: z.array(IdentityChoiceSchema).max(20).default([]),
+  bottler: IdentityChoiceSchema.nullish(),
+  series: IdentityChoiceSchema.nullish(),
+  category: BottleInputFields.category,
+  edition: BottleInputFields.edition,
+  statedAge: BottleInputFields.statedAge,
+  noAgeStatement: BottleInputFields.noAgeStatement,
+  caskStrength: BottleInputFields.caskStrength,
+  singleCask: BottleInputFields.singleCask,
+  naturalColor: BottleInputFields.naturalColor,
+  nonChillFiltered: BottleInputFields.nonChillFiltered,
+  maltPhenolPpm: BottleInputFields.maltPhenolPpm,
+  abv: BottleInputFields.abv,
+  vintageYear: BottleInputFields.vintageYear,
+  bottlingYear: BottleInputFields.bottlingYear,
+  releaseYear: BottleInputFields.releaseYear,
+  releaseMonth: BottleInputFields.releaseMonth,
+  releaseDay: BottleInputFields.releaseDay,
+  maturation: BottleInputFields.maturation,
+  caskNumber: BottleInputFields.caskNumber,
+  outturn: BottleInputFields.outturn,
+  description: BottleInputFields.description,
+  descriptionSrc: BottleInputFields.descriptionSrc,
+  flavorProfile: BottleInputFields.flavorProfile,
+  tastingNotes: BottleInputFields.tastingNotes,
+  limit: z.coerce.number().int().gte(1).lte(10).default(3),
+});
+
+export default procedure
+  .route({
+    method: "GET",
+    path: "/bottles/create-candidates",
+    summary: "Find possible existing Bottles before creation",
+    description:
+      "Return advisory Bottle candidates from entered identity and release facts without changing or blocking the submitted Bottle.",
+    spec: (spec) => ({
+      ...spec,
+      operationId: "getBottleCreateCandidates",
+    }),
+  })
+  .input(InputSchema)
+  .output(listResponse(BottleSchema))
+  .handler(async ({ input, context }) => {
+    const { limit, ...candidateInput } = input;
+    const searchQueries = buildBottleCreateCandidateQueries(candidateInput);
+    if (!searchQueries.length) {
+      return {
+        results: [],
+        rel: { nextCursor: null, prevCursor: null },
+      };
+    }
+
+    const searchConditions = searchQueries.map(
+      (query) => sql`${bottles.searchVector} @@ ${plainTextSearchQuery(query)}`,
+    );
+    const candidateRows = await db
+      .select()
+      .from(bottles)
+      .where(
+        and(
+          isNotNull(bottles.groupId),
+          sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
+          or(...searchConditions),
+        ),
+      )
+      .orderBy(desc(bottles.totalTastings), desc(bottles.updatedAt))
+      .limit(100);
+    const serialized = await serialize(
+      BottleSerializer,
+      candidateRows,
+      context.user,
+      ["description", "tastingNotes"],
+      { includeGroupSummary: true },
+    );
+
+    return {
+      results: rankBottleCreateCandidates(candidateInput, serialized, limit),
+      rel: { nextCursor: null, prevCursor: null },
+    };
+  });

--- a/apps/server/src/orpc/routes/bottles/index.ts
+++ b/apps/server/src/orpc/routes/bottles/index.ts
@@ -4,6 +4,7 @@ import applyBrandRepairGroup from "./apply-brand-repair-group";
 import brandRepairCandidates from "./brand-repair-candidates";
 import brandRepairGroups from "./brand-repair-groups";
 import create from "./create";
+import createCandidates from "./create-candidates";
 import delete_ from "./delete";
 import details from "./details";
 import editContext from "./edit-context";
@@ -25,6 +26,7 @@ export default base.tag("bottles").router({
   flavorProfile,
   list,
   create,
+  createCandidates,
   update,
   editContext,
   brandRepairCandidates,

--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -116,6 +116,7 @@ test.describe("Add Bottle", () => {
     await expect(
       page.getByRole("button", { name: testBrand.name }).first(),
     ).toBeVisible();
+    await reachFinalCreateStep(page);
     await page
       .getByRole("button", { name: "Add a bottle", exact: true })
       .click();
@@ -129,6 +130,202 @@ test.describe("Add Bottle", () => {
     await expect(
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
+  });
+
+  test("uses an existing Bottle and preserves the initiating action and photo", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "create-candidate"),
+    });
+    const pendingImageUrl =
+      "http://127.0.0.1:4999/uploads/playwright-photo.webp";
+    await page.goto(
+      `/bottles/new?name=21-year-old&brand=${testBrand.id}&returnAction=choose&pendingImageId=playwright-photo-upload&pendingImageUrl=${encodeURIComponent(pendingImageUrl)}`,
+    );
+
+    await expect(page.getByText("1 bottle may match this one.")).toBeVisible();
+    await page.getByRole("button", { name: "Review" }).click();
+    await expect(
+      page.getByRole("region", { name: "Bottles that may match" }),
+    ).toContainText(exactSearchBottle.fullName);
+    await page.getByRole("button", { name: "Use this bottle" }).click();
+
+    await expect(page).toHaveURL(
+      `/addBottle?bottle=${exactSearchBottle.id}&pendingImageId=playwright-photo-upload&pendingImageUrl=${encodeURIComponent(pendingImageUrl)}&intent=choose`,
+    );
+  });
+
+  test("allows a distinct release to be created after reviewing suggestions", async ({
+    context,
+    page,
+    snapshot,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "distinct-release"),
+    });
+    await page.goto(
+      `/bottles/new?name=21-year-old&brand=${testBrand.id}&returnAction=view`,
+    );
+
+    await expect(page.getByText("1 bottle may match this one.")).toBeVisible();
+    await reachFinalCreateStep(page);
+    const finalReview = page.getByRole("button", {
+      name: "Review 1 bottle",
+      exact: true,
+    });
+    await snapshot("Add bottle / Final duplicate gate / Desktop", {
+      fullPage: false,
+      ready: finalReview,
+    });
+    await finalReview.click();
+    await expect(
+      page.getByRole("button", { name: "Use this bottle" }),
+    ).toBeVisible();
+    const addAsNew = page.getByRole("button", {
+      name: "Add as a new bottle",
+      exact: true,
+    });
+    await snapshot("Add bottle / Final duplicate review / Desktop", {
+      fullPage: false,
+      ready: addAsNew,
+    });
+    await addAsNew.click();
+
+    await expect(page).toHaveURL(bottlePathPattern(9302));
+  });
+
+  test("reviews only Bottle ids that appeared after the last review", async ({
+    context,
+    page,
+    snapshot,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "new-candidates"),
+    });
+    await page.goto(
+      `/bottles/new?name=21-year-old&brand=${testBrand.id}&returnAction=view`,
+    );
+
+    const firstNotice = page.getByText("1 bottle may match this one.");
+    await expect(firstNotice).toBeVisible();
+    await snapshot("Add bottle / Match notice / Light", {
+      fullPage: false,
+      ready: firstNotice,
+    });
+    await page.emulateMedia({ colorScheme: "dark" });
+    await snapshot("Add bottle / Match notice / Dark", {
+      fullPage: false,
+      ready: firstNotice,
+    });
+    await page.emulateMedia({ colorScheme: "light" });
+    await page.getByRole("button", { name: "Review" }).click();
+    await page
+      .getByRole("button", { name: "None of these", exact: true })
+      .click();
+    await expect(
+      page.getByText("1 bottle may match this one."),
+    ).not.toBeVisible();
+
+    await page
+      .getByRole("textbox", { name: "Bottle name" })
+      .fill("21-year-old Kogei Collection");
+    await expect(
+      page.getByText("2 more bottles may match this one."),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Review" }).click();
+
+    const candidates = page.getByRole("region", {
+      name: "Bottles that may match",
+    });
+    await expect(candidates).not.toContainText(exactSearchBottle.fullName);
+    await expect(
+      candidates.getByRole("button", { name: "Use this bottle" }),
+    ).toHaveCount(2);
+    await snapshot("Add bottle / Match review / Desktop", {
+      fullPage: false,
+      ready: candidates,
+    });
+    await page.emulateMedia({ colorScheme: "dark" });
+    await snapshot("Add bottle / Match review / Dark", {
+      fullPage: false,
+      ready: candidates,
+    });
+    await page.emulateMedia({ colorScheme: "light" });
+    await page
+      .getByRole("button", { name: "None of these", exact: true })
+      .click();
+
+    await page
+      .getByRole("combobox", { name: "Type" })
+      .selectOption("single_malt");
+    await expect(
+      page.getByText(/bottles? may match this one\./),
+    ).not.toBeVisible();
+  });
+
+  test("reviews a matching Bottle without leaving the mobile step @mobile", async ({
+    context,
+    page,
+    snapshot,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "mobile-candidates"),
+    });
+    await page.goto(
+      `/bottles/new?name=21-year-old&brand=${testBrand.id}&returnAction=view`,
+    );
+
+    const notice = page.getByText("1 bottle may match this one.");
+    await expect(notice).toBeVisible();
+    await snapshot("Add bottle / Match notice / Mobile", {
+      fullPage: false,
+      ready: notice,
+    });
+    await page.getByRole("button", { name: "Review" }).click();
+
+    await expect(
+      page.getByRole("heading", {
+        level: 2,
+        name: "Is it already on Peated?",
+      }),
+    ).toBeFocused();
+
+    const candidates = page.getByRole("region", {
+      name: "Bottles that may match",
+    });
+    await snapshot("Add bottle / Match review / Mobile", {
+      fullPage: false,
+      ready: candidates,
+    });
+    await page
+      .getByRole("button", { name: "None of these", exact: true })
+      .click();
+
+    await expect(page.getByText("Step 1 of 7")).toBeVisible();
+    await expect(notice).not.toBeVisible();
+  });
+
+  test("treats NAS as an alternative to an age statement", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "nas-toggle"),
+    });
+    await page.goto(
+      `/bottles/new?name=Special Release&brand=${testBrand.id}&returnAction=view`,
+    );
+
+    await page.getByRole("button", { name: "Continue" }).click();
+    await page.getByRole("button", { name: "Continue" }).click();
+    const age = page.getByRole("spinbutton", { name: "Age statement" });
+    await age.fill("12");
+    await page.getByText("No age statement (NAS)", { exact: true }).click();
+
+    await expect(age).toBeDisabled();
+    await expect(age).toHaveValue("");
   });
 });
 
@@ -165,4 +362,10 @@ async function uploadLabel(page: Page) {
       "base64",
     ),
   });
+}
+
+async function reachFinalCreateStep(page: Page) {
+  for (let step = 0; step < 6; step += 1) {
+    await page.getByRole("button", { name: "Continue" }).click();
+  }
 }

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -110,6 +110,32 @@ const bottleCheckMock = createBottleCheckMock({
   testUser,
 });
 
+const visualCreateCandidates = [
+  exactSearchBottle,
+  {
+    ...exactSearchBottle,
+    id: 9313,
+    peatedId: "B9313",
+    fullName: `${testBrand.name} 21-year-old Kogei Collection - 2024 Release`,
+    edition: "Kogei Collection",
+    abv: 50.5,
+    vintageYear: 2003,
+    releaseYear: 2024,
+    caskNumber: null,
+  },
+  {
+    ...exactSearchBottle,
+    id: 9314,
+    peatedId: "B9314",
+    fullName: `${testBrand.name} 21-year-old Kogei Collection - Mizunara Cask`,
+    edition: "Kogei Collection - Mizunara Cask",
+    abv: 52.1,
+    vintageYear: 2001,
+    releaseYear: 2022,
+    caskNumber: null,
+  },
+];
+
 const server = http.createServer(async (request, response) => {
   if (request.method === "OPTIONS") {
     response.writeHead(204, corsHeaders).end();
@@ -232,13 +258,6 @@ async function handleRpcRequest({ request, response, url }) {
       );
       return true;
     case "entities/list":
-      if (input?.query === testBrand.name) {
-        sendRpcResponse(response, {
-          ...emptyList,
-          results: [testBrand],
-        });
-        return true;
-      }
       if (input?.owner === testOwner.id) {
         sendRpcResponse(response, {
           ...emptyList,
@@ -246,7 +265,28 @@ async function handleRpcRequest({ request, response, url }) {
         });
         return true;
       }
-      return false;
+      {
+        const query = String(input?.query ?? "")
+          .trim()
+          .toLowerCase();
+        const kinds = Array.isArray(input?.kinds) ? input.kinds : null;
+        const results = [
+          testBrand,
+          testOwnedEntity,
+          testBottler,
+          testOwner,
+        ].filter(
+          (entity) =>
+            (!kinds || kinds.includes(entity.kind)) &&
+            (!query || entity.name.toLowerCase().includes(query)),
+        );
+        sendRpcResponse(response, {
+          ...emptyList,
+          total: results.length,
+          results,
+        });
+      }
+      return true;
     case "entities/details":
       if (
         [testBrand, testBottler, testOwnedEntity, testOwner].some(
@@ -535,6 +575,26 @@ async function handleRpcRequest({ request, response, url }) {
           id: createdBottleId,
         };
         sendRpcResponse(response, bottle);
+        return true;
+      }
+
+      if (getAccessToken(request).includes("distinct-release")) {
+        const brandId = isJsonObject(input?.brand)
+          ? input.brand.id
+          : input?.brand;
+        if (input?.name !== "21-year-old" || brandId !== testBrand.id) {
+          sendRpcError(response, "Unexpected distinct Bottle create payload");
+          return true;
+        }
+        const bottleWithoutGroup = buildBottle({
+          id: createdBottleId,
+          name: input.name,
+          brand: testBrand,
+        });
+        sendRpcResponse(response, {
+          ...bottleWithoutGroup,
+          group: buildBottleGroup({ bottle: bottleWithoutGroup }),
+        });
         return true;
       }
 
@@ -977,6 +1037,19 @@ async function handleRpcRequest({ request, response, url }) {
         rel: { nextCursor: null, prevCursor: null },
       });
       return true;
+    case "bottles/createCandidates": {
+      const results = input?.name?.includes("21-year-old")
+        ? input.name.includes("Kogei Collection")
+          ? visualCreateCandidates
+          : [exactSearchBottle]
+        : [];
+      sendRpcResponse(response, {
+        results:
+          input?.category === "single_malt" ? [...results].reverse() : results,
+        rel: { nextCursor: null, prevCursor: null },
+      });
+      return true;
+    }
     case "bottles/suggestedTags":
       if (![createdBottleId, existingBottleId].includes(input?.bottle)) {
         sendRpcError(response, "Unexpected suggested tags payload");

--- a/apps/web/e2e/unified-bottle-workflows.spec.ts
+++ b/apps/web/e2e/unified-bottle-workflows.spec.ts
@@ -1,6 +1,6 @@
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { z } from "zod";
-import { expect, type Request, test, type TestInfo } from "./test";
+import { expect, type Page, type Request, test, type TestInfo } from "./test";
 
 import { bottlePathPattern } from "./assertions";
 import {
@@ -172,13 +172,18 @@ test.describe("unified Bottle workflows", () => {
     await expect(
       page.getByText(testBrand.name, { exact: true }).first(),
     ).toBeVisible();
-    await expect(page.getByLabel("Age statement")).toHaveValue(
-      String(anotherReleaseSourceBottle.statedAge),
+    await continueBottleForm(page, 2);
+    await expect(
+      page.getByRole("spinbutton", { name: "Age statement", exact: true }),
+    ).toHaveValue(String(anotherReleaseSourceBottle.statedAge));
+    await expect(
+      page.getByLabel("Edition or batch", { exact: true }),
+    ).toHaveValue("First Fill Oloroso");
+    await continueBottleForm(page);
+    await expect(page.getByLabel("Release year", { exact: true })).toHaveValue(
+      "2026",
     );
-    await expect(page.getByLabel("Edition or batch")).toHaveValue(
-      "First Fill Oloroso",
-    );
-    await expect(page.getByLabel("Release year")).toHaveValue("2026");
+    await continueBottleForm(page, 3);
 
     const createRequestPromise = page.waitForRequest((request) =>
       request.url().includes("/rpc/prices/matchQueue/createBottle"),
@@ -232,7 +237,11 @@ test.describe("unified Bottle workflows", () => {
     await expect(page.getByLabel("Bottle name", { exact: true })).toHaveValue(
       unifiedBottleEditContext.shared.name,
     );
-    await expect(page.getByLabel("Age statement")).toHaveValue(
+    const ageStatement = page.getByRole("spinbutton", {
+      name: "Age statement",
+      exact: true,
+    });
+    await expect(ageStatement).toHaveValue(
       String(unifiedBottleEditContext.exact.statedAge),
     );
     await expect(page.getByLabel("Shared Stated Age")).toHaveCount(0);
@@ -261,8 +270,8 @@ test.describe("unified Bottle workflows", () => {
 
     await page.getByLabel("Edition or batch").fill("Cask 43");
     await expect(page.getByLabel("Edition or batch")).toHaveValue("Cask 43");
-    await page.getByLabel("Age statement").fill("22");
-    await expect(page.getByLabel("Age statement")).toHaveValue("22");
+    await ageStatement.fill("22");
+    await expect(ageStatement).toHaveValue("22");
 
     const updateRequestPromise = page.waitForRequest((request) =>
       request.url().includes("/rpc/bottles/update"),
@@ -332,6 +341,12 @@ function uniqueAccessToken(testInfo: TestInfo, suffix: string) {
     `w${testInfo.workerIndex}`,
     `r${testInfo.retry}`,
   ].join("-");
+}
+
+async function continueBottleForm(page: Page, count = 1) {
+  for (let step = 0; step < count; step += 1) {
+    await page.getByRole("button", { name: "Continue", exact: true }).click();
+  }
 }
 
 const mockApiServer =

--- a/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
@@ -213,7 +213,7 @@ const styles = stylex.create({
     height: "34px",
     placeItems: "center",
     borderRadius: controlMetrics.radius,
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     boxShadow: `inset 0 0 0 1px ${colors.sectionRule}`,
     pointerEvents: "none",
   },

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/page.tsx
@@ -86,6 +86,7 @@ function AddSimilarBottleForm({ bottleId }: { bottleId: string }) {
 
   return (
     <BottleForm
+      mode="create"
       title="Add a similar bottle"
       saveLabel="Add a bottle"
       returnTo={returnTo}

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
@@ -51,6 +51,7 @@ function BottleEditForm({ bottleId }: { bottleId: string }) {
 
   return (
     <BottleForm
+      mode="edit"
       onSubmit={async (value, meta) => {
         const { image } = value;
         const updatedBottle = await bottleUpdateMutation.mutateAsync({

--- a/apps/web/src/app/(layout-free)/bottles/new/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/new/page.tsx
@@ -236,6 +236,21 @@ function CreateBottleForm() {
 
   return (
     <BottleForm
+      mode="create"
+      onUseExistingBottle={(bottle) => {
+        if (returnAction === "view" || !returnAction) {
+          router.replace(getBottleUrl(bottle));
+          return;
+        }
+        router.replace(
+          getAddBottleHref({
+            bottleId: bottle.id,
+            pendingImageId,
+            pendingImageUrl,
+            intent: returnAction,
+          }),
+        );
+      }}
       onSubmit={async ({ image, imageSourceUrl, imageLicense, ...data }) => {
         const createdBottle = proposalId
           ? await proposalBottleCreateMutation.mutateAsync({

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -92,7 +92,7 @@ export default async function RootLayout({
   );
 
   return (
-    <html lang="en">
+    <html lang="en" {...stylex.props(foundationStyles.documentRoot)}>
       <body {...stylex.props(foundationStyles.document)}>
         <Providers
           session={{

--- a/apps/web/src/components/admin/adminTable.stylex.tsx
+++ b/apps/web/src/components/admin/adminTable.stylex.tsx
@@ -310,7 +310,7 @@ const styles = stylex.create({
     borderColor: colors.fieldRule,
     borderRadius: controlMetrics.radius,
     outline: "none",
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     color: colors.ink,
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
     "::placeholder": { color: colors.inkMuted, opacity: 1 },

--- a/apps/web/src/components/admin/moderation/moderationInbox.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationInbox.stylex.tsx
@@ -310,7 +310,7 @@ const styles = stylex.create({
     borderColor: colors.fieldRule,
     borderRadius: controlMetrics.radius,
     outline: "none",
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     color: colors.ink,
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
     "::placeholder": { color: colors.inkMuted },

--- a/apps/web/src/components/bottleCreateCandidates.stories.tsx
+++ b/apps/web/src/components/bottleCreateCandidates.stories.tsx
@@ -1,0 +1,119 @@
+import { mockBottle } from "@peated/server/orpc/mock/fixtures";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import BottleImage from "../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
+import {
+  BottleCreateCandidates,
+  BottleCreateCandidateSummary,
+  type BottleCreateCandidate,
+} from "./bottleCreateCandidates.stylex";
+import { StoryCanvas, StoryStack } from "./storyFixtures.stylex";
+
+const match = {
+  ...mockBottle,
+  id: 51689,
+  peatedId: "B51689",
+  fullName: "Yamazaki 18-year-old",
+  name: "18-year-old",
+  brand: {
+    ...mockBottle.brand,
+    id: 8701,
+    peatedId: "E8701",
+    name: "Yamazaki",
+  },
+  distillers: [],
+  edition: null,
+  statedAge: 18,
+  abv: 43,
+  releaseYear: 2023,
+  imageUrl: BottleImage.src,
+} satisfies BottleCreateCandidate;
+
+const anniversaryMatch = {
+  ...match,
+  id: 51690,
+  peatedId: "B51690",
+  fullName: "Yamazaki 18-year-old - 100th Anniversary Edition",
+  edition: "100th Anniversary Edition",
+  imageUrl: null,
+} satisfies BottleCreateCandidate;
+
+const mizunaraMatch = {
+  ...match,
+  id: 51691,
+  peatedId: "B51691",
+  fullName: "Yamazaki 18-year-old - Mizunara 2024",
+  edition: "Mizunara 2024",
+  releaseYear: 2024,
+  abv: 48,
+  imageUrl: null,
+} satisfies BottleCreateCandidate;
+
+const meta = {
+  title: "Components/Bottles/Create Candidates",
+  component: BottleCreateCandidates,
+  args: {
+    error: false,
+    loading: false,
+    onUse: () => undefined,
+    results: [match],
+  },
+  argTypes: {
+    onUse: { control: false },
+    results: { control: false },
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="wide">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Use after Brand and Bottle name in the creation form to compare advisory catalog matches. The component owns idle, loading, empty, failure, single-match, and multiple-match states. Choosing a match is secondary to the screen's main create action.",
+      },
+    },
+  },
+} satisfies Meta<typeof BottleCreateCandidates>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {};
+
+export const MultipleMatches: Story = {
+  args: { results: [match, anniversaryMatch, mizunaraMatch] },
+};
+
+export const EntryNotices: Story = {
+  render: () => (
+    <StoryStack>
+      <BottleCreateCandidateSummary count={3} onReview={() => undefined} />
+      <BottleCreateCandidateSummary
+        count={2}
+        newSinceReview
+        onReview={() => undefined}
+      />
+    </StoryStack>
+  ),
+};
+
+export const Loading: Story = {
+  args: { loading: true, results: [] },
+};
+
+export const Idle: Story = {
+  args: { ready: false, results: [] },
+};
+
+export const EmptyAndFailure: Story = {
+  render: (args) => (
+    <StoryStack>
+      <BottleCreateCandidates {...args} results={[]} />
+      <BottleCreateCandidates {...args} error results={[]} />
+    </StoryStack>
+  ),
+};

--- a/apps/web/src/components/bottleCreateCandidates.stylex.tsx
+++ b/apps/web/src/components/bottleCreateCandidates.stylex.tsx
@@ -1,0 +1,178 @@
+import type { Outputs } from "@peated/server/orpc/router";
+import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
+import * as stylex from "@stylexjs/stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, controlMetrics, space } from "../styles/tokens.stylex";
+import { BottleIdentityRow } from "./bottleIdentityRow.stylex";
+import { Button } from "./button.stylex";
+
+export type BottleCreateCandidate =
+  Outputs["bottles"]["createCandidates"]["results"][number];
+
+export function BottleCreateCandidateSummary({
+  count,
+  newSinceReview = false,
+  onReview,
+}: {
+  count: number;
+  newSinceReview?: boolean;
+  onReview: () => void;
+}) {
+  const bottleCount = `${count} ${newSinceReview ? "more " : ""}${
+    count === 1 ? "bottle" : "bottles"
+  }`;
+  return (
+    <div {...stylex.props(styles.summary)}>
+      <p
+        aria-live="polite"
+        role="status"
+        {...stylex.props(foundationStyles.metadata, styles.status)}
+      >
+        {bottleCount} may match this one.
+      </p>
+      <Button
+        aria-label={`Review ${bottleCount} that may match this one`}
+        onClick={onReview}
+        size="sm"
+        type="button"
+        variant="text"
+      >
+        Review
+      </Button>
+    </div>
+  );
+}
+
+export function BottleCreateCandidates({
+  error,
+  loading,
+  onUse,
+  ready = true,
+  results,
+}: {
+  error: boolean;
+  loading: boolean;
+  onUse: (bottle: BottleCreateCandidate) => void;
+  ready?: boolean;
+  results: readonly BottleCreateCandidate[];
+}) {
+  return (
+    <section
+      aria-busy={loading || undefined}
+      aria-label="Bottles that may match"
+      {...stylex.props(styles.root)}
+    >
+      {!ready ? (
+        <p {...stylex.props(foundationStyles.metadata, styles.status)}>
+          Choose a brand and enter a bottle name to check for matches.
+        </p>
+      ) : loading ? (
+        <p
+          role="status"
+          {...stylex.props(foundationStyles.metadata, styles.status)}
+        >
+          Checking existing bottles…
+        </p>
+      ) : error ? (
+        <p
+          role="status"
+          {...stylex.props(foundationStyles.metadata, styles.status)}
+        >
+          Couldn’t check existing bottles. You can still add this one.
+        </p>
+      ) : results.length ? (
+        <>
+          <p {...stylex.props(foundationStyles.body, styles.instructions)}>
+            If one of these is the same bottle, use it instead of adding
+            another.
+          </p>
+          <ul {...stylex.props(styles.list)}>
+            {results.map((bottle) => (
+              <li key={bottle.id} {...stylex.props(styles.row)}>
+                <BottleIdentityRow
+                  {...getBottleIdentityProps(bottle, { includeBottler: true })}
+                  end={
+                    <Button
+                      aria-label={`Use this bottle: ${bottle.fullName}`}
+                      onClick={() => onUse(bottle)}
+                      size="sm"
+                      type="button"
+                      variant="tonal"
+                    >
+                      Use this bottle
+                    </Button>
+                  }
+                  imageUrl={bottle.imageUrl}
+                  layout="cell"
+                  variant="search"
+                  verticalPadding="sm"
+                />
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <p
+          role="status"
+          {...stylex.props(foundationStyles.metadata, styles.status)}
+        >
+          No similar bottles found.
+        </p>
+      )}
+    </section>
+  );
+}
+
+const summaryEnter = stylex.keyframes({
+  from: { opacity: 0, transform: "translateY(-8px)" },
+  to: { opacity: 1, transform: "translateY(0)" },
+});
+
+const REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)";
+
+const styles = stylex.create({
+  root: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x2,
+  },
+  summary: {
+    display: "flex",
+    minWidth: 0,
+    minHeight: "44px",
+    paddingRight: space.x2,
+    paddingLeft: space.x3,
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: space.x2,
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.accentTint,
+    animationName: { default: summaryEnter, [REDUCED_MOTION]: "none" },
+    animationDuration: "200ms",
+    animationTimingFunction: "ease-out",
+  },
+  instructions: { margin: 0, color: colors.inkMuted },
+  status: { minHeight: "20px", margin: 0, color: colors.inkMuted },
+  list: {
+    display: "flex",
+    minWidth: 0,
+    margin: 0,
+    padding: 0,
+    flexDirection: "column",
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+    listStyle: "none",
+  },
+  row: {
+    minWidth: 0,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+    ":last-child": { borderBottomWidth: 0 },
+  },
+});

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -6,6 +6,7 @@ import {
   formatCategoryName,
   formatFlavorProfile,
 } from "@peated/server/lib/format";
+import type { Inputs } from "@peated/server/orpc/router";
 import {
   BottleInputFields,
   EntityChoiceSchema,
@@ -15,26 +16,34 @@ import {
 } from "@peated/server/schemas";
 import type { Entity, EntityKind } from "@peated/server/types";
 import {
+  BottleCreateCandidates,
+  BottleCreateCandidateSummary,
   BottleIdentityRow,
   Button,
   EntityPicker,
   Field,
   FieldGroup,
   FormActions,
+  FormDesktopOnly,
   FormDetails,
   FormGrid,
   FormNotice,
   FormSection,
   FormStack,
+  FormStep,
+  FormSteps,
   PictureInput,
   SearchPicker,
   Select,
+  SeriesPicker,
   Switch,
   Textarea,
   TextInput,
   UnitInput,
+  type BottleCreateCandidate,
   type EntityPickerOption,
   type SearchPickerOption,
+  type SeriesPickerOption,
 } from "@peated/web/components";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
@@ -48,9 +57,16 @@ import { useORPC } from "@peated/web/lib/orpc/context";
 import { zodResolver } from "@peated/web/lib/zodResolver";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { WandSparkles } from "lucide-react";
-import { useEffect, useState } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type FormEvent,
+  type ReactNode,
+} from "react";
 import type { SubmitHandler } from "react-hook-form";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
+import { useDebounceValue } from "usehooks-ts";
 import { z } from "zod";
 
 const categoryList = CATEGORY_LIST.map((category) => ({
@@ -62,11 +78,6 @@ type BooleanChoice = {
   id: "unknown" | "yes" | "no";
   name: string;
 };
-
-const noAgeStatementChoices: BooleanChoice[] = [
-  { id: "unknown", name: "Not known" },
-  { id: "yes", name: "NAS" },
-];
 
 const colorChoices: BooleanChoice[] = [
   { id: "unknown", name: "Not stated" },
@@ -127,20 +138,6 @@ function isNumericChoice(value: number | Entity | ChoiceLike): value is number {
 
 function isCatalogEntity(value: number | Entity | ChoiceLike): value is Entity {
   return CatalogEntityMarkerSchema.safeParse(value).success;
-}
-
-function isDraftSeries(
-  value: number | ChoiceLike | null | undefined,
-): value is ChoiceLike {
-  const parsed = ChoiceLikeSchema.safeParse(value);
-  return parsed.success && !parsed.data.id;
-}
-
-function seriesChoiceId(value: number | ChoiceLike | null | undefined) {
-  const numeric = z.number().safeParse(value);
-  if (numeric.success) return String(numeric.data);
-  const choice = ChoiceLikeSchema.safeParse(value);
-  return choice.success && choice.data.id ? String(choice.data.id) : "";
 }
 
 export type BottleFormInitialData = Partial<
@@ -250,6 +247,18 @@ function toSearchPickerOption(
   };
 }
 
+function toSeriesPickerOption(
+  value: number | ChoiceLike | null | undefined,
+  brandName?: string,
+): SeriesPickerOption | null {
+  if (value === null || value === undefined) return null;
+  return {
+    id: choiceId(value),
+    name: choiceName(value),
+    brand: brandName,
+  };
+}
+
 function entityPickerOption(entity: Entity): EntityPickerOption {
   return {
     id: String(entity.id),
@@ -282,8 +291,12 @@ function distillerChoiceFromOption(
     : Number(option.id);
 }
 
-function draftSeries(name: string): NonNullable<FormSchemaType["series"]> {
-  return BottleInputFields.series.parse({ name })!;
+function seriesChoiceFromOption(
+  option: SeriesPickerOption,
+): NonNullable<FormSchemaType["series"]> {
+  return option.id.startsWith("new:")
+    ? BottleInputFields.series.parse({ name: option.name })!
+    : Number(option.id);
 }
 
 function makeDraftEntityOption(
@@ -301,18 +314,58 @@ function numberOrNull(value: string) {
   return value ? Number(value) : null;
 }
 
+function normalizedPickerQuery(query: string) {
+  return query.trim().replace(/\s+/g, " ").toLocaleLowerCase();
+}
+
+function identityChoice(option: { id: string | number; name: string }) {
+  const id = String(option.id);
+  return {
+    id: /^\d+$/.test(id) ? Number(id) : null,
+    name: option.name,
+  };
+}
+
+function finiteNumber(value: number | null | undefined) {
+  const parsed = z.number().finite().safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+type BottleCreateCandidateQuery = Inputs["bottles"]["createCandidates"];
+
+const candidateDebounceOptions = {
+  equalityFn: (
+    left: BottleCreateCandidateQuery,
+    right: BottleCreateCandidateQuery,
+  ) => JSON.stringify(left) === JSON.stringify(right),
+};
+
+const createSteps = [
+  "Bottle",
+  "Made by",
+  "Release",
+  "Dates",
+  "Production",
+  "Cask",
+  "Photo",
+] as const;
+
 export default function BottleForm({
   initialData,
+  mode,
   onSubmit,
+  onUseExistingBottle,
   returnTo,
   saveLabel = "Save bottle",
   title,
 }: {
   initialData: BottleFormInitialData;
+  mode: "create" | "edit";
   onSubmit: (
     value: BottleFormSubmitValue,
     meta: BottleFormSubmitMeta,
   ) => void | Promise<void>;
+  onUseExistingBottle?: (bottle: BottleCreateCandidate) => void;
   returnTo?: string | null;
   saveLabel?: string;
   title: string;
@@ -324,6 +377,7 @@ export default function BottleForm({
   const [brandQuery, setBrandQuery] = useState("");
   const [bottlerQuery, setBottlerQuery] = useState("");
   const [distillerQuery, setDistillerQuery] = useState("");
+  const [seriesQuery, setSeriesQuery] = useState("");
   const [brand, setBrand] = useState<EntityPickerOption | null>(() =>
     toEntityPickerOption(initialData.brand),
   );
@@ -333,16 +387,21 @@ export default function BottleForm({
   const [distillers, setDistillers] = useState<readonly SearchPickerOption[]>(
     () => initialData.distillers?.map(toSearchPickerOption) ?? [],
   );
-  const [seriesMode, setSeriesMode] = useState(() => {
-    const series = initialData.series;
-    return isDraftSeries(series) ? "new" : "";
-  });
-  const [newSeriesName, setNewSeriesName] = useState(() => {
-    const series = initialData.series;
-    return isDraftSeries(series) ? series.name : "";
-  });
+  const [series, setSeries] = useState<SeriesPickerOption | null>(() =>
+    toSeriesPickerOption(initialData.series, brand?.name),
+  );
   const [image, setImage] = useState<File | null | undefined>(undefined);
   const [imagePreview, setImagePreview] = useState(imageUrl ?? undefined);
+  const [currentStep, setCurrentStep] = useState(0);
+  const [candidateReviewOpen, setCandidateReviewOpen] = useState(false);
+  const [reviewedCandidateIds, setReviewedCandidateIds] = useState<
+    ReadonlySet<number>
+  >(() => new Set());
+  const [candidateReviewResults, setCandidateReviewResults] = useState<
+    readonly BottleCreateCandidate[]
+  >([]);
+  const [submitAfterCandidateReview, setSubmitAfterCandidateReview] =
+    useState(false);
   const {
     control,
     formState: { dirtyFields, errors, isSubmitting },
@@ -350,7 +409,7 @@ export default function BottleForm({
     handleSubmit,
     register,
     setValue,
-    watch,
+    trigger,
   } = useForm<FormSchemaType>({
     defaultValues: {
       ...initialFormData,
@@ -362,48 +421,217 @@ export default function BottleForm({
     resolver: zodResolver(BottleFormSchema),
   });
 
-  const brandResults = useQuery(
-    orpc.entities.list.queryOptions({
+  const normalizedBrandQuery = normalizedPickerQuery(brandQuery);
+  const normalizedBottlerQuery = normalizedPickerQuery(bottlerQuery);
+  const normalizedDistillerQuery = normalizedPickerQuery(distillerQuery);
+  const normalizedSeriesQuery = normalizedPickerQuery(seriesQuery);
+  const [debouncedBrandQuery] = useDebounceValue(normalizedBrandQuery, 150);
+  const [debouncedBottlerQuery] = useDebounceValue(normalizedBottlerQuery, 150);
+  const [debouncedDistillerQuery] = useDebounceValue(
+    normalizedDistillerQuery,
+    150,
+  );
+  const [debouncedSeriesQuery] = useDebounceValue(normalizedSeriesQuery, 150);
+
+  const brandResults = useQuery({
+    ...orpc.entities.list.queryOptions({
       input: {
+        kinds: ["brand"],
         limit: 25,
-        query: brandQuery,
-        sort: brandQuery ? "rank" : "name",
+        query: debouncedBrandQuery,
+        sort: debouncedBrandQuery ? "rank" : "name",
       },
     }),
-  );
-  const bottlerResults = useQuery(
-    orpc.entities.list.queryOptions({
+    staleTime: 5 * 60_000,
+  });
+  const bottlerResults = useQuery({
+    ...orpc.entities.list.queryOptions({
       input: {
+        kinds: ["bottler"],
         limit: 25,
-        query: bottlerQuery,
-        sort: bottlerQuery ? "rank" : "name",
+        query: debouncedBottlerQuery,
+        sort: debouncedBottlerQuery ? "rank" : "name",
       },
     }),
-  );
-  const distillerResults = useQuery(
-    orpc.entities.list.queryOptions({
+    staleTime: 5 * 60_000,
+  });
+  const distillerResults = useQuery({
+    ...orpc.entities.list.queryOptions({
       input: {
+        kinds: ["distillery"],
         limit: 25,
-        query: distillerQuery,
-        sort: distillerQuery ? "rank" : "name",
+        query: debouncedDistillerQuery,
+        sort: debouncedDistillerQuery ? "rank" : "name",
       },
     }),
-  );
+    staleTime: 5 * 60_000,
+  });
   const numericBrandId = brand && /^\d+$/.test(brand.id) ? Number(brand.id) : 0;
-  const seriesResults = useQuery({
+  const seriesPreloadResults = useQuery({
     ...orpc.bottleSeries.list.queryOptions({
-      input: { brand: numericBrandId, limit: 100, query: "" },
+      input: {
+        brand: numericBrandId,
+        limit: 100,
+        query: "",
+      },
     }),
     enabled: Boolean(numericBrandId),
+    staleTime: 5 * 60_000,
   });
+  const needsRemoteSeriesSearch =
+    (seriesPreloadResults.data?.total ?? 0) >
+    (seriesPreloadResults.data?.results.length ?? 0);
+  const seriesSearchResults = useQuery({
+    ...orpc.bottleSeries.list.queryOptions({
+      input: {
+        brand: numericBrandId,
+        limit: 100,
+        query: debouncedSeriesQuery,
+      },
+    }),
+    enabled: Boolean(
+      numericBrandId && needsRemoteSeriesSearch && debouncedSeriesQuery,
+    ),
+    staleTime: 5 * 60_000,
+  });
+  const seriesResults =
+    needsRemoteSeriesSearch && debouncedSeriesQuery
+      ? seriesSearchResults
+      : seriesPreloadResults;
   const generateData = useMutation(orpc.ai.bottleLookup.mutationOptions());
-  const name = watch("name");
-  const category = watch("category");
-  const statedAge = watch("statedAge");
-  const noAgeStatement = watch("noAgeStatement");
-  const abv = watch("abv");
-  const edition = watch("edition");
-  const releaseYear = watch("releaseYear");
+  const draft = useWatch({ control });
+  const {
+    abv,
+    bottlingYear,
+    caskNumber,
+    caskStrength,
+    category,
+    description,
+    descriptionSrc,
+    edition,
+    flavorProfile,
+    maltPhenolPpm,
+    maturation,
+    name,
+    naturalColor,
+    noAgeStatement,
+    nonChillFiltered,
+    outturn,
+    releaseDay,
+    releaseMonth,
+    releaseYear,
+    singleCask,
+    statedAge,
+    tastingNotes,
+    vintageYear,
+  } = draft;
+  const candidateInput = useMemo<BottleCreateCandidateQuery>(
+    () => ({
+      name: name ?? "",
+      brand: brand ? identityChoice(brand) : null,
+      distillers: distillers.map((distiller) =>
+        identityChoice({ id: distiller.id, name: distiller.label }),
+      ),
+      bottler: bottler ? identityChoice(bottler) : null,
+      series: series ? identityChoice(series) : null,
+      category: category ?? null,
+      statedAge: finiteNumber(statedAge),
+      noAgeStatement: noAgeStatement ?? null,
+      caskStrength: caskStrength ?? null,
+      singleCask: singleCask ?? null,
+      naturalColor: naturalColor ?? null,
+      nonChillFiltered: nonChillFiltered ?? null,
+      maltPhenolPpm: finiteNumber(maltPhenolPpm),
+      abv: finiteNumber(abv),
+      edition: edition || null,
+      vintageYear: finiteNumber(vintageYear),
+      bottlingYear: finiteNumber(bottlingYear),
+      releaseYear: finiteNumber(releaseYear),
+      releaseMonth: finiteNumber(releaseMonth),
+      releaseDay: finiteNumber(releaseDay),
+      maturation: maturation || null,
+      caskNumber: caskNumber || null,
+      outturn: finiteNumber(outturn),
+      description: description || null,
+      descriptionSrc: descriptionSrc ?? null,
+      flavorProfile: flavorProfile ?? null,
+      tastingNotes: tastingNotes
+        ? {
+            nose: tastingNotes.nose ?? "",
+            palate: tastingNotes.palate ?? "",
+            finish: tastingNotes.finish ?? "",
+          }
+        : null,
+      limit: 3,
+    }),
+    [
+      abv,
+      bottler,
+      bottlingYear,
+      brand,
+      caskNumber,
+      caskStrength,
+      category,
+      description,
+      descriptionSrc,
+      distillers,
+      edition,
+      flavorProfile,
+      maltPhenolPpm,
+      maturation,
+      name,
+      naturalColor,
+      noAgeStatement,
+      nonChillFiltered,
+      outturn,
+      releaseDay,
+      releaseMonth,
+      releaseYear,
+      series,
+      singleCask,
+      statedAge,
+      tastingNotes,
+      vintageYear,
+    ],
+  );
+  const [debouncedCandidateInput] = useDebounceValue(
+    candidateInput,
+    300,
+    candidateDebounceOptions,
+  );
+  const candidateEnabled = Boolean(
+    onUseExistingBottle && brand && debouncedCandidateInput.name.trim(),
+  );
+  const candidateResults = useQuery({
+    ...orpc.bottles.createCandidates.queryOptions({
+      input: debouncedCandidateInput,
+    }),
+    enabled: candidateEnabled,
+    staleTime: 5 * 60_000,
+  });
+  const candidateInputPending =
+    JSON.stringify(candidateInput) !== JSON.stringify(debouncedCandidateInput);
+  const candidateList = candidateResults.data?.results ?? [];
+  const candidateCheckLoading = Boolean(
+    candidateEnabled && (candidateInputPending || candidateResults.isFetching),
+  );
+  const unreviewedCandidates = candidateList.filter(
+    (candidate) => !reviewedCandidateIds.has(candidate.id),
+  );
+  const hasUnreviewedCandidates = unreviewedCandidates.length > 0;
+  const reviewingCandidates = candidateReviewOpen;
+  const isCreate = mode === "create";
+  const isLastCreateStep = currentStep === createSteps.length - 1;
+  const draftIdentityProps = getBottleIdentityProps({
+    name: name || "Bottle preview",
+    brand: { name: brand?.name ?? "" },
+    category: category ?? null,
+    statedAge: statedAge ?? null,
+    noAgeStatement: noAgeStatement ?? null,
+    abv: abv ?? null,
+    edition,
+    releaseYear,
+  });
 
   useEffect(() => {
     return () => {
@@ -445,632 +673,921 @@ export default function BottleForm({
     }
   }
 
+  function scrollToFormTop() {
+    window.scrollTo({ top: 0 });
+  }
+
+  function openCandidateReview(submitAfterReview = false) {
+    if (!unreviewedCandidates.length) return;
+    setCandidateReviewResults(unreviewedCandidates);
+    setCandidateReviewOpen(true);
+    setSubmitAfterCandidateReview(submitAfterReview);
+    scrollToFormTop();
+  }
+
+  function closeCandidateReview() {
+    setCandidateReviewOpen(false);
+    setCandidateReviewResults([]);
+    setSubmitAfterCandidateReview(false);
+    scrollToFormTop();
+  }
+
+  function markCandidateReviewComplete() {
+    setReviewedCandidateIds((current) => {
+      const next = new Set(current);
+      for (const candidate of candidateReviewResults) next.add(candidate.id);
+      return next;
+    });
+  }
+
+  async function continueCreateFlow() {
+    const stepFields: ReadonlyArray<ReadonlyArray<BottleFormFieldName>> = [
+      ["brand", "name", "category"],
+      ["distillers", "bottler", "series"],
+      ["statedAge", "noAgeStatement", "abv", "edition"],
+      [
+        "vintageYear",
+        "bottlingYear",
+        "releaseYear",
+        "releaseMonth",
+        "releaseDay",
+      ],
+      [
+        "singleCask",
+        "caskStrength",
+        "naturalColor",
+        "nonChillFiltered",
+        "maltPhenolPpm",
+      ],
+      ["maturation", "caskNumber", "outturn"],
+      ["flavorProfile", "imageSourceUrl", "imageLicense", "description"],
+    ];
+    if (!(await trigger([...stepFields[currentStep]]))) return;
+    setCurrentStep((step) => Math.min(step + 1, createSteps.length - 1));
+    scrollToFormTop();
+  }
+
+  function previousCreateStep(event: FormEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    setCurrentStep((step) => Math.max(step - 1, 0));
+    scrollToFormTop();
+  }
+
+  function continueAfterCandidateReview() {
+    markCandidateReviewComplete();
+    setCandidateReviewOpen(false);
+    setCandidateReviewResults([]);
+    if (submitAfterCandidateReview) {
+      setSubmitAfterCandidateReview(false);
+      void handleSubmit(submit)();
+    }
+  }
+
+  function handlePrimaryAction(
+    event: FormEvent<HTMLButtonElement | HTMLFormElement>,
+  ) {
+    event.preventDefault();
+    if (!isCreate) {
+      void handleSubmit(submit)(event);
+      return;
+    }
+    if (reviewingCandidates) {
+      continueAfterCandidateReview();
+      return;
+    }
+    if (!isLastCreateStep) {
+      void continueCreateFlow();
+      return;
+    }
+    if (hasUnreviewedCandidates) {
+      openCandidateReview(true);
+      return;
+    }
+    void handleSubmit(submit)(event);
+  }
+
   return (
     <WorkflowScreen
+      mobileSaveBar={isCreate}
       onClose={returnTo ? () => window.location.assign(returnTo) : undefined}
-      onSave={handleSubmit(submit)}
-      saveLabel={saveLabel}
+      onPrevious={
+        reviewingCandidates
+          ? (event) => {
+              event.preventDefault();
+              closeCandidateReview();
+            }
+          : isCreate && currentStep > 0
+            ? previousCreateStep
+            : undefined
+      }
+      onSave={handlePrimaryAction}
+      saveDisabled={
+        isCreate &&
+        !reviewingCandidates &&
+        isLastCreateStep &&
+        candidateCheckLoading
+      }
+      saveHint={
+        isCreate &&
+        !reviewingCandidates &&
+        isLastCreateStep &&
+        candidateCheckLoading
+          ? "Checking existing bottles…"
+          : undefined
+      }
+      saveLabel={
+        reviewingCandidates
+          ? submitAfterCandidateReview
+            ? "Add as a new bottle"
+            : "None of these"
+          : isCreate && !isLastCreateStep
+            ? "Continue"
+            : hasUnreviewedCandidates
+              ? `Review ${unreviewedCandidates.length} ${
+                  unreviewedCandidates.length === 1 ? "bottle" : "bottles"
+                }`
+              : saveLabel
+      }
       saving={isSubmitting}
-      title={title}
+      title={reviewingCandidates ? "Is it already on Peated?" : title}
     >
-      <form onSubmit={handleSubmit(submit)}>
+      <form onSubmit={handlePrimaryAction}>
         <FormStack>
-          <FormNotice>
-            Add what you can confirm from the label. Brand and bottle name are
-            required. You can leave everything else blank.
-          </FormNotice>
-          {name || brand ? (
-            <BottleIdentityRow
-              {...getBottleIdentityProps({
-                name: name || "Bottle preview",
-                brand: { name: brand?.name ?? "" },
-                category: category ?? null,
-                statedAge: statedAge ?? null,
-                noAgeStatement: noAgeStatement ?? null,
-                abv: abv ?? null,
-                edition,
-                releaseYear,
-              })}
-            />
-          ) : null}
           {submitError ? (
             <FormNotice role="alert">{submitError}</FormNotice>
           ) : null}
-          <FormSection title="Bottle details">
-            <EntityPicker
-              error={errors.brand?.message}
-              help="The main label the bottle is sold under."
-              kind="brand"
-              loading={brandResults.isFetching}
-              onChange={(option) => {
-                setBrand(option);
-                const nextBrand = option
-                  ? entityChoiceFromOption(option, "brand")
-                  : undefined;
-                // SAFETY: the form can hold an empty required field until schema validation runs.
-                setValue("brand", nextBrand as FormSchemaType["brand"], {
-                  shouldDirty: true,
-                  shouldValidate: true,
-                });
-                setValue("series", null, { shouldDirty: true });
-                setSeriesMode("");
-                setNewSeriesName("");
-              }}
-              onCreate={(query) => {
-                const option = makeDraftEntityOption(query, "brand");
-                setBrand(option);
-                setValue(
-                  "brand",
-                  EntityChoiceSchema.parse({ kind: "brand", name: query }),
-                  {
-                    shouldDirty: true,
-                    shouldValidate: true,
-                  },
-                );
-              }}
-              onQueryChange={setBrandQuery}
-              options={(brandResults.data?.results ?? []).map(
-                entityPickerOption,
-              )}
-              placeholder="Laphroaig"
-              required
-              value={brand}
-            />
-            <Field
-              error={errors.name?.message}
-              htmlFor="bottle-name"
-              label="Bottle name"
-              required
-            >
-              <TextInput
-                {...register("name")}
-                autoFocus
-                id="bottle-name"
-                invalid={Boolean(errors.name)}
-                placeholder="12-year-old"
+          {reviewingCandidates ? (
+            <FormStep key="candidate-review" title="Is it already on Peated?">
+              <BottleIdentityRow
+                {...draftIdentityProps}
+                imageUrl={imagePreview}
+                layout="cell"
+                variant="search"
+                verticalPadding="sm"
               />
-            </Field>
-            <Field
-              error={errors.category?.message}
-              htmlFor="bottle-category"
-              label="Type"
-              optional
-            >
-              <Select
-                {...register("category", {
-                  setValueAs: (value) => value || null,
-                })}
-                id="bottle-category"
-                invalid={Boolean(errors.category)}
-              >
-                <option value="">Not set</option>
-                {categoryList.map((item) => (
-                  <option key={item.id} value={item.id}>
-                    {item.name}
-                  </option>
-                ))}
-              </Select>
-            </Field>
-            <FormGrid>
-              <Field
-                error={errors.statedAge?.message}
-                htmlFor="bottle-age"
-                label="Age statement"
-                optional
-              >
-                <UnitInput
-                  {...register("statedAge", {
-                    setValueAs: (value) => numberOrNull(value),
-                  })}
-                  disabled={noAgeStatement === true}
-                  id="bottle-age"
-                  invalid={Boolean(errors.statedAge)}
-                  min={0}
-                  placeholder="12"
-                  unit="years"
-                />
-              </Field>
-              <Field
-                error={errors.noAgeStatement?.message}
-                htmlFor="bottle-age-information"
-                label="Age information"
-                optional
-              >
-                <Controller
-                  control={control}
-                  name="noAgeStatement"
-                  render={({ field }) => (
-                    <Select
-                      id="bottle-age-information"
-                      onChange={(event) => {
-                        const next = booleanChoiceValue(
-                          event.currentTarget.value,
-                        );
-                        field.onChange(next);
-                        if (next) {
-                          setValue("statedAge", null, { shouldDirty: true });
-                        }
-                      }}
-                      value={booleanChoiceId(field.value)}
-                    >
-                      {noAgeStatementChoices.map((choice) => (
-                        <option key={choice.id} value={choice.id}>
-                          {choice.name}
-                        </option>
-                      ))}
-                    </Select>
-                  )}
-                />
-              </Field>
-            </FormGrid>
-            <Field
-              error={errors.abv?.message}
-              htmlFor="bottle-abv"
-              label="Alcohol"
-              optional
-            >
-              <UnitInput
-                {...register("abv", {
-                  setValueAs: (value) => numberOrNull(value),
-                })}
-                id="bottle-abv"
-                invalid={Boolean(errors.abv)}
-                max={100}
-                min={0}
-                placeholder="40.5"
-                step="0.1"
-                unit="% ABV"
-              />
-            </Field>
-            <SearchPicker
-              help="The distilleries that produced the spirit."
-              label="Distilled by"
-              loading={distillerResults.isFetching}
-              onChange={(options) => {
-                setDistillers(options);
-                setValue("distillers", options.map(distillerChoiceFromOption), {
-                  shouldDirty: true,
-                  shouldValidate: true,
-                });
-              }}
-              onCreate={(query) => {
-                const option: SearchPickerOption = {
-                  entity: { name: query, kind: "distillery" },
-                  id: `new:${query}`,
-                  label: query,
-                };
-                const next = [...distillers, option];
-                setDistillers(next);
-                setValue("distillers", next.map(distillerChoiceFromOption), {
-                  shouldDirty: true,
-                  shouldValidate: true,
-                });
-              }}
-              onQueryChange={setDistillerQuery}
-              options={(distillerResults.data?.results ?? []).map(
-                entitySearchOption,
-              )}
-              placeholder="Search distilleries"
-              value={distillers}
-            />
-            <EntityPicker
-              help="The independent bottler, if this isn't an official brand or distillery release."
-              kind="bottler"
-              loading={bottlerResults.isFetching}
-              onChange={(option) => {
-                setBottler(option);
-                setValue(
-                  "bottler",
-                  option ? entityChoiceFromOption(option, "bottler") : null,
-                  { shouldDirty: true, shouldValidate: true },
-                );
-              }}
-              onCreate={(query) => {
-                const option = makeDraftEntityOption(query, "bottler");
-                setBottler(option);
-                setValue(
-                  "bottler",
-                  EntityChoiceSchema.parse({ kind: "bottler", name: query }),
-                  {
-                    shouldDirty: true,
-                    shouldValidate: true,
-                  },
-                );
-              }}
-              onQueryChange={setBottlerQuery}
-              options={(bottlerResults.data?.results ?? []).map(
-                entityPickerOption,
-              )}
-              placeholder="Search bottlers"
-              value={bottler}
-            />
-          </FormSection>
-
-          <FormDetails
-            defaultOpen={hasMoreDetails(initialData)}
-            description="Edition, year, cask, production, and catalog information."
-            title="More details"
-          >
-            <Field
-              error={errors.edition?.message}
-              htmlFor="bottle-edition"
-              label="Edition or batch"
-              optional
-            >
-              <TextInput
-                {...register("edition", {
-                  setValueAs: (value) => value || null,
-                })}
-                id="bottle-edition"
-                invalid={Boolean(errors.edition)}
-                placeholder="Batch 24"
-              />
-            </Field>
-            <Field
-              error={errors.series?.message}
-              htmlFor="bottle-series"
-              label="Series"
-              optional
-            >
-              <Select
-                disabled={!brand}
-                id="bottle-series"
-                onChange={(event) => {
-                  const next = event.currentTarget.value;
-                  setSeriesMode(next);
-                  if (!next) setValue("series", null, { shouldDirty: true });
-                  else if (next === "new") {
-                    setValue("series", draftSeries(newSeriesName), {
-                      shouldDirty: true,
-                    });
-                  } else {
-                    setValue("series", Number(next), { shouldDirty: true });
-                  }
+              <BottleCreateCandidates
+                error={false}
+                loading={false}
+                onUse={(candidate) => {
+                  markCandidateReviewComplete();
+                  onUseExistingBottle?.(candidate);
                 }}
-                value={seriesMode || seriesChoiceId(initialData.series)}
-              >
-                <option value="">Not set</option>
-                {seriesResults.data?.results.map((item) => (
-                  <option key={item.id} value={item.id}>
-                    {item.name}
-                  </option>
-                ))}
-                <option value="new">Add a new series…</option>
-              </Select>
-            </Field>
-            {seriesMode === "new" ? (
-              <Field
-                error={errors.series?.message}
-                htmlFor="bottle-new-series"
-                label="New series name"
-                required
-              >
-                <TextInput
-                  id="bottle-new-series"
-                  onChange={(event) => {
-                    const next = event.currentTarget.value;
-                    setNewSeriesName(next);
-                    setValue("series", draftSeries(next), {
-                      shouldDirty: true,
-                      shouldValidate: true,
-                    });
-                  }}
-                  value={newSeriesName}
-                />
-              </Field>
-            ) : null}
-            <FormGrid>
-              <YearField
-                error={errors.vintageYear?.message}
-                id="bottle-distillation-year"
-                label="Distillation year"
-                register={register("vintageYear", {
-                  setValueAs: (value) => numberOrNull(value),
-                })}
+                results={candidateReviewResults}
               />
-              <YearField
-                error={errors.bottlingYear?.message}
-                id="bottle-bottling-year"
-                label="Bottling year"
-                register={register("bottlingYear", {
-                  setValueAs: (value) => numberOrNull(value),
-                })}
-              />
-              <YearField
-                error={errors.releaseYear?.message}
-                id="bottle-release-year"
-                label="Release year"
-                register={register("releaseYear", {
-                  setValueAs: (value) => numberOrNull(value),
-                })}
-              />
-              <Field
-                error={errors.releaseMonth?.message}
-                htmlFor="bottle-release-month"
-                label="Release month"
-                optional
-              >
-                <Controller
-                  control={control}
-                  name="releaseMonth"
-                  render={({ field }) => (
-                    <Select
-                      id="bottle-release-month"
-                      invalid={Boolean(errors.releaseMonth)}
-                      onChange={(event) =>
-                        field.onChange(
-                          event.currentTarget.value
-                            ? Number(event.currentTarget.value)
-                            : null,
-                        )
-                      }
-                      value={field.value ?? ""}
-                    >
-                      <option value="">Not set</option>
-                      {releaseMonths.map((month, index) => (
-                        <option key={month} value={index + 1}>
-                          {month}
-                        </option>
-                      ))}
-                    </Select>
-                  )}
-                />
-              </Field>
-              <Field
-                error={errors.releaseDay?.message}
-                htmlFor="bottle-release-day"
-                label="Release day"
-                optional
-              >
-                <TextInput
-                  {...register("releaseDay", {
-                    setValueAs: (value) => numberOrNull(value),
-                  })}
-                  format="data"
-                  id="bottle-release-day"
-                  invalid={Boolean(errors.releaseDay)}
-                  max={31}
-                  min={1}
-                  type="number"
-                />
-              </Field>
-            </FormGrid>
-            <Controller
-              control={control}
-              name="singleCask"
-              render={({ field }) => (
-                <Switch
-                  checked={Boolean(field.value)}
-                  description="The label states that this is a single-cask bottling."
-                  label="Single cask"
-                  onCheckedChange={field.onChange}
-                />
-              )}
-            />
-            <Controller
-              control={control}
-              name="caskStrength"
-              render={({ field }) => (
-                <Switch
-                  checked={Boolean(field.value)}
-                  description="The label states that this was bottled at cask strength."
-                  label="Cask strength"
-                  onCheckedChange={field.onChange}
-                />
-              )}
-            />
-            <FormGrid>
-              <BooleanSelectField
-                choices={colorChoices}
-                id="bottle-color"
-                label="Color"
-                onChange={(value) =>
-                  setValue("naturalColor", value, { shouldDirty: true })
-                }
-                value={watch("naturalColor")}
-              />
-              <BooleanSelectField
-                choices={filtrationChoices}
-                id="bottle-filtration"
-                label="Filtration"
-                onChange={(value) =>
-                  setValue("nonChillFiltered", value, { shouldDirty: true })
-                }
-                value={watch("nonChillFiltered")}
-              />
-            </FormGrid>
-            <Field
-              error={errors.maltPhenolPpm?.message}
-              htmlFor="bottle-ppm"
-              label="Phenol level"
-              optional
-            >
-              <UnitInput
-                {...register("maltPhenolPpm", {
-                  setValueAs: (value) => numberOrNull(value),
-                })}
-                id="bottle-ppm"
-                invalid={Boolean(errors.maltPhenolPpm)}
-                min={0}
-                placeholder="101.4"
-                step="0.1"
-                unit="PPM"
-              />
-            </Field>
-            <Field
-              error={errors.maturation?.message}
-              hint="Use the producer's cask or maturation wording."
-              htmlFor="bottle-maturation"
-              label="Maturation"
-              optional
-            >
-              <Textarea
-                {...register("maturation", {
-                  setValueAs: (value) => value?.trim() || null,
-                })}
-                id="bottle-maturation"
-                invalid={Boolean(errors.maturation)}
-                placeholder="2nd fill ex-bourbon hogshead"
-                rows={3}
-              />
-            </Field>
-            <FormGrid>
-              <Field
-                error={errors.caskNumber?.message}
-                htmlFor="bottle-cask-number"
-                label="Cask number"
-                optional
-              >
-                <TextInput
-                  {...register("caskNumber", {
-                    setValueAs: (value) => value?.trim() || null,
-                  })}
-                  id="bottle-cask-number"
-                  invalid={Boolean(errors.caskNumber)}
-                  placeholder="35.401"
-                />
-              </Field>
-              <Field
-                error={errors.outturn?.message}
-                htmlFor="bottle-outturn"
-                label="Outturn"
-                optional
-              >
-                <UnitInput
-                  {...register("outturn", {
-                    setValueAs: (value) => numberOrNull(value),
-                  })}
-                  id="bottle-outturn"
-                  invalid={Boolean(errors.outturn)}
-                  min={1}
-                  placeholder="240"
-                  unit="bottles"
-                />
-              </Field>
-            </FormGrid>
-            <Field
-              error={errors.flavorProfile?.message}
-              htmlFor="bottle-flavor-profile"
-              label="Flavor profile"
-              optional
-            >
-              <Select
-                {...register("flavorProfile", {
-                  setValueAs: (value) => value || null,
-                })}
-                id="bottle-flavor-profile"
-                invalid={Boolean(errors.flavorProfile)}
-              >
-                <option value="">Not set</option>
-                {FLAVOR_PROFILES.map((profile) => (
-                  <option key={profile} value={profile}>
-                    {formatFlavorProfile(profile)}
-                  </option>
-                ))}
-              </Select>
-            </Field>
-            {user?.mod || user?.admin ? (
-              <FormActions>
-                <Button
-                  loading={generateData.isPending}
-                  onClick={() => void fillDetails()}
-                  size="sm"
-                  variant="tonal"
-                >
-                  <WandSparkles aria-hidden="true" size={15} />
-                  Fill description
-                </Button>
-              </FormActions>
-            ) : null}
-            <FieldGroup label="Bottle image" optional>
-              <PictureInput
-                disabled={isSubmitting}
-                id="bottle-image"
-                label="Add a bottle image"
-                name="image"
-                onFilesSelected={(files) => {
-                  const file = files.item(0);
-                  if (!file) return;
-                  setImage(file);
-                  setImagePreview(URL.createObjectURL(file));
-                  setValue("imageSourceUrl", null, { shouldDirty: true });
-                  setValue("imageLicense", null, { shouldDirty: true });
-                }}
-                onRemove={
-                  imagePreview
-                    ? () => {
-                        setImage(null);
-                        setImagePreview(undefined);
-                        setValue("imageSourceUrl", null, {
-                          shouldDirty: true,
-                        });
-                        setValue("imageLicense", null, { shouldDirty: true });
-                      }
-                    : undefined
-                }
-                preview={
-                  imagePreview
-                    ? { alt: "Current bottle image", src: imagePreview }
-                    : undefined
-                }
-              />
-              {user?.mod || user?.admin ? (
-                <>
-                  <Field
-                    error={errors.imageSourceUrl?.message}
-                    htmlFor="bottle-image-source"
-                    label="Source URL"
-                    optional
-                  >
-                    <TextInput
-                      {...register("imageSourceUrl", {
-                        setValueAs: (value) => value || null,
-                      })}
-                      id="bottle-image-source"
-                      invalid={Boolean(errors.imageSourceUrl)}
-                      placeholder="https://example.com/original-image"
-                      type="url"
+            </FormStep>
+          ) : (
+            <>
+              {name || brand ? (
+                isCreate ? (
+                  <FormDesktopOnly>
+                    <BottleIdentityRow
+                      {...draftIdentityProps}
+                      imageUrl={imagePreview}
+                      layout="cell"
+                      variant="search"
+                      verticalPadding="sm"
                     />
-                  </Field>
-                  <Field
-                    error={errors.imageLicense?.message}
-                    htmlFor="bottle-image-license"
-                    label="License"
-                    optional
-                  >
-                    <TextInput
-                      {...register("imageLicense", {
-                        setValueAs: (value) => value || null,
-                      })}
-                      id="bottle-image-license"
-                      invalid={Boolean(errors.imageLicense)}
-                      placeholder="CC BY-SA 4.0"
-                    />
-                  </Field>
-                </>
+                  </FormDesktopOnly>
+                ) : (
+                  <BottleIdentityRow
+                    {...draftIdentityProps}
+                    imageUrl={imagePreview}
+                  />
+                )
               ) : null}
-            </FieldGroup>
-            <Field
-              error={errors.description?.message}
-              htmlFor="bottle-description"
-              label="Description"
-              optional
-            >
-              <Textarea
-                {...register("description", {
-                  onChange: () =>
-                    setValue("descriptionSrc", "user", { shouldDirty: true }),
-                  setValueAs: (value) => value || null,
-                })}
-                id="bottle-description"
-                invalid={Boolean(errors.description)}
-                rows={8}
+              {isCreate &&
+              onUseExistingBottle &&
+              candidateResults.isSuccess &&
+              !candidateCheckLoading &&
+              hasUnreviewedCandidates ? (
+                <BottleCreateCandidateSummary
+                  count={unreviewedCandidates.length}
+                  newSinceReview={reviewedCandidateIds.size > 0}
+                  onReview={() => openCandidateReview()}
+                />
+              ) : null}
+              {isCreate ? (
+                <FormSteps
+                  compactOnMobile
+                  currentStep={currentStep}
+                  steps={createSteps}
+                />
+              ) : null}
+              <BottleFieldsLayout
+                create={isCreate}
+                currentStep={currentStep}
+                defaultOpen={hasMoreDetails(initialData)}
+                primary={
+                  <>
+                    {!isCreate || currentStep === 0 ? (
+                      <>
+                        <EntityPicker
+                          error={errors.brand?.message}
+                          help="The main label the bottle is sold under."
+                          kind="brand"
+                          loading={
+                            normalizedBrandQuery !== debouncedBrandQuery ||
+                            brandResults.isFetching
+                          }
+                          onChange={(option) => {
+                            setBrand(option);
+                            const nextBrand = option
+                              ? entityChoiceFromOption(option, "brand")
+                              : undefined;
+                            // SAFETY: the form can hold an empty required field until schema validation runs.
+                            setValue(
+                              "brand",
+                              nextBrand as FormSchemaType["brand"],
+                              {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                              },
+                            );
+                            setValue("series", null, { shouldDirty: true });
+                            setSeries(null);
+                            setSeriesQuery("");
+                          }}
+                          onCreate={(query) => {
+                            const option = makeDraftEntityOption(
+                              query,
+                              "brand",
+                            );
+                            setBrand(option);
+                            setValue(
+                              "brand",
+                              EntityChoiceSchema.parse({
+                                kind: "brand",
+                                name: query,
+                              }),
+                              {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                              },
+                            );
+                          }}
+                          onQueryChange={setBrandQuery}
+                          options={(brandResults.data?.results ?? []).map(
+                            entityPickerOption,
+                          )}
+                          placeholder="Laphroaig"
+                          required
+                          searchError={
+                            brandResults.isError
+                              ? "Unable to search brands. Keep typing or try again."
+                              : undefined
+                          }
+                          value={brand}
+                        />
+                        <Field
+                          error={errors.name?.message}
+                          htmlFor="bottle-name"
+                          label="Bottle name"
+                          required
+                        >
+                          <TextInput
+                            {...register("name")}
+                            autoFocus
+                            id="bottle-name"
+                            invalid={Boolean(errors.name)}
+                            placeholder="12-year-old"
+                          />
+                        </Field>
+                        <Field
+                          error={errors.category?.message}
+                          htmlFor="bottle-category"
+                          label="Type"
+                          optional
+                        >
+                          <Select
+                            {...register("category", {
+                              setValueAs: (value) => value || null,
+                            })}
+                            id="bottle-category"
+                            invalid={Boolean(errors.category)}
+                          >
+                            <option value="">Not set</option>
+                            {categoryList.map((item) => (
+                              <option key={item.id} value={item.id}>
+                                {item.name}
+                              </option>
+                            ))}
+                          </Select>
+                        </Field>
+                      </>
+                    ) : null}
+                    {!isCreate || currentStep === 2 ? (
+                      <>
+                        <FormGrid>
+                          <Field
+                            error={errors.statedAge?.message}
+                            htmlFor="bottle-age"
+                            label="Age statement"
+                            optional
+                          >
+                            <UnitInput
+                              {...register("statedAge", {
+                                setValueAs: (value) => numberOrNull(value),
+                              })}
+                              disabled={noAgeStatement === true}
+                              id="bottle-age"
+                              invalid={Boolean(errors.statedAge)}
+                              min={0}
+                              placeholder="12"
+                              unit="years"
+                            />
+                          </Field>
+                          <Controller
+                            control={control}
+                            name="noAgeStatement"
+                            render={({ field }) => (
+                              <Switch
+                                checked={field.value === true}
+                                description="The label does not state an age."
+                                label="No age statement (NAS)"
+                                onCheckedChange={(checked) => {
+                                  field.onChange(checked ? true : null);
+                                  if (checked) {
+                                    setValue("statedAge", null, {
+                                      shouldDirty: true,
+                                      shouldValidate: true,
+                                    });
+                                  }
+                                }}
+                              />
+                            )}
+                          />
+                        </FormGrid>
+                        <Field
+                          error={errors.abv?.message}
+                          htmlFor="bottle-abv"
+                          label="Alcohol"
+                          optional
+                        >
+                          <UnitInput
+                            {...register("abv", {
+                              setValueAs: (value) => numberOrNull(value),
+                            })}
+                            id="bottle-abv"
+                            invalid={Boolean(errors.abv)}
+                            max={100}
+                            min={0}
+                            placeholder="40.5"
+                            step="0.1"
+                            unit="% ABV"
+                          />
+                        </Field>
+                      </>
+                    ) : null}
+                    {!isCreate || currentStep === 1 ? (
+                      <>
+                        <SearchPicker
+                          help="The distilleries that produced the spirit."
+                          label="Distilled by"
+                          loading={
+                            normalizedDistillerQuery !==
+                              debouncedDistillerQuery ||
+                            distillerResults.isFetching
+                          }
+                          onChange={(options) => {
+                            setDistillers(options);
+                            setValue(
+                              "distillers",
+                              options.map(distillerChoiceFromOption),
+                              {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                              },
+                            );
+                          }}
+                          onCreate={(query) => {
+                            const option: SearchPickerOption = {
+                              entity: { name: query, kind: "distillery" },
+                              id: `new:${query}`,
+                              label: query,
+                            };
+                            const next = [...distillers, option];
+                            setDistillers(next);
+                            setValue(
+                              "distillers",
+                              next.map(distillerChoiceFromOption),
+                              {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                              },
+                            );
+                          }}
+                          onQueryChange={setDistillerQuery}
+                          options={(distillerResults.data?.results ?? []).map(
+                            entitySearchOption,
+                          )}
+                          placeholder="Search distilleries"
+                          searchError={
+                            distillerResults.isError
+                              ? "Unable to search distilleries. Keep typing or try again."
+                              : undefined
+                          }
+                          value={distillers}
+                        />
+                        <EntityPicker
+                          help="The independent bottler, if this isn't an official brand or distillery release."
+                          kind="bottler"
+                          loading={
+                            normalizedBottlerQuery !== debouncedBottlerQuery ||
+                            bottlerResults.isFetching
+                          }
+                          onChange={(option) => {
+                            setBottler(option);
+                            setValue(
+                              "bottler",
+                              option
+                                ? entityChoiceFromOption(option, "bottler")
+                                : null,
+                              { shouldDirty: true, shouldValidate: true },
+                            );
+                          }}
+                          onCreate={(query) => {
+                            const option = makeDraftEntityOption(
+                              query,
+                              "bottler",
+                            );
+                            setBottler(option);
+                            setValue(
+                              "bottler",
+                              EntityChoiceSchema.parse({
+                                kind: "bottler",
+                                name: query,
+                              }),
+                              {
+                                shouldDirty: true,
+                                shouldValidate: true,
+                              },
+                            );
+                          }}
+                          onQueryChange={setBottlerQuery}
+                          options={(bottlerResults.data?.results ?? []).map(
+                            entityPickerOption,
+                          )}
+                          placeholder="Search bottlers"
+                          searchError={
+                            bottlerResults.isError
+                              ? "Unable to search bottlers. Keep typing or try again."
+                              : undefined
+                          }
+                          value={bottler}
+                        />
+                      </>
+                    ) : null}
+                  </>
+                }
+                secondary={
+                  <>
+                    {!isCreate || currentStep === 2 ? (
+                      <>
+                        <Field
+                          error={errors.edition?.message}
+                          htmlFor="bottle-edition"
+                          label="Edition or batch"
+                          optional
+                        >
+                          <TextInput
+                            {...register("edition", {
+                              setValueAs: (value) => value || null,
+                            })}
+                            id="bottle-edition"
+                            invalid={Boolean(errors.edition)}
+                            placeholder="Batch 24"
+                          />
+                        </Field>
+                      </>
+                    ) : null}
+                    {!isCreate || currentStep === 1 ? (
+                      <SeriesPicker
+                        disabled={!brand}
+                        error={errors.series?.message}
+                        loading={
+                          (needsRemoteSeriesSearch &&
+                            normalizedSeriesQuery !== debouncedSeriesQuery) ||
+                          (Boolean(numericBrandId) && seriesResults.isFetching)
+                        }
+                        onChange={(option) => {
+                          setSeries(option);
+                          setValue(
+                            "series",
+                            option ? seriesChoiceFromOption(option) : null,
+                            { shouldDirty: true, shouldValidate: true },
+                          );
+                        }}
+                        onCreate={(query) => {
+                          const option = {
+                            id: `new:${query}`,
+                            name: query,
+                            brand: brand?.name,
+                          };
+                          setSeries(option);
+                          setValue("series", seriesChoiceFromOption(option), {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          });
+                        }}
+                        onQueryChange={setSeriesQuery}
+                        options={(seriesResults.data?.results ?? []).map(
+                          (item) => ({
+                            id: String(item.id),
+                            name: item.name,
+                            brand: brand?.name,
+                          }),
+                        )}
+                        searchError={
+                          seriesResults.isError
+                            ? "Unable to search Series. Keep typing or try again."
+                            : undefined
+                        }
+                        value={series}
+                      />
+                    ) : null}
+                    {!isCreate || currentStep === 3 ? (
+                      <FormGrid compactOnMobile={isCreate}>
+                        <YearField
+                          error={errors.vintageYear?.message}
+                          id="bottle-distillation-year"
+                          label="Distillation year"
+                          register={register("vintageYear", {
+                            setValueAs: (value) => numberOrNull(value),
+                          })}
+                        />
+                        <YearField
+                          error={errors.bottlingYear?.message}
+                          id="bottle-bottling-year"
+                          label="Bottling year"
+                          register={register("bottlingYear", {
+                            setValueAs: (value) => numberOrNull(value),
+                          })}
+                        />
+                        <YearField
+                          error={errors.releaseYear?.message}
+                          id="bottle-release-year"
+                          label="Release year"
+                          register={register("releaseYear", {
+                            setValueAs: (value) => numberOrNull(value),
+                          })}
+                        />
+                        <Field
+                          error={errors.releaseMonth?.message}
+                          htmlFor="bottle-release-month"
+                          label="Release month"
+                          optional
+                        >
+                          <Controller
+                            control={control}
+                            name="releaseMonth"
+                            render={({ field }) => (
+                              <Select
+                                id="bottle-release-month"
+                                invalid={Boolean(errors.releaseMonth)}
+                                onChange={(event) =>
+                                  field.onChange(
+                                    event.currentTarget.value
+                                      ? Number(event.currentTarget.value)
+                                      : null,
+                                  )
+                                }
+                                value={field.value ?? ""}
+                              >
+                                <option value="">Not set</option>
+                                {releaseMonths.map((month, index) => (
+                                  <option key={month} value={index + 1}>
+                                    {month}
+                                  </option>
+                                ))}
+                              </Select>
+                            )}
+                          />
+                        </Field>
+                        <Field
+                          error={errors.releaseDay?.message}
+                          htmlFor="bottle-release-day"
+                          label="Release day"
+                          optional
+                        >
+                          <TextInput
+                            {...register("releaseDay", {
+                              setValueAs: (value) => numberOrNull(value),
+                            })}
+                            format="data"
+                            id="bottle-release-day"
+                            invalid={Boolean(errors.releaseDay)}
+                            max={31}
+                            min={1}
+                            type="number"
+                          />
+                        </Field>
+                      </FormGrid>
+                    ) : null}
+                    {!isCreate || currentStep === 4 ? (
+                      <>
+                        <Controller
+                          control={control}
+                          name="singleCask"
+                          render={({ field }) => (
+                            <Switch
+                              checked={Boolean(field.value)}
+                              description="The label states that this is a single-cask bottling."
+                              label="Single cask"
+                              onCheckedChange={field.onChange}
+                            />
+                          )}
+                        />
+                        <Controller
+                          control={control}
+                          name="caskStrength"
+                          render={({ field }) => (
+                            <Switch
+                              checked={Boolean(field.value)}
+                              description="The label states that this was bottled at cask strength."
+                              label="Cask strength"
+                              onCheckedChange={field.onChange}
+                            />
+                          )}
+                        />
+                        <FormGrid compactOnMobile={isCreate}>
+                          <BooleanSelectField
+                            choices={colorChoices}
+                            id="bottle-color"
+                            label="Color"
+                            onChange={(value) =>
+                              setValue("naturalColor", value, {
+                                shouldDirty: true,
+                              })
+                            }
+                            value={naturalColor}
+                          />
+                          <BooleanSelectField
+                            choices={filtrationChoices}
+                            id="bottle-filtration"
+                            label="Filtration"
+                            onChange={(value) =>
+                              setValue("nonChillFiltered", value, {
+                                shouldDirty: true,
+                              })
+                            }
+                            value={nonChillFiltered}
+                          />
+                        </FormGrid>
+                        <Field
+                          error={errors.maltPhenolPpm?.message}
+                          hint="The label may show a PPM number for the malted barley."
+                          htmlFor="bottle-ppm"
+                          label="Phenol level"
+                          optional
+                        >
+                          <UnitInput
+                            {...register("maltPhenolPpm", {
+                              setValueAs: (value) => numberOrNull(value),
+                            })}
+                            id="bottle-ppm"
+                            invalid={Boolean(errors.maltPhenolPpm)}
+                            min={0}
+                            placeholder="101.4"
+                            step="0.1"
+                            unit="PPM"
+                          />
+                        </Field>
+                      </>
+                    ) : null}
+                    {!isCreate || currentStep === 5 ? (
+                      <>
+                        <Field
+                          error={errors.maturation?.message}
+                          hint="Copy the producer's wording from the label."
+                          htmlFor="bottle-maturation"
+                          label="Cask details"
+                          optional
+                        >
+                          <Textarea
+                            {...register("maturation", {
+                              setValueAs: (value) => value?.trim() || null,
+                            })}
+                            id="bottle-maturation"
+                            invalid={Boolean(errors.maturation)}
+                            placeholder="2nd fill ex-bourbon hogshead"
+                            rows={3}
+                          />
+                        </Field>
+                        <FormGrid compactOnMobile={isCreate}>
+                          <Field
+                            error={errors.caskNumber?.message}
+                            htmlFor="bottle-cask-number"
+                            label="Cask number"
+                            optional
+                          >
+                            <TextInput
+                              {...register("caskNumber", {
+                                setValueAs: (value) => value?.trim() || null,
+                              })}
+                              id="bottle-cask-number"
+                              invalid={Boolean(errors.caskNumber)}
+                              placeholder="35.401"
+                            />
+                          </Field>
+                          <Field
+                            error={errors.outturn?.message}
+                            htmlFor="bottle-outturn"
+                            label="Number of bottles"
+                            optional
+                          >
+                            <UnitInput
+                              {...register("outturn", {
+                                setValueAs: (value) => numberOrNull(value),
+                              })}
+                              id="bottle-outturn"
+                              invalid={Boolean(errors.outturn)}
+                              min={1}
+                              placeholder="240"
+                              unit="bottles"
+                            />
+                          </Field>
+                        </FormGrid>
+                      </>
+                    ) : null}
+                    {!isCreate || currentStep === 6 ? (
+                      <>
+                        <Field
+                          error={errors.flavorProfile?.message}
+                          htmlFor="bottle-flavor-profile"
+                          label="Flavor profile"
+                          optional
+                        >
+                          <Select
+                            {...register("flavorProfile", {
+                              setValueAs: (value) => value || null,
+                            })}
+                            id="bottle-flavor-profile"
+                            invalid={Boolean(errors.flavorProfile)}
+                          >
+                            <option value="">Not set</option>
+                            {FLAVOR_PROFILES.map((profile) => (
+                              <option key={profile} value={profile}>
+                                {formatFlavorProfile(profile)}
+                              </option>
+                            ))}
+                          </Select>
+                        </Field>
+                        {user?.mod || user?.admin ? (
+                          <FormActions>
+                            <Button
+                              loading={generateData.isPending}
+                              onClick={() => void fillDetails()}
+                              size="sm"
+                              variant="tonal"
+                            >
+                              <WandSparkles aria-hidden="true" size={15} />
+                              Fill description
+                            </Button>
+                          </FormActions>
+                        ) : null}
+                        <FieldGroup label="Bottle image" optional>
+                          <PictureInput
+                            disabled={isSubmitting}
+                            id="bottle-image"
+                            label="Add a bottle image"
+                            name="image"
+                            onFilesSelected={(files) => {
+                              const file = files.item(0);
+                              if (!file) return;
+                              setImage(file);
+                              setImagePreview(URL.createObjectURL(file));
+                              setValue("imageSourceUrl", null, {
+                                shouldDirty: true,
+                              });
+                              setValue("imageLicense", null, {
+                                shouldDirty: true,
+                              });
+                            }}
+                            onRemove={
+                              imagePreview
+                                ? () => {
+                                    setImage(null);
+                                    setImagePreview(undefined);
+                                    setValue("imageSourceUrl", null, {
+                                      shouldDirty: true,
+                                    });
+                                    setValue("imageLicense", null, {
+                                      shouldDirty: true,
+                                    });
+                                  }
+                                : undefined
+                            }
+                            preview={
+                              imagePreview
+                                ? {
+                                    alt: "Current bottle image",
+                                    src: imagePreview,
+                                  }
+                                : undefined
+                            }
+                          />
+                          {user?.mod || user?.admin ? (
+                            <>
+                              <Field
+                                error={errors.imageSourceUrl?.message}
+                                htmlFor="bottle-image-source"
+                                label="Source URL"
+                                optional
+                              >
+                                <TextInput
+                                  {...register("imageSourceUrl", {
+                                    setValueAs: (value) => value || null,
+                                  })}
+                                  id="bottle-image-source"
+                                  invalid={Boolean(errors.imageSourceUrl)}
+                                  placeholder="https://example.com/original-image"
+                                  type="url"
+                                />
+                              </Field>
+                              <Field
+                                error={errors.imageLicense?.message}
+                                htmlFor="bottle-image-license"
+                                label="License"
+                                optional
+                              >
+                                <TextInput
+                                  {...register("imageLicense", {
+                                    setValueAs: (value) => value || null,
+                                  })}
+                                  id="bottle-image-license"
+                                  invalid={Boolean(errors.imageLicense)}
+                                  placeholder="CC BY-SA 4.0"
+                                />
+                              </Field>
+                            </>
+                          ) : null}
+                        </FieldGroup>
+                        <Field
+                          error={errors.description?.message}
+                          htmlFor="bottle-description"
+                          label="Description"
+                          optional
+                        >
+                          <Textarea
+                            {...register("description", {
+                              onChange: () =>
+                                setValue("descriptionSrc", "user", {
+                                  shouldDirty: true,
+                                }),
+                              setValueAs: (value) => value || null,
+                            })}
+                            id="bottle-description"
+                            invalid={Boolean(errors.description)}
+                            rows={isCreate ? 4 : 8}
+                          />
+                        </Field>
+                      </>
+                    ) : null}
+                  </>
+                }
               />
-            </Field>
-          </FormDetails>
+            </>
+          )}
         </FormStack>
       </form>
     </WorkflowScreen>
+  );
+}
+
+function BottleFieldsLayout({
+  create,
+  currentStep,
+  defaultOpen,
+  primary,
+  secondary,
+}: {
+  create: boolean;
+  currentStep: number;
+  defaultOpen: boolean;
+  primary: ReactNode;
+  secondary: ReactNode;
+}) {
+  if (create) {
+    const title = createSteps[currentStep] ?? createSteps[0];
+    return (
+      <FormStep key={title} title={title}>
+        {primary}
+        {secondary}
+      </FormStep>
+    );
+  }
+
+  return (
+    <>
+      <FormSection title="Bottle details">{primary}</FormSection>
+      <FormDetails
+        defaultOpen={defaultOpen}
+        description="Edition, year, cask, production, and catalog information."
+        title="More details"
+      >
+        {secondary}
+      </FormDetails>
+    </>
   );
 }
 

--- a/apps/web/src/components/collectionBottleStatus.stylex.tsx
+++ b/apps/web/src/components/collectionBottleStatus.stylex.tsx
@@ -85,7 +85,7 @@ const styles = stylex.create({
     alignItems: "center",
     justifyContent: "center",
     borderRadius: controlMetrics.radius,
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     color: colors.inkMuted,
     fontWeight: 600,
     cursor: "pointer",

--- a/apps/web/src/components/entityPicker.stories.tsx
+++ b/apps/web/src/components/entityPicker.stories.tsx
@@ -58,6 +58,18 @@ export const WithCreateHandoff: Story = {
   ),
 };
 
+export const LoadingAndFailure: Story = {
+  render: (args) => (
+    <StoryStack>
+      <ControlledEntityPicker {...args} loading />
+      <ControlledEntityPicker
+        {...args}
+        searchError="Unable to search distilleries. Keep typing or try again."
+      />
+    </StoryStack>
+  ),
+};
+
 function ControlledEntityPicker(
   props: React.ComponentProps<typeof EntityPicker>,
 ) {

--- a/apps/web/src/components/entityPicker.stylex.tsx
+++ b/apps/web/src/components/entityPicker.stylex.tsx
@@ -24,6 +24,7 @@ export type EntityPickerProps = {
   options: readonly EntityPickerOption[];
   placeholder?: string;
   required?: boolean;
+  searchError?: ReactNode;
   value: EntityPickerOption | null;
 };
 
@@ -58,6 +59,7 @@ export function EntityPicker({
   options,
   placeholder,
   required = false,
+  searchError,
   value,
 }: EntityPickerProps) {
   const copy = kind
@@ -109,6 +111,7 @@ export function EntityPicker({
       options={options.map(toPickerOption)}
       placeholder={placeholder ?? `Search ${copy.plural}`}
       required={required}
+      searchError={searchError}
       value={value ? toPickerOption(value) : null}
     />
   );

--- a/apps/web/src/components/feedback.stylex.tsx
+++ b/apps/web/src/components/feedback.stylex.tsx
@@ -1,3 +1,4 @@
+import type { CompiledStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { HTMLAttributes, ReactNode } from "react";
 import { SectionHeading } from "./sectionHeading.stylex";
@@ -19,11 +20,16 @@ export type FloatingPanelProps = Omit<
   "className" | "style"
 > & {
   children: ReactNode;
+  style?: CompiledStyles;
 };
 
-export function FloatingPanel({ children, ...props }: FloatingPanelProps) {
+export function FloatingPanel({
+  children,
+  style,
+  ...props
+}: FloatingPanelProps) {
   return (
-    <div {...props} {...stylex.props(styles.overlay)}>
+    <div {...props} {...stylex.props(styles.overlay, style)}>
       {children}
     </div>
   );

--- a/apps/web/src/components/field.stylex.tsx
+++ b/apps/web/src/components/field.stylex.tsx
@@ -194,7 +194,7 @@ const styles = stylex.create({
     display: "flex",
     minWidth: 0,
     flexDirection: "column",
-    rowGap: "7px",
+    rowGap: space.x2,
   },
   fieldset: {
     margin: 0,
@@ -215,7 +215,7 @@ const styles = stylex.create({
     columnGap: space.x2,
   },
   label: {
-    color: colors.ink,
+    color: colors.accentDeep,
   },
   required: {
     color: colors.accentDeep,
@@ -228,16 +228,10 @@ const styles = stylex.create({
   control: {
     boxSizing: "border-box",
     width: "100%",
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: {
-      default: colors.sectionRule,
-      ":hover": colors.inkMuted,
-      ":focus": colors.accent,
-    },
+    borderWidth: 0,
     borderRadius: controlMetrics.radius,
     outline: "none",
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     color: colors.ink,
     opacity: {
       default: 1,
@@ -245,7 +239,7 @@ const styles = stylex.create({
     },
     boxShadow: {
       default: "none",
-      ":focus": `inset 0 0 0 1px ${colors.accent}`,
+      ":focus": `inset 0 0 0 2px ${colors.accent}`,
     },
     "::placeholder": {
       color: colors.inkMuted,
@@ -278,7 +272,6 @@ const styles = stylex.create({
     fontVariantNumeric: "tabular-nums",
   },
   invalid: {
-    borderColor: colors.critical,
     boxShadow: {
       default: effects.errorRing,
       ":focus-visible": effects.errorRing,

--- a/apps/web/src/components/formControls.stylex.tsx
+++ b/apps/web/src/components/formControls.stylex.tsx
@@ -261,16 +261,10 @@ const styles = stylex.create({
     appearance: "none",
     paddingRight: "38px",
     paddingLeft: "13px",
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: {
-      default: colors.fieldRule,
-      ":hover": colors.inkMuted,
-      ":focus": colors.accent,
-    },
+    borderWidth: 0,
     borderRadius: controlMetrics.radius,
     outline: "none",
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     color: colors.ink,
     cursor: {
       default: "pointer",
@@ -278,7 +272,7 @@ const styles = stylex.create({
     },
     boxShadow: {
       default: "none",
-      ":focus": `inset 0 0 0 1px ${colors.accent}`,
+      ":focus": `inset 0 0 0 2px ${colors.accent}`,
     },
   },
   selectIcon: {
@@ -289,7 +283,6 @@ const styles = stylex.create({
     pointerEvents: "none",
   },
   invalid: {
-    borderColor: colors.critical,
     boxShadow: {
       default: effects.errorRing,
       ":focus-visible": effects.errorRing,
@@ -327,7 +320,7 @@ const styles = stylex.create({
     width: "44px",
     height: "24px",
     borderRadius: controlMetrics.radius,
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     boxShadow: `inset 0 0 0 2px ${colors.fieldRule}`,
     transitionProperty: "background-color",
     transitionDuration: "120ms",

--- a/apps/web/src/components/formLayout.stylex.tsx
+++ b/apps/web/src/components/formLayout.stylex.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import * as stylex from "@stylexjs/stylex";
 import { ChevronDown } from "lucide-react";
-import type { HTMLAttributes, ReactNode } from "react";
+import { useEffect, useRef, type HTMLAttributes, type ReactNode } from "react";
 import { SectionHeading } from "./sectionHeading.stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
@@ -10,8 +12,52 @@ export function FormStack({ children }: { children: ReactNode }) {
   return <div {...stylex.props(styles.stack)}>{children}</div>;
 }
 
-export function FormGrid({ children }: { children: ReactNode }) {
-  return <div {...stylex.props(styles.grid)}>{children}</div>;
+export function FormGrid({
+  children,
+  compactOnMobile = false,
+}: {
+  children: ReactNode;
+  compactOnMobile?: boolean;
+}) {
+  return (
+    <div
+      {...stylex.props(
+        styles.grid,
+        compactOnMobile && styles.compactMobileGrid,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Keeps supporting context in wider layouts without crowding a short mobile step. */
+export function FormDesktopOnly({ children }: { children: ReactNode }) {
+  return <div {...stylex.props(styles.desktopOnly)}>{children}</div>;
+}
+
+/** Groups a short form step and announces it when Back or Continue changes the fields. */
+export function FormStep({
+  children,
+  title,
+}: {
+  children: ReactNode;
+  title: string;
+}) {
+  const heading = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    heading.current?.focus({ preventScroll: true });
+  }, []);
+
+  return (
+    <section aria-label={title} {...stylex.props(styles.formStep)}>
+      <h2 ref={heading} tabIndex={-1} {...stylex.props(styles.hiddenHeading)}>
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
 }
 
 export type FormSectionProps = Omit<
@@ -57,15 +103,33 @@ export function FormActions({ children }: { children: ReactNode }) {
 }
 
 export type FormStepsProps = {
+  compactOnMobile?: boolean;
   currentStep: number;
   steps: readonly string[];
 };
 
 /** Shows the full sequence for a form that moves through a few clear steps. */
-export function FormSteps({ currentStep, steps }: FormStepsProps) {
+export function FormSteps({
+  compactOnMobile = false,
+  currentStep,
+  steps,
+}: FormStepsProps) {
   return (
     <nav aria-label="Form progress" {...stylex.props(styles.steps)}>
-      <ol {...stylex.props(styles.stepList)}>
+      {compactOnMobile ? (
+        <p {...stylex.props(foundationStyles.interactive, styles.compactStep)}>
+          <span {...stylex.props(styles.compactStepCount)}>
+            Step {currentStep + 1} of {steps.length}
+          </span>
+          <span>{steps[currentStep]}</span>
+        </p>
+      ) : null}
+      <ol
+        {...stylex.props(
+          styles.stepList,
+          compactOnMobile && styles.fullStepsWithCompactMobile,
+        )}
+      >
         {steps.map((step, index) => (
           <li
             aria-current={index === currentStep ? "step" : undefined}
@@ -191,6 +255,35 @@ const styles = stylex.create({
     },
     gap: space.x6,
   },
+  compactMobileGrid: {
+    "@media (max-width: 559px)": {
+      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+      columnGap: space.x3,
+      rowGap: space.x4,
+    },
+  },
+  desktopOnly: {
+    minWidth: 0,
+    "@media (max-width: 559px)": { display: "none" },
+  },
+  formStep: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: {
+      default: space.x6,
+      "@media (max-width: 559px)": space.x4,
+    },
+  },
+  hiddenHeading: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    margin: 0,
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+  },
   section: {
     boxSizing: "border-box",
     display: "flex",
@@ -237,12 +330,27 @@ const styles = stylex.create({
     flexWrap: "wrap",
   },
   steps: { minWidth: 0 },
+  compactStep: {
+    display: {
+      default: "none",
+      "@media (max-width: 559px)": "flex",
+    },
+    minHeight: "44px",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: space.x3,
+    margin: 0,
+  },
+  compactStepCount: { color: colors.inkMuted },
   stepList: {
     display: "flex",
     minWidth: 0,
     margin: 0,
     padding: 0,
     listStyle: "none",
+  },
+  fullStepsWithCompactMobile: {
+    "@media (max-width: 559px)": { display: "none" },
   },
   step: {
     position: "relative",

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -16,6 +16,11 @@ export { Avatar } from "./avatar.stylex";
 export type { AvatarProps, AvatarSize } from "./avatar.stylex";
 export { BadgeImage } from "./badgeImage.stylex";
 export type { BadgeImageProps } from "./badgeImage.stylex";
+export {
+  BottleCreateCandidateSummary,
+  BottleCreateCandidates,
+} from "./bottleCreateCandidates.stylex";
+export type { BottleCreateCandidate } from "./bottleCreateCandidates.stylex";
 export { BottleIdentityRow } from "./bottleIdentityRow.stylex";
 export type { BottleIdentityRowProps } from "./bottleIdentityRow.stylex";
 export { BottleList } from "./bottleList.stylex";
@@ -134,11 +139,13 @@ export type {
 } from "./formControls.stylex";
 export {
   FormActions,
+  FormDesktopOnly,
   FormDetails,
   FormGrid,
   FormNotice,
   FormSection,
   FormStack,
+  FormStep,
   FormSteps,
 } from "./formLayout.stylex";
 export type {
@@ -254,6 +261,11 @@ export { SelectedBottleSummary } from "./selectedBottleSummary.stylex";
 export type { SelectedBottleSummaryProps } from "./selectedBottleSummary.stylex";
 export { SeriesIdentityRow } from "./seriesIdentityRow.stylex";
 export type { SeriesIdentityRowProps } from "./seriesIdentityRow.stylex";
+export { SeriesPicker } from "./seriesPicker.stylex";
+export type {
+  SeriesPickerOption,
+  SeriesPickerProps,
+} from "./seriesPicker.stylex";
 export { SiteFooter } from "./siteFooter.stylex";
 export type { FooterLink, SiteFooterProps } from "./siteFooter.stylex";
 export { Slideout } from "./slideout.stylex";

--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -310,7 +310,7 @@ const styles = stylex.create({
     borderRadius: controlMetrics.radius,
     outline: "none",
     backgroundImage: "none",
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     color: colors.ink,
     fontWeight: 600,
     cursor: "pointer",

--- a/apps/web/src/components/notePicker.stylex.tsx
+++ b/apps/web/src/components/notePicker.stylex.tsx
@@ -157,7 +157,7 @@ export function NotePickerField({
       </div>
 
       {suggestionsOpen ? (
-        <FloatingPanel {...stylex.props(styles.suggestionOverlay)}>
+        <FloatingPanel style={styles.suggestionOverlay}>
           <div id={listboxId} role="listbox">
             {matches.length ? (
               matches.map((note, index) => (
@@ -420,19 +420,13 @@ const styles = stylex.create({
     paddingRight: space.x1,
     paddingBottom: space.x1,
     paddingLeft: space.x2,
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: {
-      default: colors.sectionRule,
-      ":hover": colors.inkMuted,
-      ":focus-within": colors.accent,
-    },
+    borderWidth: 0,
     borderRadius: controlMetrics.radius,
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     flexWrap: "wrap",
     boxShadow: {
       default: "none",
-      ":focus-within": `inset 0 0 0 1px ${colors.accent}`,
+      ":focus-within": `inset 0 0 0 2px ${colors.accent}`,
     },
   },
   fieldInput: {
@@ -593,20 +587,14 @@ const styles = stylex.create({
     height: controlMetrics.controlHeight,
     paddingRight: space.x3,
     paddingLeft: space.x3,
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: {
-      default: colors.sectionRule,
-      ":hover": colors.inkMuted,
-      ":focus": colors.accent,
-    },
+    borderWidth: 0,
     borderRadius: controlMetrics.radius,
     outline: "none",
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     color: colors.ink,
     boxShadow: {
       default: "none",
-      ":focus": `inset 0 0 0 1px ${colors.accent}`,
+      ":focus": `inset 0 0 0 2px ${colors.accent}`,
     },
     "::placeholder": {
       color: colors.inkMuted,

--- a/apps/web/src/components/searchPicker.stylex.tsx
+++ b/apps/web/src/components/searchPicker.stylex.tsx
@@ -26,6 +26,10 @@ import { IconButton } from "./button.stylex";
 import { Chip } from "./chip.stylex";
 import { FloatingPanel } from "./feedback.stylex";
 import { ValidationMessage } from "./field.stylex";
+import {
+  SeriesIdentityRow,
+  type SeriesIdentityRowProps,
+} from "./seriesIdentityRow.stylex";
 import { useListboxNavigation } from "./useListboxNavigation";
 
 export type SearchPickerOption = {
@@ -35,6 +39,7 @@ export type SearchPickerOption = {
     BottleIdentityRowProps,
     "name" | "provenance" | "metadata" | "imageUrl"
   >;
+  series?: Pick<SeriesIdentityRowProps, "brand" | "name">;
   detail?: string;
   id: number | string;
   label: string;
@@ -55,6 +60,7 @@ export type SearchPickerProps = {
   options: readonly SearchPickerOption[];
   placeholder: string;
   required?: boolean;
+  searchError?: ReactNode;
   value: readonly SearchPickerOption[];
 };
 
@@ -94,6 +100,7 @@ export function SearchPicker({
   options,
   placeholder,
   required = false,
+  searchError,
   value,
 }: SearchPickerProps) {
   return (
@@ -112,6 +119,7 @@ export function SearchPicker({
       options={options}
       placeholder={placeholder}
       required={required}
+      searchError={searchError}
       selectionMode="multiple"
       value={value}
     />
@@ -133,6 +141,7 @@ function PickerControl({
   options,
   placeholder,
   required = false,
+  searchError,
   selectionMode,
   value,
 }: SearchPickerProps & { selectionMode: "multiple" | "single" }) {
@@ -219,6 +228,8 @@ function PickerControl({
                 layout="cell"
                 variant="search"
               />
+            ) : value[0].series ? (
+              <SeriesIdentityRow {...value[0].series} layout="cell" />
             ) : (
               <>
                 <span
@@ -300,6 +311,25 @@ function PickerControl({
                   }
                 />
               </div>
+            ) : option.series ? (
+              <div key={option.id} {...stylex.props(styles.selectedIdentity)}>
+                <SeriesIdentityRow
+                  {...option.series}
+                  layout="cell"
+                  end={
+                    <IconButton
+                      disabled={disabled}
+                      icon={<X aria-hidden="true" size={16} />}
+                      label={`Remove ${option.label}`}
+                      onClick={() =>
+                        onChange(value.filter((item) => item.id !== option.id))
+                      }
+                      size="sm"
+                      variant="text"
+                    />
+                  }
+                />
+              </div>
             ) : (
               <Chip
                 aria-label={`Remove ${option.label}`}
@@ -351,7 +381,7 @@ function PickerControl({
             )}
           />
           {isOpen && !disabled ? (
-            <FloatingPanel {...stylex.props(styles.overlay)}>
+            <FloatingPanel style={styles.overlay}>
               <div
                 aria-label={`${label} results`}
                 id={listboxId}
@@ -365,6 +395,13 @@ function PickerControl({
                   >
                     Searching…
                   </p>
+                ) : searchError ? (
+                  <p
+                    role="alert"
+                    {...stylex.props(foundationStyles.body, styles.empty)}
+                  >
+                    {searchError}
+                  </p>
                 ) : availableOptions.length ? (
                   availableOptions.map((option, index) => (
                     <button
@@ -377,8 +414,9 @@ function PickerControl({
                       type="button"
                       {...stylex.props(
                         styles.result,
-                        Boolean(option.bottle || option.entity) &&
-                          styles.identityResult,
+                        Boolean(
+                          option.bottle || option.entity || option.series,
+                        ) && styles.identityResult,
                         index === activeIndex && styles.activeResult,
                       )}
                     >
@@ -394,6 +432,12 @@ function PickerControl({
                           layout="cell"
                           query={query}
                           variant="search"
+                        />
+                      ) : option.series ? (
+                        <SeriesIdentityRow
+                          {...option.series}
+                          layout="cell"
+                          query={query}
                         />
                       ) : (
                         <>
@@ -488,7 +532,7 @@ const styles = stylex.create({
     justifyContent: "space-between",
     columnGap: space.x4,
   },
-  label: { color: colors.inkMuted },
+  label: { color: colors.accentDeep },
   required: { color: colors.accentDeep },
   selected: { display: "flex", gap: space.x2, flexWrap: "wrap" },
   selectedIdentity: { width: "100%", minWidth: 0 },
@@ -503,6 +547,10 @@ const styles = stylex.create({
     paddingLeft: "14px",
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.inset,
+    boxShadow: {
+      default: "none",
+      ":focus-within": `inset 0 0 0 2px ${colors.accent}`,
+    },
   },
   selectedCopy: {
     display: "flex",
@@ -563,7 +611,7 @@ const styles = stylex.create({
     color: colors.ink,
     boxShadow: {
       default: "none",
-      ":focus-visible": effects.focusRing,
+      ":focus": `inset 0 0 0 2px ${colors.accent}`,
     },
     "::placeholder": { color: colors.inkMuted, opacity: 1 },
     "::-webkit-search-cancel-button": { appearance: "none" },

--- a/apps/web/src/components/searchPicker.test.tsx
+++ b/apps/web/src/components/searchPicker.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchSelect, type SearchPickerOption } from "./searchPicker.stylex";
+
+const options: SearchPickerOption[] = [
+  { id: 1, label: "Lagavulin" },
+  { id: 2, label: "Laphroaig" },
+];
+
+function PickerHarness({
+  loading = false,
+  searchError,
+}: {
+  loading?: boolean;
+  searchError?: string;
+}) {
+  const [value, setValue] = useState<SearchPickerOption | null>(null);
+  return (
+    <SearchSelect
+      label="Brand"
+      loading={loading}
+      onChange={setValue}
+      options={options}
+      placeholder="Search brands"
+      searchError={searchError}
+      value={value}
+    />
+  );
+}
+
+describe("SearchSelect", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("selects and clears a value with keyboard-accessible controls", () => {
+    act(() => root.render(<PickerHarness />));
+    const input = container.querySelector<HTMLInputElement>("input")!;
+
+    act(() => {
+      input.focus();
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "ArrowDown" }),
+      );
+    });
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+      );
+    });
+
+    expect(container.textContent).toContain("Lagavulin");
+    const clear = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Clear Lagavulin"]',
+    );
+    expect(clear?.tabIndex).toBe(0);
+    act(() => clear?.click());
+    expect(container.querySelector<HTMLInputElement>("input")).not.toBeNull();
+  });
+
+  it("shows the same loading and remote failure states without changing value", () => {
+    act(() => root.render(<PickerHarness loading />));
+    act(() => container.querySelector<HTMLInputElement>("input")?.focus());
+    expect(container.querySelector('[role="status"]')?.textContent).toContain(
+      "Searching",
+    );
+
+    act(() =>
+      root.render(
+        <PickerHarness searchError="Unable to search brands. Try again." />,
+      ),
+    );
+    act(() => container.querySelector<HTMLInputElement>("input")?.focus());
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      "Unable to search brands",
+    );
+  });
+
+  it("ignores results that do not match the current input text", () => {
+    const onChange = vi.fn();
+    act(() =>
+      root.render(
+        <SearchSelect
+          label="Brand"
+          onChange={onChange}
+          options={options}
+          placeholder="Search brands"
+          value={null}
+        />,
+      ),
+    );
+    const input = container.querySelector<HTMLInputElement>("input")!;
+    act(() => {
+      const valueDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      );
+      valueDescriptor?.set?.call(input, "Yamazaki");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(container.querySelectorAll('[role="option"]')).toHaveLength(0);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/seriesPicker.stories.tsx
+++ b/apps/web/src/components/seriesPicker.stories.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+import { SeriesPicker, type SeriesPickerOption } from "./seriesPicker.stylex";
+import { StoryCanvas, StoryStack } from "./storyFixtures.stylex";
+
+const options: SeriesPickerOption[] = [
+  { id: "1", name: "Distillers Edition", brand: "Lagavulin" },
+  { id: "2", name: "Jazz Festival", brand: "Lagavulin" },
+];
+
+const meta = {
+  title: "Components/Catalog/Series Picker",
+  component: SeriesPicker,
+  args: {
+    onChange: () => undefined,
+    options,
+    value: null,
+  },
+  argTypes: {
+    onChange: { control: false },
+    onCreate: { control: false },
+    options: { control: false },
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="compact">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta<typeof SeriesPicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+  render: (args) => (
+    <StoryStack>
+      <ControlledSeriesPicker {...args} onCreate={() => undefined} />
+      <SeriesPicker {...args} loading />
+      <SeriesPicker
+        {...args}
+        searchError="Unable to search Series. Keep typing or try again."
+      />
+    </StoryStack>
+  ),
+};
+
+function ControlledSeriesPicker(
+  props: React.ComponentProps<typeof SeriesPicker>,
+) {
+  const [value, setValue] = useState<SeriesPickerOption | null>(props.value);
+  return <SeriesPicker {...props} onChange={setValue} value={value} />;
+}

--- a/apps/web/src/components/seriesPicker.stylex.tsx
+++ b/apps/web/src/components/seriesPicker.stylex.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useMemo } from "react";
+import { SearchSelect, type SearchPickerOption } from "./searchPicker.stylex";
+
+export type SeriesPickerOption = {
+  id: string;
+  name: string;
+  brand?: string;
+};
+
+export type SeriesPickerProps = {
+  disabled?: boolean;
+  error?: ReactNode;
+  loading?: boolean;
+  onChange: (value: SeriesPickerOption | null) => void;
+  onCreate?: (query: string) => void;
+  onQueryChange?: (query: string) => void;
+  options: readonly SeriesPickerOption[];
+  searchError?: ReactNode;
+  value: SeriesPickerOption | null;
+};
+
+function toPickerOption(option: SeriesPickerOption): SearchPickerOption {
+  return {
+    id: option.id,
+    label: option.name,
+    series: { brand: option.brand, name: option.name },
+  };
+}
+
+/** Selects one Series while the caller owns brand scope and remote search. */
+export function SeriesPicker({
+  disabled = false,
+  error,
+  loading = false,
+  onChange,
+  onCreate,
+  onQueryChange,
+  options,
+  searchError,
+  value,
+}: SeriesPickerProps) {
+  const seriesById = useMemo(
+    () =>
+      new Map(
+        [...options, ...(value ? [value] : [])].map((option) => [
+          option.id,
+          option,
+        ]),
+      ),
+    [options, value],
+  );
+
+  return (
+    <SearchSelect
+      createHint="Last resort"
+      disabled={disabled}
+      emptyText="No matching Series."
+      error={error}
+      getCreateLabel={(query) => `Add “${query}” as a new Series`}
+      help="A named range from this Brand."
+      label="Series"
+      loading={loading}
+      onChange={(nextValue) =>
+        onChange(
+          nextValue ? (seriesById.get(String(nextValue.id)) ?? null) : null,
+        )
+      }
+      onCreate={onCreate}
+      onQueryChange={onQueryChange}
+      options={options.map(toPickerOption)}
+      placeholder={disabled ? "Choose a Brand first" : "Search Series"}
+      searchError={searchError}
+      value={value ? toPickerOption(value) : null}
+    />
+  );
+}

--- a/apps/web/src/components/tastingFormSteps.stylex.tsx
+++ b/apps/web/src/components/tastingFormSteps.stylex.tsx
@@ -2,17 +2,12 @@
 
 import * as stylex from "@stylexjs/stylex";
 import { Camera, Users } from "lucide-react";
-import {
-  useEffect,
-  useRef,
-  useState,
-  type ComponentProps,
-  type ReactNode,
-} from "react";
+import { useState, type ComponentProps } from "react";
 
 import { space } from "../styles/tokens.stylex";
 import { Button } from "./button.stylex";
 import { Field, FieldGroup, Textarea, ValidationMessage } from "./field.stylex";
+import { FormStep } from "./formLayout.stylex";
 import { MemberPicker, type MemberPickerProps } from "./memberPicker.stylex";
 import { NotePickerField } from "./notePicker.stylex";
 import { Slideout } from "./slideout.stylex";
@@ -29,30 +24,6 @@ import {
   type ServingStyleInputProps,
 } from "./tastingInputs.stylex";
 
-/** Groups a short form step and announces it when Back or Continue changes the fields. */
-function TastingFormStep({
-  children,
-  title,
-}: {
-  children: ReactNode;
-  title: string;
-}) {
-  const heading = useRef<HTMLHeadingElement>(null);
-
-  useEffect(() => {
-    heading.current?.focus({ preventScroll: true });
-  }, []);
-
-  return (
-    <section aria-label={title} {...stylex.props(styles.step)}>
-      <h2 ref={heading} tabIndex={-1} {...stylex.props(styles.hiddenHeading)}>
-        {title}
-      </h2>
-      {children}
-    </section>
-  );
-}
-
 /** Captures a member's words before asking for flavors, serving details, or a rating. */
 export function TastingNotesStep({
   notes,
@@ -68,7 +39,7 @@ export function TastingNotesStep({
   label?: string;
 }) {
   return (
-    <TastingFormStep title="Notes">
+    <FormStep title="Notes">
       <Field
         error={notesError}
         errorId={`${notes.id}-error`}
@@ -87,7 +58,7 @@ export function TastingNotesStep({
       <Field error={flavorsError} htmlFor={flavors.id} label="Flavors" optional>
         <NotePickerField {...flavors} />
       </Field>
-    </TastingFormStep>
+    </FormStep>
   );
 }
 
@@ -125,7 +96,7 @@ export function TastingPourStep({
   }
 
   return (
-    <TastingFormStep title="The pour">
+    <FormStep title="The pour">
       <FieldGroup error={servingError} label="Serving style" optional>
         <ServingStyleInput {...serving} />
       </FieldGroup>
@@ -173,7 +144,7 @@ export function TastingPourStep({
           <MemberPicker {...friends} />
         )}
       </Slideout>
-    </TastingFormStep>
+    </FormStep>
   );
 }
 
@@ -183,11 +154,11 @@ export function TastingRatingStep({
   ...props
 }: RatingBandInputProps & { error?: string }) {
   return (
-    <TastingFormStep title="Rating">
+    <FormStep title="Rating">
       <FieldGroup error={error} label="How was it?" required={props.required}>
         <RatingBandInput {...props} />
       </FieldGroup>
-    </TastingFormStep>
+    </FormStep>
   );
 }
 
@@ -197,29 +168,14 @@ export function MemberReviewScoreStep({
   ...props
 }: ReviewScoreInputProps & { error?: string }) {
   return (
-    <TastingFormStep title="Score">
+    <FormStep title="Score">
       <ReviewScoreInput {...props} invalid={Boolean(error)} />
       {error ? <ValidationMessage>{error}</ValidationMessage> : null}
-    </TastingFormStep>
+    </FormStep>
   );
 }
 
 const styles = stylex.create({
-  step: {
-    display: "flex",
-    minWidth: 0,
-    flexDirection: "column",
-    gap: space.x3,
-  },
-  hiddenHeading: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    margin: 0,
-    overflow: "hidden",
-    clip: "rect(0, 0, 0, 0)",
-    whiteSpace: "nowrap",
-  },
   attachments: {
     display: "grid",
     gridTemplateColumns: "repeat(2, minmax(0, 1fr))",

--- a/apps/web/src/components/tastingInputs.stylex.tsx
+++ b/apps/web/src/components/tastingInputs.stylex.tsx
@@ -728,7 +728,7 @@ const styles = stylex.create({
     rowGap: space.x1,
     overflow: "hidden",
     borderRadius: controlMetrics.radiusSmall,
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     cursor: "pointer",
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.fieldRule}`,
@@ -803,7 +803,7 @@ const styles = stylex.create({
     justifyContent: "center",
     columnGap: space.x2,
     borderRadius: controlMetrics.radius,
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     color: colors.inkMuted,
     fontWeight: 600,
     cursor: "pointer",

--- a/apps/web/src/components/unitInput.stylex.tsx
+++ b/apps/web/src/components/unitInput.stylex.tsx
@@ -58,22 +58,15 @@ const styles = stylex.create({
     width: "100%",
     height: controlMetrics.controlHeightLarge,
     alignItems: "center",
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: {
-      default: colors.fieldRule,
-      ":hover": colors.inkMuted,
-      ":focus-within": colors.accent,
-    },
+    borderWidth: 0,
     borderRadius: controlMetrics.radius,
-    backgroundColor: colors.fieldBackground,
+    backgroundColor: colors.inset,
     boxShadow: {
       default: "none",
-      ":focus-within": `inset 0 0 0 1px ${colors.accent}`,
+      ":focus-within": `inset 0 0 0 2px ${colors.accent}`,
     },
   },
   invalid: {
-    borderColor: colors.critical,
     boxShadow: {
       default: effects.errorRing,
       ":focus-within": effects.errorRing,

--- a/apps/web/src/styles/foundations.stylex.ts
+++ b/apps/web/src/styles/foundations.stylex.ts
@@ -1,13 +1,17 @@
 import * as stylex from "@stylexjs/stylex";
 import { colors, fonts } from "./tokens.stylex";
 
+const DARK = "@media (prefers-color-scheme: dark)";
+
 /** Web typography roles. Components compose these with layout, color, and emphasis. */
 export const foundationStyles = stylex.create({
+  documentRoot: {
+    colorScheme: { default: "light", [DARK]: "dark" },
+  },
   document: {
     boxSizing: "border-box",
     margin: 0,
     minHeight: "100dvh",
-    colorScheme: "light dark",
     backgroundColor: colors.ground,
     color: colors.ink,
     fontFamily: fonts.reading,

--- a/apps/web/src/styles/tokens.stylex.ts
+++ b/apps/web/src/styles/tokens.stylex.ts
@@ -74,10 +74,6 @@ export const colors = stylex.defineVars({
     default: "rgb(22 25 20 / 0.28)",
     [DARK]: "rgb(232 234 227 / 0.32)",
   },
-  fieldBackground: {
-    default: "rgb(255 255 255 / 0.55)",
-    [DARK]: "rgb(255 255 255 / 0.04)",
-  },
   imageBackground: "#ffffff",
   critical: { default: "#a3231a", [DARK]: "#f0776b" },
   criticalQuiet: {
@@ -118,7 +114,6 @@ export const lightColorTheme = stylex.createTheme(colors, {
   hairline: "rgb(22 25 20 / 0.11)",
   sectionRule: "rgb(22 25 20 / 0.16)",
   fieldRule: "rgb(22 25 20 / 0.28)",
-  fieldBackground: "rgb(255 255 255 / 0.55)",
   imageBackground: "#ffffff",
   critical: "#a3231a",
   criticalQuiet: "rgb(163 35 26 / 0.42)",
@@ -153,7 +148,6 @@ export const darkColorTheme = stylex.createTheme(colors, {
   hairline: "rgb(232 234 227 / 0.11)",
   sectionRule: "rgb(232 234 227 / 0.16)",
   fieldRule: "rgb(232 234 227 / 0.32)",
-  fieldBackground: "rgb(255 255 255 / 0.04)",
   imageBackground: "#ffffff",
   critical: "#f0776b",
   criticalQuiet: "rgb(240 119 107 / 0.42)",

--- a/openspec/changes/add-bottle-flow/design.md
+++ b/openspec/changes/add-bottle-flow/design.md
@@ -112,6 +112,30 @@ The control should be unchecked unless product decides the scan suitability and 
 
 After adding to Library, show an Add to your Library flow with the saved entry and image. Primary action: Add another to Library. Secondary action: View Library. Add another to Library clears resolver state and starts a fresh Library-intent flow, even when the user entered with another intent and chose Library as a secondary outcome.
 
+### Manual creation reviews unseen existing Bottles
+
+The manual Add a bottle form checks for existing Bottles in the background once
+Brand and Bottle name are available. Later Bottle facts refresh the candidate
+ranking without interrupting data entry. The form sends its normalized Bottle
+draft so the server owns which facts affect discovery and ranking.
+
+Track reviewed candidates by stable Bottle id for the lifetime of the form. A
+candidate becomes reviewed only after the member explicitly rejects the review
+set or chooses an existing Bottle. Result ordering and repeated appearances do
+not make a reviewed Bottle new again. Do not persist this state across a page
+reload.
+
+During data entry, a compact notice below the Bottle preview offers review when
+the current results contain unseen Bottle ids. The notice disappears after
+review and returns only for newly surfaced ids. Duplicate review is not a
+numbered form step. On the final step, the primary action changes from Add a
+bottle to review the unseen Bottles before creation can continue.
+
+The review view keeps the draft Bottle visible for comparison and lists only
+the unseen existing Bottles using `BottleIdentityRow`. Choosing an existing
+Bottle leaves manual creation. Rejecting the review from the final save boundary
+uses Add as a new bottle and continues the pending submission.
+
 ## Risks / Trade-offs
 
 - Pending upload semantics may conflict with existing attached/cleanup behavior. -> Update helper tests first and keep expiry/ownership checks authoritative.

--- a/openspec/changes/add-bottle-flow/specs/add-bottle-flow/spec.md
+++ b/openspec/changes/add-bottle-flow/specs/add-bottle-flow/spec.md
@@ -185,3 +185,45 @@ The system SHALL preserve existing bottle-scoped tasting deep links while user-f
 
 - **WHEN** the bottle-scoped tasting route renders visible tasting copy
 - **THEN** the copy uses Log a tasting
+
+### Requirement: Existing Bottle review during manual creation
+
+The system SHALL surface advisory existing Bottle candidates while preserving
+manual Bottle creation as the member's primary task.
+
+#### Scenario: Unseen candidates appear during entry
+
+- **WHEN** the manual creation matcher returns one or more Bottle ids the member has not reviewed in the current form session
+- **THEN** the form shows a compact review notice without leaving the current numbered step
+- **AND** the notice count includes only unseen Bottle ids
+
+#### Scenario: Reviewed candidates repeat or reorder
+
+- **WHEN** matcher results contain only Bottle ids the member already reviewed in the current form session
+- **THEN** the form does not ask the member to review them again
+- **AND** changes to result ordering do not make those Bottles unseen
+
+#### Scenario: New candidate appears after review
+
+- **WHEN** a later matcher result contains a Bottle id that was not in a completed review
+- **THEN** the form identifies that Bottle as new
+- **AND** offers review again using only unseen candidates
+
+#### Scenario: Final creation has unseen candidates
+
+- **WHEN** the member reaches the final manual creation action with unseen candidates
+- **THEN** the system requires candidate review before creating the Bottle
+- **AND** the review is an unnumbered view that preserves the final numbered step and all entered data
+
+#### Scenario: Compare the draft with existing Bottles
+
+- **WHEN** candidate review opens
+- **THEN** the system keeps the draft Bottle visible
+- **AND** lists only unseen existing Bottles using the standard Bottle identity row
+- **AND** lets the member use an existing Bottle or add the draft as a new Bottle
+
+#### Scenario: Matcher receives the Bottle draft
+
+- **WHEN** Bottle facts change during manual creation
+- **THEN** the matcher receives the normalized Bottle draft
+- **AND** the server decides which facts affect candidate discovery and ranking

--- a/openspec/changes/add-bottle-flow/tasks.md
+++ b/openspec/changes/add-bottle-flow/tasks.md
@@ -75,3 +75,12 @@
 - [x] 10.4 Run focused image extraction evals and final classifier evals for the five scan-backed cases.
 - [x] 10.5 Audit review policy downgrades surfaced by those evals and remove or narrow gates only after the classifier result is proven correct.
 - [x] 10.6 Run targeted classifier tests, eval fixture validation, typecheck, and commit intentional eval replay recordings.
+
+## 11. Manual Creation Duplicate Review
+
+- [x] 11.1 Send the normalized Bottle draft to candidate matching and rank with additional distinguishing Bottle facts.
+- [x] 11.2 Track reviewed candidates by Bottle id and show review only for unseen ids.
+- [x] 11.3 Keep the draft Bottle visible in an unnumbered review view and use clear existing-versus-new actions.
+- [x] 11.4 Make unseen candidates a conditional final creation gate without adding a numbered step.
+- [x] 11.5 Add focused matcher and browser coverage for repeated, reordered, and newly surfaced candidate ids.
+- [x] 11.6 Verify the creation and candidate-review flow at desktop and mobile widths in light and dark mode.


### PR DESCRIPTION
Add Bottle is now a seven-step workflow that keeps the draft visible, makes Brand, distiller, bottler, and Series pickers respond quickly, and checks the catalog as identity and release facts are entered. Bottle editing remains the existing single-page form.

Possible matches appear in a compact notice and use the standard Bottle row. The form remembers reviewed Bottle IDs for the life of the draft, calls out newly found matches, and requires a final review of any unseen candidates before saving. Choosing an existing Bottle preserves the original Library, tasting, choose, or view action and any pending photo; choosing to add a new one still creates a distinct release.

The new read-only candidate endpoint broadens discovery without rewriting submitted names, then ranks active Bottles using stored identity and release facts. Matching remains advisory: a lookup failure does not block creation, and facts that do not define Bottle identity do not influence the result.

The supporting form-control work is shared across the design system: pickers now use normalized debounced queries, cached results, consistent keyboard and error behavior, inset field surfaces, and explicit light and dark color-scheme handling. Reviewers should start with `bottleForm.tsx` for the interaction flow and `bottleCreateCandidates.ts` for discovery and ranking. Desktop, mobile, light, and dark states are covered by the visual E2E checkpoints.

Fixes #1087
