### PR TITLE
fix(web): search all entities in bottle form

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -7,6 +7,7 @@ import {
   existingBottle,
   testAccessToken,
   testBrand,
+  testOwnedEntity,
 } from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 import { expect, type Page, test, type TestInfo } from "./test";
@@ -129,6 +130,25 @@ test.describe("Add Bottle", () => {
     await page.getByRole("button", { name: "Add to Library" }).click();
     await expect(
       page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
+  });
+
+  test("offers an Entity with a different kind as the Brand", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "cross-kind-brand"),
+    });
+    await page.goto("/bottles/new?returnAction=view");
+
+    await page.getByPlaceholder("Laphroaig").fill(testOwnedEntity.name);
+    await page
+      .getByRole("option", { name: new RegExp(testOwnedEntity.name) })
+      .click();
+
+    await expect(
+      page.getByText(testOwnedEntity.name, { exact: true }),
     ).toBeVisible();
   });
 

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -436,7 +436,6 @@ export default function BottleForm({
   const brandResults = useQuery({
     ...orpc.entities.list.queryOptions({
       input: {
-        kinds: ["brand"],
         limit: 25,
         query: debouncedBrandQuery,
         sort: debouncedBrandQuery ? "rank" : "name",
@@ -447,7 +446,6 @@ export default function BottleForm({
   const bottlerResults = useQuery({
     ...orpc.entities.list.queryOptions({
       input: {
-        kinds: ["bottler"],
         limit: 25,
         query: debouncedBottlerQuery,
         sort: debouncedBottlerQuery ? "rank" : "name",
@@ -458,7 +456,6 @@ export default function BottleForm({
   const distillerResults = useQuery({
     ...orpc.entities.list.queryOptions({
       input: {
-        kinds: ["distillery"],
         limit: 25,
         query: debouncedDistillerQuery,
         sort: debouncedDistillerQuery ? "rank" : "name",


### PR DESCRIPTION
Bottle relationship pickers now search the full Entity catalog instead of limiting results to the Entity's browse kind. This allows identities such as Lagavulin, which is stored as a distillery, to be selected as a Bottle's Brand and preserves the same cross-kind behavior for bottler and distiller relationships.

Entity kind still controls browse placement and new-Entity creation. A focused browser regression covers selecting a distillery-kind Entity in the Brand field.
