### PR TITLE
ref(scrapers): retire Bruichladdich and prepare North Star

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -142,6 +142,15 @@ function prepareKilchoman(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareNorthStar(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "northstarspirits", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 const canonicalUrl =
   "https://thebourbonculture.com/whiskey-reviews/example-review/";
 
@@ -153,6 +162,7 @@ function codeOwnedSource(
     | "compassbox"
     | "gordonmacphail"
     | "kilchoman"
+    | "northstarspirits"
     | "whiskeyreviewer"
     | "whiskynotes"
     | "whiskysaga"
@@ -233,6 +243,11 @@ const gordonMacphailRegistry = createScraperRegistry({
 const kilchomanRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("kilchoman")!],
   sources: [codeOwnedSource("kilchoman")],
+});
+
+const northStarRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("northstarspirits")!],
+  sources: [codeOwnedSource("northstarspirits")],
 });
 
 async function setupMigration(bottleId: number | null = null) {
@@ -690,6 +705,25 @@ async function setupKilchomanMigration() {
     })
     .returning();
   await syncScraperDefinitions(kilchomanRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
+}
+
+async function setupNorthStarMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "northstarspirits",
+      name: "North Star",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(northStarRegistry);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "succeeded",
@@ -1715,6 +1749,105 @@ describe("POST /admin/scrape-sources/prepare", () => {
       code: "BAD_REQUEST",
       message: "Kilchoman has no stored prices to verify.",
     });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares North Star without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupNorthStarMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "11471377727829",
+      name: "The Speyside Connection",
+      price: 6999,
+      currency: "gbp",
+      volume: 700,
+      url: "https://northstarspirits.com/products/speyside-connection",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "9887521767765",
+      name: "Caol Ila Sherry Octave",
+      price: 5700,
+      currency: "gbp",
+      volume: 500,
+      url: "https://northstarspirits.com/products/caol-ila-sherry-octave",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareNorthStar()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareNorthStar({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(northStarRegistry);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl: "https://northstarspirits.com/collections/shop",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+    await expect(prepareNorthStar({ apply: true })).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "North Star is already prepared for saved scraping rules.",
+    });
+  });
+
+  test("refuses an unexpected North Star price without changing records", async ({
+    fixtures,
+  }) => {
+    const site = await setupNorthStarMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "not-a-number",
+      name: "Unknown release",
+      currency: "gbp",
+      volume: 700,
+      url: "https://northstarspirits.com/products/unknown-release",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareNorthStar({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check North Star price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
     expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -7,6 +7,7 @@ import { prepareCadenheadsSource } from "@peated/server/scraper/configured/prepa
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
 import { prepareGordonMacphailSource } from "@peated/server/scraper/configured/prepareGordonMacphail";
 import { prepareKilchomanSource } from "@peated/server/scraper/configured/prepareKilchoman";
+import { prepareNorthStarSource } from "@peated/server/scraper/configured/prepareNorthStar";
 import { prepareWhiskeyReviewerSource } from "@peated/server/scraper/configured/prepareWhiskeyReviewer";
 import { prepareWhiskyNotesSource } from "@peated/server/scraper/configured/prepareWhiskyNotes";
 import { prepareWhiskySagaSource } from "@peated/server/scraper/configured/prepareWhiskySaga";
@@ -36,7 +37,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, gordonmacphail, kilchoman, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
+          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, gordonmacphail, kilchoman, northstarspirits, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -73,6 +74,7 @@ export default procedure
       compassbox: prepareCompassBoxSource,
       gordonmacphail: prepareGordonMacphailSource,
       kilchoman: prepareKilchomanSource,
+      northstarspirits: prepareNorthStarSource,
       whiskeyreviewer: prepareWhiskeyReviewerSource,
       whiskynotes: prepareWhiskyNotesSource,
       whiskysaga: prepareWhiskySagaSource,

--- a/apps/server/src/scraper/configured/prepareNorthStar.ts
+++ b/apps/server/src/scraper/configured/prepareNorthStar.ts
@@ -1,0 +1,24 @@
+import { ALLOWED_VOLUMES } from "@peated/server/constants";
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks North Star by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareNorthStarSource(input: PreparePriceSourceInput) {
+  return preparePriceSource(input, {
+    siteKey: "northstarspirits",
+    siteName: "North Star",
+    targetKey: "northstarspirits",
+    origin: "https://northstarspirits.com",
+    listUrl: "https://northstarspirits.com/collections/shop",
+    isExpectedPrice: (price) =>
+      /^https:\/\/northstarspirits\.com\/products\/[a-z0-9][a-z0-9-]*$/.test(
+        price.url,
+      ) &&
+      /^\d+$/.test(price.externalProductId ?? "") &&
+      price.name.trim().length > 0 &&
+      price.currency === "gbp" &&
+      ALLOWED_VOLUMES.includes(price.volume),
+  });
+}

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -1,26 +1,12 @@
 import { EXTERNAL_SITE_DEFINITIONS } from "@peated/server/constants";
-import { db } from "@peated/server/db";
-import {
-  externalSiteRuns,
-  externalSites,
-  storePrices,
-} from "@peated/server/db/schema";
 import { ExternalReviewArticleIngestionSchema } from "@peated/server/externalReviews/observation";
-import { syncExternalSites } from "@peated/server/lib/externalSites";
-import { loadFixture } from "@peated/server/lib/test/fixtures";
-import { eq } from "drizzle-orm";
-import { vi } from "vitest";
-import type { ScraperHttpClock } from "./http";
 import { createScraperLifecycle } from "./lifecycle";
 import { scraperRegistry } from "./registry";
-import { executeScraperRun } from "./runs";
 import { externalReviewSink } from "./sinks/externalReviews";
-import { syncScraperDefinitions } from "./syncDefinitions";
 
 const registeredSources = [
   "astorwines",
   "berrybrosrudd",
-  "bruichladdich",
   "decadentdrinks",
   "douglaslaing",
   "dramface",
@@ -55,6 +41,7 @@ const registeredReviewSources = [
 
 const configuredSources = [
   "bourbonculture",
+  "bruichladdich",
   "cadenheads",
   "compassbox",
   "gordonmacphail",
@@ -65,22 +52,6 @@ const configuredSources = [
   "whiskynotes",
   "wordsofwhisky",
 ];
-
-type RuntimeTestClock = ScraperHttpClock & { advanceTo(value: Date): void };
-
-function runtimeClock(): RuntimeTestClock {
-  let now = new Date("2026-08-18T12:00:00Z");
-  return {
-    now: () => now,
-    sleep: async (milliseconds) => {
-      now = new Date(now.getTime() + milliseconds);
-    },
-    random: () => 0,
-    advanceTo: (value) => {
-      now = value;
-    },
-  };
-}
 
 test("registers each code-owned scraper source with explicit target ownership", () => {
   expect([...scraperRegistry.sources.keys()].sort()).toEqual(
@@ -109,6 +80,7 @@ test("registers each code-owned scraper source with explicit target ownership", 
     requestsPerWindow: 10,
     windowMs: 3_600_000,
   });
+  expect(scraperRegistry.targets.get("bruichladdich")).toBeDefined();
   expect(scraperRegistry.targets.get("compassbox")).toBeDefined();
   expect(EXTERNAL_SITE_DEFINITIONS.dramface.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("dramface")).toMatchObject({
@@ -193,69 +165,11 @@ test("registers each code-owned scraper source with explicit target ownership", 
   }
 });
 
-test("runs Bruichladdich through the production runtime with fixture parity", async () => {
-  await syncExternalSites();
-  await syncScraperDefinitions(scraperRegistry);
-  const [site] = await db
-    .select()
-    .from(externalSites)
-    .where(eq(externalSites.type, "bruichladdich"));
-  if (!site) throw new Error("Expected synchronized site.");
-  const [run] = await db
-    .insert(externalSiteRuns)
-    .values({
-      externalSiteId: site.id,
-      trigger: "manual",
-      requestLimit: 100,
-    })
-    .returning();
-  if (!run) throw new Error("Expected run.");
-  const fixture = await loadFixture("bruichladdich", "bottle-list.json");
-  const fetchImpl = vi.fn<typeof fetch>(async (input) => {
-    const url = new URL(input instanceof Request ? input.url : input);
-    if (url.pathname === "/robots.txt") {
-      return new Response(null, { status: 404 });
-    }
-    if (url.searchParams.get("page") === "1") return new Response(fixture);
-    return new Response(JSON.stringify({ products: [] }));
-  });
-
-  await expect(
-    executeScraperRun(
-      { runId: run.id },
-      {
-        registry: scraperRegistry,
-        fetchImpl,
-        clock: runtimeClock(),
-        executionToken: "owner",
-      },
-    ),
-  ).resolves.toEqual({ status: "completed" });
-
-  expect(
-    await db
-      .select()
-      .from(storePrices)
-      .where(eq(storePrices.externalSiteId, site.id)),
-  ).toHaveLength(4);
-  const [storedRun] = await db
-    .select()
-    .from(externalSiteRuns)
-    .where(eq(externalSiteRuns.id, run.id));
-  expect(storedRun).toMatchObject({
-    status: "succeeded",
-    requestCount: 3,
-    emittedItemCount: 4,
-    itemCount: 4,
-    cursor: { sequence: 1, page: 1 },
-  });
-});
-
-test("dispatches migrated sources to the isolated scraper job", async ({
+test("dispatches code-owned sources to the isolated scraper job", async ({
   fixtures,
 }) => {
   const requestedBy = await fixtures.User({ admin: true });
-  const site = await fixtures.ExternalSite({ type: "bruichladdich" });
+  const site = await fixtures.ExternalSite({ type: "edradour" });
   const enqueue = vi.fn(async () => undefined);
 
   const run = await createScraperLifecycle({

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -11,7 +11,6 @@ import {
 } from "./adapters/fredMinnick";
 import scrapeAstorWines from "./adapters/legacy/scrapeAstorWines";
 import scrapeBerryBrosRudd from "./adapters/legacy/scrapeBerryBrosRudd";
-import scrapeBruichladdich from "./adapters/legacy/scrapeBruichladdich";
 import scrapeDecadentDrinks from "./adapters/legacy/scrapeDecadentDrinks";
 import scrapeDouglasLaing from "./adapters/legacy/scrapeDouglasLaing";
 import scrapeDramfool from "./adapters/legacy/scrapeDramfool";
@@ -73,11 +72,6 @@ const legacyPriceSources = [
     type: "berrybrosrudd",
     origin: "https://www.bbr.com",
     scrape: scrapeBerryBrosRudd,
-  },
-  {
-    type: "bruichladdich",
-    origin: "https://www.bruichladdich.com",
-    scrape: scrapeBruichladdich,
   },
   {
     type: "decadentdrinks",
@@ -228,6 +222,15 @@ export const scraperRegistry = createScraperRegistry({
       origins: [
         {
           origin: "https://thebourbonculture.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
+      key: "bruichladdich",
+      origins: [
+        {
+          origin: "https://www.bruichladdich.com",
           robots: { mode: "enforce" },
         },
       ],

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -260,6 +260,32 @@ preview. Activate only exact output, trigger one manual collection, and confirm
 that it updates the same price IDs and Bottle matches. Check the run and Sentry
 before restoring the saved schedule.
 
+## North Star
+
+Use the preparation endpoint with `{"site": "northstarspirits"}`. The check-only
+request examines every saved price without changing it. It reports the total,
+the number shown on Peated, and the number linked to Bottles. It stops if a price
+does not use the expected North Star product URL, numeric product ID published
+by the shop, non-empty name, GBP currency, or supported bottle size. Applying
+moves the site's request limits to a saved-rule price source with collection
+turned off. Its shop page is `https://northstarspirits.com/collections/shop`.
+It does not update saved prices or their history.
+
+Before applying, stop the `northstarspirits` schedule and wait for queued or
+running collection to finish.
+Save the same price and run records listed for Compass Box. Run the candidate
+rules through the local preview, which does not save prices. Do not set a product
+limit. The shop currently mixes whisky with gin and liqueur, so the shop-page
+rules must exclude both non-whisky products. The product-page rules must read
+the exact product name, current GBP price, published bottle size, product URL,
+product ID, and image. Compare every listing with the code scraper, including
+sale prices and any supported size other than 700 ml.
+
+After applying, save and preview the reviewed rules. Activate them only after
+the output matches exactly. Trigger one manual collection and confirm that it
+updates the same price IDs and Bottle links. Check the run and Sentry before
+restoring the saved schedule.
+
 ## If something goes wrong
 
 A request without `apply: true` leaves records unchanged. After applying, keep the
@@ -270,10 +296,10 @@ handles reviews added after the switch. Do not delete source or run history.
 ## Other sources
 
 The preparation API is shared. It currently supports Bourbon Culture,
-Bruichladdich, Cadenhead's, Compass Box, Gordon & MacPhail, Kilchoman, The
-Whiskey Reviewer, WhiskyNotes, Whisky Saga, The Whisky Study, and Words of
-Whisky. Other sites are rejected without changing records. Add each site's
-conversion behind this route as its existing records are reviewed.
+Bruichladdich, Cadenhead's, Compass Box, Gordon & MacPhail, Kilchoman, North
+Star, The Whiskey Reviewer, WhiskyNotes, Whisky Saga, The Whisky Study, and
+Words of Whisky. Other sites are rejected without changing records. Add each
+site's conversion behind this route as its existing records are reviewed.
 
 Prepare each source using its own rules for recognizing existing records.
 Articles with several reviews need a verified match for each review. Store


### PR DESCRIPTION
Bruichladdich now runs only through its active saved rules, while its existing request limits and robots checks remain registered. This removes the obsolete code-owned runtime path after both the manual and scheduled production runs returned the expected 21 listings.

North Star gains an admin-only preparation step for moving to saved rules. It checks every saved price before making changes, keeps price IDs, Bottle links, history, and request limits, and creates the replacement source with collection turned off. Deployment alone does not change production data; the operator guide requires an exact preview comparison, one manual collection, and verification before restoring the schedule.
