### PR TITLE
perf(search)!: return results without counting every match

### DIFF
--- a/apps/server/src/orpc/contracts/search.ts
+++ b/apps/server/src/orpc/contracts/search.ts
@@ -111,42 +111,42 @@ const MemberResultSchema = z.object({
 const GroupSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("bottles"),
-    total: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
     results: z.array(BottleResultSchema),
   }),
   z.object({
     type: z.literal("series"),
-    total: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
     results: z.array(SeriesResultSchema),
   }),
   z.object({
     type: z.literal("distilleries"),
-    total: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
     results: z.array(EntityResultSchema),
   }),
   z.object({
     type: z.literal("brands"),
-    total: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
     results: z.array(EntityResultSchema),
   }),
   z.object({
     type: z.literal("bottlers"),
-    total: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
     results: z.array(EntityResultSchema),
   }),
   z.object({
     type: z.literal("companies"),
-    total: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
     results: z.array(EntityResultSchema),
   }),
   z.object({
     type: z.literal("regions"),
-    total: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
     results: z.array(RegionResultSchema),
   }),
   z.object({
     type: z.literal("members"),
-    total: z.number().int().nonnegative(),
+    hasMore: z.boolean(),
     results: z.array(MemberResultSchema),
   }),
 ]);
@@ -170,22 +170,10 @@ const NearestSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("members"), result: MemberResultSchema }),
 ]);
 
-export const ScopeTotalsSchema = z.object({
-  bottles: z.number().int().nonnegative(),
-  series: z.number().int().nonnegative(),
-  distilleries: z.number().int().nonnegative(),
-  brands: z.number().int().nonnegative(),
-  bottlers: z.number().int().nonnegative(),
-  companies: z.number().int().nonnegative(),
-  regions: z.number().int().nonnegative(),
-  members: z.number().int().nonnegative().optional(),
-});
-
 export const SearchOutputSchema = z.object({
   query: z.string(),
   exact: ExactSchema,
   groups: z.array(GroupSchema),
-  scopeTotals: ScopeTotalsSchema.nullable(),
   nearest: z.array(NearestSchema).max(3),
 });
 
@@ -209,10 +197,6 @@ export default contract
           .array(z.enum(SEARCH_SCOPE_LIST))
           .default([...SEARCH_SCOPE_LIST]),
         limit: z.coerce.number().gte(1).lte(50).default(3),
-        includeFacets: z.coerce
-          .boolean()
-          .default(false)
-          .describe("Compute totals for each searchable scope"),
       })
       .strict(),
   )

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -97,10 +97,10 @@ describe("mock oRPC router", () => {
       ref: { id: mockEntity.id, name: mockEntity.name },
     });
     expect(search.groups).toMatchObject([
-      { type: "bottles", total: 3 },
+      { type: "bottles", hasMore: false },
       {
         type: "distilleries",
-        total: 1,
+        hasMore: false,
         results: [{ id: mockEntity.id, name: mockEntity.name }],
       },
     ]);
@@ -710,7 +710,6 @@ describe("mock oRPC router", () => {
 
   it("returns no results when the fixed data does not match", async () => {
     const results = await anonymousClient.search({
-      includeFacets: true,
       query: "Ardbeg",
       scopes: ["bottles", "distilleries", "members"],
     });
@@ -719,38 +718,22 @@ describe("mock oRPC router", () => {
       query: "Ardbeg",
       exact: null,
       groups: [
-        { type: "bottles", total: 0, results: [] },
-        { type: "distilleries", total: 0, results: [] },
+        { type: "bottles", hasMore: false, results: [] },
+        { type: "distilleries", hasMore: false, results: [] },
       ],
-      scopeTotals: {
-        bottles: mockBottles.length,
-        series: 0,
-        distilleries: mockEntities.filter(
-          (entity) => entity.kind === "distillery",
-        ).length,
-        brands: mockEntities.filter((entity) => entity.kind === "brand").length,
-        bottlers: mockEntities.filter((entity) => entity.kind === "bottler")
-          .length,
-        companies: mockEntities.filter((entity) => entity.kind === "company")
-          .length,
-        regions: mockRegions.length,
-      },
       nearest: [],
     });
   });
 
   it("shows member search results only after sign-in", async () => {
     const anonymousResults = await anonymousClient.search({
-      includeFacets: true,
       query: mockUser.username,
       scopes: ["members"],
     });
     expect(anonymousResults.groups).toEqual([]);
-    expect(anonymousResults.scopeTotals?.members).toBeUndefined();
 
     await expect(
       authenticatedClient.search({
-        includeFacets: true,
         query: mockUser.username,
         scopes: ["members"],
       }),
@@ -758,7 +741,7 @@ describe("mock oRPC router", () => {
       groups: [
         {
           type: "members",
-          total: 1,
+          hasMore: false,
           results: [
             {
               member: {
@@ -771,9 +754,6 @@ describe("mock oRPC router", () => {
           ],
         },
       ],
-      scopeTotals: {
-        members: 3,
-      },
     });
   });
 

--- a/apps/server/src/orpc/mock/routes/search.ts
+++ b/apps/server/src/orpc/mock/routes/search.ts
@@ -50,12 +50,12 @@ export default mockOS.search.handler(async ({ input, context }) => {
   if (input.scopes.includes("bottles")) {
     groups.push({
       type: "bottles",
-      total: bottles.length,
+      hasMore: bottles.length > input.limit,
       results: bottles.slice(0, input.limit),
     });
   }
   if (input.scopes.includes("series")) {
-    groups.push({ type: "series", total: 0, results: [] });
+    groups.push({ type: "series", hasMore: false, results: [] });
   }
   for (const scope of [
     "distilleries",
@@ -67,7 +67,7 @@ export default mockOS.search.handler(async ({ input, context }) => {
       const results = entitiesByScope[scope];
       groups.push({
         type: scope,
-        total: results.length,
+        hasMore: results.length > input.limit,
         results: results.slice(0, input.limit),
       });
     }
@@ -75,7 +75,7 @@ export default mockOS.search.handler(async ({ input, context }) => {
   if (input.scopes.includes("regions")) {
     groups.push({
       type: "regions",
-      total: regions.length,
+      hasMore: regions.length > input.limit,
       results: regions.slice(0, input.limit),
     });
   }
@@ -97,7 +97,7 @@ export default mockOS.search.handler(async ({ input, context }) => {
   if (context.user && input.scopes.includes("members")) {
     groups.push({
       type: "members",
-      total: members.length,
+      hasMore: members.length > input.limit,
       results: members.slice(0, input.limit),
     });
   }
@@ -134,23 +134,6 @@ export default mockOS.search.handler(async ({ input, context }) => {
       ),
   );
 
-  const scopeTotals: MockOutputs["search"]["scopeTotals"] = input.includeFacets
-    ? {
-        bottles: mockBottles.length,
-        series: 0,
-        distilleries: mockEntities.filter(
-          (entity) => entity.kind === "distillery",
-        ).length,
-        brands: mockEntities.filter((entity) => entity.kind === "brand").length,
-        bottlers: mockEntities.filter((entity) => entity.kind === "bottler")
-          .length,
-        companies: mockEntities.filter((entity) => entity.kind === "company")
-          .length,
-        regions: mockRegions.length,
-      }
-    : null;
-  if (context.user && scopeTotals) scopeTotals.members = 3;
-
   return SearchOutputSchema.parse({
     query: input.query,
     exact:
@@ -160,7 +143,6 @@ export default mockOS.search.handler(async ({ input, context }) => {
           ? { type: "entity", ref: exactEntity }
           : null,
     groups,
-    scopeTotals,
     nearest: [],
   });
 });

--- a/apps/server/src/orpc/routes/search.test.ts
+++ b/apps/server/src/orpc/routes/search.test.ts
@@ -38,7 +38,7 @@ describe("GET /search", () => {
     });
   });
 
-  test("returns independently capped groups with exact totals", async ({
+  test("returns independently capped groups and indicates more results", async ({
     fixtures,
   }) => {
     const bottles = await Promise.all(
@@ -92,18 +92,22 @@ describe("GET /search", () => {
     expect(data.groups).toMatchObject([
       {
         type: "bottles",
-        total: 4,
+        hasMore: true,
         results: [{ id: bottles[0]!.id }, { id: bottles[1]!.id }],
       },
-      { type: "distilleries", total: 1, results: [{ id: distiller.id }] },
-      { type: "brands", total: 1, results: [{ id: brand.id }] },
-      { type: "bottlers", total: 1, results: [{ id: bottler.id }] },
-      { type: "companies", total: 1, results: [{ id: company.id }] },
-      { type: "regions", total: 1, results: [{ id: region.id }] },
+      {
+        type: "distilleries",
+        hasMore: false,
+        results: [{ id: distiller.id }],
+      },
+      { type: "brands", hasMore: false, results: [{ id: brand.id }] },
+      { type: "bottlers", hasMore: false, results: [{ id: bottler.id }] },
+      { type: "companies", hasMore: false, results: [{ id: company.id }] },
+      { type: "regions", hasMore: false, results: [{ id: region.id }] },
     ]);
   });
 
-  test("finds Series with Brand context and exact totals", async ({
+  test("finds Series with Brand context and indicates more results", async ({
     fixtures,
   }) => {
     const brand = await fixtures.Entity({ name: "Dramfool" });
@@ -131,7 +135,7 @@ describe("GET /search", () => {
     expect(data.groups).toMatchObject([
       {
         type: "series",
-        total: 2,
+        hasMore: true,
         results: [
           {
             id: first.id,
@@ -166,7 +170,11 @@ describe("GET /search", () => {
     });
 
     expect(data.groups).toMatchObject([
-      { type: "distilleries", total: 1, results: [{ id: distiller.id }] },
+      {
+        type: "distilleries",
+        hasMore: false,
+        results: [{ id: distiller.id }],
+      },
     ]);
   });
 
@@ -193,39 +201,6 @@ describe("GET /search", () => {
     ]);
   });
 
-  test("returns searchable scope totals", async ({ fixtures }) => {
-    await fixtures.Bottle({ name: "Population Bottle" });
-    await fixtures.Entity({
-      name: "Population Bottler",
-      kind: "bottler",
-    });
-    await fixtures.Entity({
-      name: "Population Company",
-      type: [],
-      kind: "company",
-    });
-
-    const data = await routerClient.search({
-      includeFacets: true,
-      query: "no-population-match",
-      scopes: ["bottles", "bottlers", "companies"],
-    });
-
-    expect(data.scopeTotals?.bottles).toBeGreaterThanOrEqual(1);
-    expect(data.scopeTotals?.bottlers).toBeGreaterThanOrEqual(1);
-    expect(data.scopeTotals?.companies).toBeGreaterThanOrEqual(1);
-    expect(data.scopeTotals?.members).toBeUndefined();
-  });
-
-  test("does not include scope facets by default", async () => {
-    const data = await routerClient.search({
-      query: "no-facet-match",
-      scopes: ["brands"],
-    });
-
-    expect(data.scopeTotals).toBeNull();
-  });
-
   test("keeps member search authenticated and hides unsearchable profiles", async ({
     defaults,
     fixtures,
@@ -244,21 +219,16 @@ describe("GET /search", () => {
     const [anonymous, authenticated] = await Promise.all([
       routerClient.search({ query: "memberneedle", scopes: ["members"] }),
       routerClient.search(
-        {
-          includeFacets: true,
-          query: "memberneedle",
-          scopes: ["members"],
-        },
+        { query: "memberneedle", scopes: ["members"] },
         { context: { user: defaults.user } },
       ),
     ]);
 
     expect(anonymous.groups).toEqual([]);
-    expect(anonymous.scopeTotals).toBeNull();
     expect(authenticated.groups).toMatchObject([
       {
         type: "members",
-        total: 1,
+        hasMore: false,
         results: [{ member: { id: publicMember.id }, totalTastings: 2 }],
       },
     ]);
@@ -287,7 +257,7 @@ describe("GET /search", () => {
     expect(data.groups).toMatchObject([
       {
         type: "members",
-        total: 1,
+        hasMore: false,
         results: [{ member: { id: privateMember.id }, totalTastings: 0 }],
       },
     ]);
@@ -402,7 +372,7 @@ describe("GET /search", () => {
     });
 
     expect(data.groups).toMatchObject([
-      { type: "bottles", total: 0, results: [] },
+      { type: "bottles", hasMore: false, results: [] },
     ]);
     expect(data.nearest).toMatchObject([
       { type: "bottles", result: { id: bottle.id } },
@@ -485,10 +455,14 @@ describe("GET /search", () => {
     ]);
 
     expect(aliasSearch.groups).toMatchObject([
-      { type: "bottles", total: 1, results: [{ id: retainedBottle.id }] },
+      {
+        type: "bottles",
+        hasMore: false,
+        results: [{ id: retainedBottle.id }],
+      },
     ]);
     expect(legacySearch.groups).toMatchObject([
-      { type: "bottles", total: 0, results: [] },
+      { type: "bottles", hasMore: false, results: [] },
     ]);
   });
 
@@ -508,7 +482,7 @@ describe("GET /search", () => {
     });
 
     expect(data.groups).toMatchObject([
-      { type: "brands", total: 1, results: [{ id: entity.id }] },
+      { type: "brands", hasMore: false, results: [{ id: entity.id }] },
     ]);
   });
 
@@ -531,7 +505,7 @@ describe("GET /search", () => {
     });
 
     expect(data.groups).toMatchObject([
-      { type: "brands", total: 1, results: [{ id: entity.id }] },
+      { type: "brands", hasMore: false, results: [{ id: entity.id }] },
     ]);
   });
 

--- a/apps/server/src/orpc/routes/search.ts
+++ b/apps/server/src/orpc/routes/search.ts
@@ -66,35 +66,34 @@ type SeriesRow = Omit<SeriesResult, "peatedId" | "brand"> & {
   brand: Omit<SeriesResult["brand"], "peatedId">;
 };
 type RegionRow = RegionResult & { totalBottles: number };
-type ScopeTotals = NonNullable<SearchOutput["scopeTotals"]>;
 type GroupRows =
   | {
       type: "bottles";
-      total: number;
+      hasMore: boolean;
       results: BottleRow[];
       exactMatch: boolean;
     }
   | {
       type: "series";
-      total: number;
+      hasMore: boolean;
       results: SeriesRow[];
       exactMatch: boolean;
     }
   | {
       type: EntitySearchScope;
-      total: number;
+      hasMore: boolean;
       results: EntityRow[];
       exactMatch: boolean;
     }
   | {
       type: "regions";
-      total: number;
+      hasMore: boolean;
       results: RegionRow[];
       exactMatch: boolean;
     }
   | {
       type: "members";
-      total: number;
+      hasMore: boolean;
       results: MemberResult[];
       exactMatch: boolean;
     };
@@ -121,7 +120,6 @@ type SearchRows = {
   query: string;
   exact: ExactRow;
   groups: GroupRows[];
-  scopeTotals: ScopeTotals | null;
   nearest: NearestRow[];
 };
 
@@ -129,7 +127,6 @@ type SearchInput = {
   query: string;
   scopes: SearchScope[];
   limit: number;
-  includeFacets: boolean;
 };
 
 function normalizeText(value: string) {
@@ -205,21 +202,23 @@ function visibleMemberWhere(context: Context) {
 }
 
 function exactBottleReferenceMatch(query: string) {
-  return sql`${bottles.id} IN (
+  return sql`${bottles.id} = (
     SELECT ${bottleReferences.bottleId}
     FROM ${bottleReferences}
     WHERE LOWER(${bottleReferences.name}) = ${query.toLowerCase().trim()}
       AND ${bottleReferences.ignored} IS NOT TRUE
       AND ${bottleReferences.bottleId} IS NOT NULL
+    LIMIT 1
   )`;
 }
 
 function exactEntityReferenceMatch(query: string) {
-  return sql`${entities.id} IN (
+  return sql`${entities.id} = (
     SELECT ${entityReferences.entityId}
     FROM ${entityReferences}
     WHERE LOWER(${entityReferences.name}) = ${query.toLowerCase().trim()}
       AND ${entityReferences.entityId} IS NOT NULL
+    LIMIT 1
   )`;
 }
 
@@ -317,38 +316,12 @@ function entityScopeWhere(scope: EntitySearchScope) {
   return eq(entities.kind, ENTITY_KIND_BY_SEARCH_SCOPE[scope]);
 }
 
-async function countRows(
-  database: AnyDatabase,
-  table:
-    | typeof bottles
-    | typeof bottleSeries
-    | typeof entities
-    | typeof regions
-    | typeof users,
-  where: SQL<unknown> | undefined,
-) {
-  const query = database.select({ total: sql<string>`COUNT(*)` });
-  let row: { total: string } | undefined;
-  if (table === bottles) {
-    [row] = await query.from(bottles).where(where);
-  } else if (table === bottleSeries) {
-    [row] = await query.from(bottleSeries).where(where);
-  } else if (table === entities) {
-    [row] = await query.from(entities).where(where);
-  } else if (table === regions) {
-    [row] = await query.from(regions).where(where);
-  } else {
-    [row] = await query.from(users).where(where);
-  }
-  return Number(row?.total ?? 0);
-}
-
 async function searchSeries(
   database: AnyDatabase,
   query: string,
   limit: number,
-): Promise<{ total: number; results: SeriesRow[]; exactMatch: boolean }> {
-  if (!query) return { total: 0, results: [], exactMatch: false };
+): Promise<{ hasMore: boolean; results: SeriesRow[]; exactMatch: boolean }> {
+  if (!query) return { hasMore: false, results: [], exactMatch: false };
   const textQuery = plainTextSearchQuery(query);
   const prefixQuery = prefixTextSearchQuery(query);
   const where = or(
@@ -363,18 +336,15 @@ async function searchSeries(
     .select({
       ...seriesColumns(),
       searchRank: rank,
-      searchTotal: sql<number>`COUNT(*) OVER()`,
     })
     .from(bottleSeries)
     .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
     .where(where)
-    .limit(limit)
+    .limit(limit + 1)
     .orderBy(rank, sql`${bottleSeries.numReleases} DESC`, asc(bottleSeries.id));
   return {
-    total: Number(rows[0]?.searchTotal ?? 0),
-    results: rows.map(
-      ({ searchRank: _, searchTotal: __, ...result }) => result,
-    ),
+    hasMore: rows.length > limit,
+    results: rows.slice(0, limit).map(({ searchRank: _, ...result }) => result),
     exactMatch: Number(rows[0]?.searchRank) === 0,
   };
 }
@@ -383,8 +353,8 @@ async function searchBottles(
   database: AnyDatabase,
   query: string,
   limit: number,
-): Promise<{ total: number; results: BottleRow[]; exactMatch: boolean }> {
-  if (!query) return { total: 0, results: [], exactMatch: false };
+): Promise<{ hasMore: boolean; results: BottleRow[]; exactMatch: boolean }> {
+  if (!query) return { hasMore: false, results: [], exactMatch: false };
   const textQuery = plainTextSearchQuery(query);
   const prefixQuery = prefixTextSearchQuery(query);
   const referenceMatch = exactBottleReferenceMatch(query);
@@ -405,20 +375,17 @@ async function searchBottles(
     .select({
       ...bottleColumns(),
       searchRank: rank,
-      searchTotal: sql<number>`COUNT(*) OVER()`,
     })
     .from(bottles)
     .innerJoin(entities, eq(bottles.brandId, entities.id))
     .leftJoin(bottleSeries, eq(bottles.seriesId, bottleSeries.id))
     .leftJoin(bottleGroups, eq(bottles.groupId, bottleGroups.id))
     .where(where)
-    .limit(limit)
+    .limit(limit + 1)
     .orderBy(rank, sql`${bottleRatingCount()} DESC`, asc(bottles.id));
   return {
-    total: Number(rows[0]?.searchTotal ?? 0),
-    results: rows.map(
-      ({ searchRank: _, searchTotal: __, ...result }) => result,
-    ),
+    hasMore: rows.length > limit,
+    results: rows.slice(0, limit).map(({ searchRank: _, ...result }) => result),
     exactMatch: Number(rows[0]?.searchRank) === 0,
   };
 }
@@ -429,8 +396,8 @@ async function searchEntities(
   scope: EntitySearchScope,
   query: string,
   limit: number,
-): Promise<{ total: number; results: EntityRow[]; exactMatch: boolean }> {
-  if (!query) return { total: 0, results: [], exactMatch: false };
+): Promise<{ hasMore: boolean; results: EntityRow[]; exactMatch: boolean }> {
+  if (!query) return { hasMore: false, results: [], exactMatch: false };
   const textQuery = plainTextSearchQuery(query);
   const prefixQuery = prefixTextSearchQuery(query);
   const referenceMatch = exactEntityReferenceMatch(query);
@@ -451,18 +418,15 @@ async function searchEntities(
     .select({
       ...entityColumns(context),
       searchRank: rank,
-      searchTotal: sql<number>`COUNT(*) OVER()`,
     })
     .from(entities)
     .leftJoin(regions, eq(entities.regionId, regions.id))
     .where(where)
-    .limit(limit)
+    .limit(limit + 1)
     .orderBy(rank, sql`${entities.totalTastings} DESC`, asc(entities.id));
   return {
-    total: Number(rows[0]?.searchTotal ?? 0),
-    results: rows.map(
-      ({ searchRank: _, searchTotal: __, ...result }) => result,
-    ),
+    hasMore: rows.length > limit,
+    results: rows.slice(0, limit).map(({ searchRank: _, ...result }) => result),
     exactMatch: Number(rows[0]?.searchRank) === 0,
   };
 }
@@ -471,8 +435,8 @@ async function searchRegions(
   database: AnyDatabase,
   query: string,
   limit: number,
-): Promise<{ total: number; results: RegionRow[]; exactMatch: boolean }> {
-  if (!query) return { total: 0, results: [], exactMatch: false };
+): Promise<{ hasMore: boolean; results: RegionRow[]; exactMatch: boolean }> {
+  if (!query) return { hasMore: false, results: [], exactMatch: false };
   const normalizedQuery = normalizeText(query);
   const name = sql`LOWER(unaccent(${regions.name}))`;
   const where = like(name, `%${escapeLike(normalizedQuery)}%`);
@@ -481,18 +445,15 @@ async function searchRegions(
     .select({
       ...regionColumns(),
       searchRank: rank,
-      searchTotal: sql<number>`COUNT(*) OVER()`,
     })
     .from(regions)
     .innerJoin(countries, eq(regions.countryId, countries.id))
     .where(where)
-    .limit(limit)
+    .limit(limit + 1)
     .orderBy(rank, sql`${regions.totalBottles} DESC`, asc(regions.id));
   return {
-    total: Number(rows[0]?.searchTotal ?? 0),
-    results: rows.map(
-      ({ searchRank: _, searchTotal: __, ...result }) => result,
-    ),
+    hasMore: rows.length > limit,
+    results: rows.slice(0, limit).map(({ searchRank: _, ...result }) => result),
     exactMatch: Number(rows[0]?.searchRank) === 0,
   };
 }
@@ -502,9 +463,9 @@ async function searchMembers(
   context: Context,
   query: string,
   limit: number,
-): Promise<{ total: number; results: MemberResult[]; exactMatch: boolean }> {
+): Promise<{ hasMore: boolean; results: MemberResult[]; exactMatch: boolean }> {
   if (!context.user || !query) {
-    return { total: 0, results: [], exactMatch: false };
+    return { hasMore: false, results: [], exactMatch: false };
   }
   const normalizedQuery = normalizeText(query.replace(/^@/, ""));
   const username = sql`LOWER(unaccent(${users.username}))`;
@@ -525,53 +486,21 @@ async function searchMembers(
       },
       totalTastings: publicTastingCount,
       searchRank: rank,
-      searchTotal: sql<number>`COUNT(*) OVER()`,
     })
     .from(users)
     .leftJoin(tastings, eq(tastings.createdById, users.id))
     .where(where)
     .groupBy(users.id)
-    .limit(limit)
+    .limit(limit + 1)
     .orderBy(rank, sql`${publicTastingCount} DESC`, asc(users.id));
   return {
-    total: Number(rows[0]?.searchTotal ?? 0),
-    results: rows.map((row) => ({
+    hasMore: rows.length > limit,
+    results: rows.slice(0, limit).map((row) => ({
       member: row.member,
       totalTastings: Number(row.totalTastings),
     })),
     exactMatch: Number(rows[0]?.searchRank) === 0,
   };
-}
-
-async function getScopeTotals(
-  database: AnyDatabase,
-  context: Context,
-): Promise<ScopeTotals> {
-  const totals: ScopeTotals = {
-    bottles: await countRows(database, bottles, activeBottleWhere()),
-    series: await countRows(database, bottleSeries, undefined),
-    distilleries: await countRows(
-      database,
-      entities,
-      entityScopeWhere("distilleries"),
-    ),
-    brands: await countRows(database, entities, entityScopeWhere("brands")),
-    bottlers: await countRows(database, entities, entityScopeWhere("bottlers")),
-    companies: await countRows(
-      database,
-      entities,
-      entityScopeWhere("companies"),
-    ),
-    regions: await countRows(database, regions, undefined),
-  };
-  if (context.user) {
-    totals.members = await countRows(
-      database,
-      users,
-      visibleMemberWhere(context),
-    );
-  }
-  return totals;
 }
 
 function entityMatchesScopes(entity: EntityRow, scopes: SearchScope[]) {
@@ -741,12 +670,11 @@ async function findNearest(
   const normalizedQuery = normalizeText(query.replace(/^@/, ""));
   if (!normalizedQuery) return [];
   const prefix = normalizedQuery.slice(0, Math.min(3, normalizedQuery.length));
-  const groups: GroupRows[] = [];
-  for (const scope of scopes) {
-    groups.push(
-      await traceSearchGroup(database, context, scope, prefix, 10, true),
-    );
-  }
+  const groups = await Promise.all(
+    scopes.map((scope) =>
+      traceSearchGroup(database, context, scope, prefix, 10, true),
+    ),
+  );
 
   const nearest: NearestRow[] = [];
   const seen = new Set<string>();
@@ -857,72 +785,41 @@ async function readSearchRows(
     (scope) =>
       input.scopes.includes(scope) && (scope !== "members" || !!context.user),
   );
-  return db.transaction(
-    async (tx) => {
-      // Scope totals are search facets. Each total scans one complete scope,
-      // so callers must request them explicitly.
-      const scopeTotals = input.includeFacets
-        ? await Sentry.startSpan(
-            {
-              name: "search.scope_totals",
-              op: "function",
-              attributes: { "search.authenticated": !!context.user },
-            },
-            () => getScopeTotals(tx, context),
-          )
-        : null;
-      const exact = await Sentry.startSpan(
-        { name: "search.resolve_exact", op: "function" },
-        () => findExact(tx, context, input.query, scopes),
-      );
-      if (parsePeatedId(input.query)) {
-        return {
-          query: input.query,
-          exact,
-          groups: [],
-          scopeTotals,
-          nearest: [],
-        };
-      }
-
-      const groups: GroupRows[] = [];
-      for (const scope of scopes) {
-        groups.push(
-          await traceSearchGroup(
-            tx,
-            context,
-            scope,
-            input.query,
-            input.limit,
-            false,
-          ),
-        );
-      }
-      // Exact name matches own the first group position across search scopes.
-      groups.sort(
-        (left, right) => Number(right.exactMatch) - Number(left.exactMatch),
-      );
-      const matchTotal = groups.reduce(
-        (total, group) => total + group.total,
-        0,
-      );
-      const nearest =
-        input.query && matchTotal === 0
-          ? await Sentry.startSpan(
-              { name: "search.nearest", op: "function" },
-              () => findNearest(tx, context, scopes, input.query),
-            )
-          : [];
-      return {
-        query: input.query,
-        exact: null,
-        groups,
-        scopeTotals,
-        nearest,
-      };
-    },
-    { accessMode: "read only", isolationLevel: "repeatable read" },
+  const exact = await Sentry.startSpan(
+    { name: "search.resolve_exact", op: "function" },
+    () => findExact(db, context, input.query, scopes),
   );
+  if (parsePeatedId(input.query)) {
+    return {
+      query: input.query,
+      exact,
+      groups: [],
+      nearest: [],
+    };
+  }
+
+  const groups = await Promise.all(
+    scopes.map((scope) =>
+      traceSearchGroup(db, context, scope, input.query, input.limit, false),
+    ),
+  );
+  // Exact name matches own the first group position across search scopes.
+  groups.sort(
+    (left, right) => Number(right.exactMatch) - Number(left.exactMatch),
+  );
+  const hasMatches = groups.some((group) => group.results.length > 0);
+  const nearest =
+    input.query && !hasMatches
+      ? await Sentry.startSpan({ name: "search.nearest", op: "function" }, () =>
+          findNearest(db, context, scopes, input.query),
+        )
+      : [];
+  return {
+    query: input.query,
+    exact: null,
+    groups,
+    nearest,
+  };
 }
 
 function bottleResult(row: BottleRow, includeGroup = false): BottleResult {
@@ -965,13 +862,13 @@ function serializeGroup(group: GroupRows) {
     case "bottles":
       return {
         type: group.type,
-        total: group.total,
+        hasMore: group.hasMore,
         results: group.results.map((row) => bottleResult(row, true)),
       };
     case "series":
       return {
         type: group.type,
-        total: group.total,
+        hasMore: group.hasMore,
         results: group.results.map(seriesResult),
       };
     case "distilleries":
@@ -981,13 +878,13 @@ function serializeGroup(group: GroupRows) {
     case "regions":
       return {
         type: group.type,
-        total: group.total,
+        hasMore: group.hasMore,
         results: group.results,
       };
     case "members":
       return {
         type: group.type,
-        total: group.total,
+        hasMore: group.hasMore,
         results: group.results.map(memberResult),
       };
   }
@@ -1035,7 +932,6 @@ function serializeSearch(rows: SearchRows) {
     query: rows.query,
     exact,
     groups,
-    scopeTotals: rows.scopeTotals,
     nearest,
   });
 }

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -510,20 +510,10 @@ async function handleRpcRequest({ request, response, url }) {
             ? exactSearchBottle
             : existingBottle,
       );
-      const scopeTotals = {
-        bottles: 1,
-        distilleries: 0,
-        brands: 0,
-        bottlers: 0,
-        companies: 0,
-        regions: 0,
-      };
-      if (getAccessToken(request)) scopeTotals.members = 0;
       sendRpcResponse(response, {
         query: input.query ?? "",
         exact: null,
-        groups: [{ type: "bottles", total: 1, results: [bottle] }],
-        scopeTotals,
+        groups: [{ type: "bottles", hasMore: false, results: [bottle] }],
         nearest: [],
       });
       return true;

--- a/apps/web/src/app/(app)/search/page.tsx
+++ b/apps/web/src/app/(app)/search/page.tsx
@@ -70,7 +70,11 @@ export default async function SearchPage(props: {
       ? "all"
       : requestedScope;
   const searchScopes = databaseSearch
-    ? apiScopes.filter((scope) => Boolean(session.user) || scope !== "members")
+    ? selectedScope === "all"
+      ? apiScopes.filter(
+          (scope) => Boolean(session.user) || scope !== "members",
+        )
+      : [selectedScope]
     : memberSearch
       ? (["members"] as const)
       : (["bottles"] as const);
@@ -79,7 +83,6 @@ export default async function SearchPage(props: {
     getPublicStats(),
     query
       ? client.search({
-          includeFacets: databaseSearch,
           limit: searchLimit,
           query,
           scopes: [...searchScopes],

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -82,14 +82,11 @@ type MemberSearchResult = Extract<
 export type SearchScope = (typeof searchScopes)[number]["value"];
 
 type SearchSnapshot = {
-  count: number;
   emptyText?: string;
   groups: SearchResultGroup[];
   hasExact: boolean;
   query: string;
   scope: SearchScope;
-  scopeCounts: Record<SearchScope, number>;
-  scopeTotals: SearchResponse["scopeTotals"];
 };
 
 export type SearchProps = {
@@ -116,7 +113,6 @@ export type SearchProps = {
 };
 
 const SEARCH_DEBOUNCE_MS = 140;
-const SEARCH_INDICATOR_FLOOR_MS = 250;
 
 function getDefaultContributionHref(query: string) {
   return getCreateBottleHref({ query });
@@ -135,12 +131,6 @@ function recentSearchGroups(searches: readonly string[]): SearchResultGroup[] {
       label: "Recent searches",
     },
   ];
-}
-
-function waitForSearchIndicator() {
-  return new Promise<void>((resolve) => {
-    window.setTimeout(resolve, SEARCH_INDICATOR_FLOOR_MS);
-  });
 }
 
 function isSearchScope(value: string): value is SearchScope {
@@ -303,7 +293,6 @@ function resultGroups(
         id: "exact",
         items: [exactItem(response.exact, bottleOptions)],
         label: "Exact match",
-        total: 1,
       },
     ];
   }
@@ -318,10 +307,9 @@ function resultGroups(
         items,
         label: getGroupLabel(group.type),
         moreHref:
-          showMoreLinks && group.total > items.length
+          showMoreLinks && group.hasMore
             ? getMoreHref(query, group.type)
             : undefined,
-        total: group.total,
       },
     ];
   });
@@ -353,27 +341,6 @@ function exactMatchesScope(exact: SearchExact, scope: SearchScope) {
   );
 }
 
-function getResultCount(response: SearchResponse, scope: SearchScope) {
-  if (response.exact && exactMatchesScope(response.exact, scope)) return 1;
-  return response.groups.reduce(
-    (total, group) =>
-      total + (groupMatchesScope(group.type, scope) ? group.total : 0),
-    0,
-  );
-}
-
-function getResultScopeTotals(response: SearchResponse) {
-  return {
-    all: getResultCount(response, "all"),
-    bottles: getResultCount(response, "bottles"),
-    series: getResultCount(response, "series"),
-    distilleries: getResultCount(response, "distilleries"),
-    brands: getResultCount(response, "brands"),
-    bottlers: getResultCount(response, "bottlers"),
-    members: getResultCount(response, "members"),
-  } satisfies Record<SearchScope, number>;
-}
-
 function getSearchSnapshot(
   response: SearchResponse,
   query: string,
@@ -381,23 +348,25 @@ function getSearchSnapshot(
   bottleOptions: BottleItemOptions,
   showMoreLinks: boolean,
 ): SearchSnapshot {
-  const count = getResultCount(response, scope);
+  const hasResults = Boolean(
+    (response.exact && exactMatchesScope(response.exact, scope)) ||
+    response.groups.some(
+      (group) =>
+        groupMatchesScope(group.type, scope) && group.results.length > 0,
+    ),
+  );
   return {
-    count,
-    emptyText:
-      count > 0
-        ? undefined
-        : response.nearest.length
-          ? `No exact matches for “${query}”.`
-          : `Nothing matches “${query}”.`,
+    emptyText: hasResults
+      ? undefined
+      : response.nearest.length
+        ? `No exact matches for “${query}”.`
+        : `Nothing matches “${query}”.`,
     groups: resultGroups(response, query, bottleOptions, showMoreLinks, scope),
     hasExact: Boolean(
       response.exact && exactMatchesScope(response.exact, scope),
     ),
     query,
     scope,
-    scopeCounts: getResultScopeTotals(response),
-    scopeTotals: response.scopeTotals,
   };
 }
 
@@ -423,18 +392,6 @@ function nearestItem(nearest: SearchNearest, bottleOptions: BottleItemOptions) {
     case "members":
       return memberItem(nearest.result);
   }
-}
-
-function getScopeCount(
-  scope: SearchScope,
-  totals: SearchResponse["scopeTotals"] | undefined,
-) {
-  if (!totals) return undefined;
-  if (scope !== "all") return totals[scope];
-  return Object.values(totals).reduce<number>(
-    (total, count) => total + (count ?? 0),
-    0,
-  );
 }
 
 export function Search({
@@ -490,6 +447,7 @@ export function Search({
   const [status, setStatus] = useState<"error" | "ready" | "searching">(
     initialQuery.trim() && !initialSnapshot ? "searching" : "ready",
   );
+  const activeRequest = useRef<AbortController | undefined>(undefined);
   const latestRequest = useRef(0);
   const initialSearchStarted = useRef(Boolean(initialSnapshot));
   const previousInitialQuery = useRef(initialQuery);
@@ -504,45 +462,36 @@ export function Search({
     snapshot?.query === query.trim() && snapshot.scope === effectiveScope
       ? snapshot
       : undefined;
-  const availableScopes = availableScopeDefinitions.map((option) => ({
-    ...option,
-    count: getScopeCount(option.value, currentSnapshot?.scopeTotals),
-  }));
+  const availableScopes = availableScopeDefinitions;
   const availableScopeFacets = currentSnapshot
-    ? availableScopeDefinitions.map((option) => ({
-        ...option,
-        count: currentSnapshot.scopeCounts[option.value],
-      }))
+    ? availableScopeDefinitions
     : undefined;
 
   const runSearch = useCallback(
     async (nextQuery: string, nextScope: SearchScope) => {
       const requestId = latestRequest.current + 1;
       latestRequest.current = requestId;
+      activeRequest.current?.abort();
       const trimmedQuery = nextQuery.trim();
       if (!trimmedQuery) {
+        activeRequest.current = undefined;
         setSnapshot(undefined);
         setStatus("ready");
         return;
       }
 
+      const request = new AbortController();
+      activeRequest.current = request;
       setStatus("searching");
-      const indicatorFloor = waitForSearchIndicator();
       try {
-        const [response] = await Promise.all([
-          orpc.search.call({
-            includeFacets: placement === "database",
+        const response = await orpc.search.call(
+          {
             limit: placement === "database" && nextScope !== "all" ? 50 : limit,
             query: trimmedQuery,
-            scopes: [
-              ...getApiScopes(
-                placement === "database" ? "all" : nextScope,
-                Boolean(user),
-              ),
-            ],
-          }),
-          indicatorFloor,
-        ]);
+            scopes: [...getApiScopes(nextScope, Boolean(user))],
+          },
+          { signal: request.signal },
+        );
         if (latestRequest.current !== requestId) return;
         setSnapshot(
           getSearchSnapshot(
@@ -555,16 +504,26 @@ export function Search({
         );
         setStatus("ready");
       } catch {
-        await indicatorFloor;
+        if (request.signal.aborted) return;
         if (latestRequest.current !== requestId) return;
         setStatus("error");
+      } finally {
+        if (activeRequest.current === request) {
+          activeRequest.current = undefined;
+        }
       }
     },
     [getBottleHref, limit, orpc, placement, showBottleRatings, user],
   );
   const debouncedSearch = useDebounceCallback(runSearch, SEARCH_DEBOUNCE_MS);
 
-  useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch]);
+  useEffect(
+    () => () => {
+      debouncedSearch.cancel();
+      activeRequest.current?.abort();
+    },
+    [debouncedSearch],
+  );
 
   useEffect(() => {
     if (placement !== "database") return;
@@ -599,6 +558,7 @@ export function Search({
     setQuery(nextQuery);
     // Invalidate the current request before the next debounced request starts.
     latestRequest.current += 1;
+    activeRequest.current?.abort();
     if (!nextQuery.trim()) {
       debouncedSearch.cancel();
       setSnapshot(undefined);
@@ -670,7 +630,6 @@ export function Search({
       placement={placement}
       placeholder={placeholder}
       query={query}
-      resultCount={currentSnapshot?.count}
       resultQuery={snapshot?.query}
       scope={effectiveScope}
       scopeFacets={availableScopeFacets}

--- a/apps/web/src/components/searchBox.stylex.tsx
+++ b/apps/web/src/components/searchBox.stylex.tsx
@@ -49,7 +49,6 @@ export type SearchBoxProps = Pick<
   placeholder?: string;
   placement?: "database" | "overlay" | "page";
   query: string;
-  resultCount?: number;
   resultQuery?: string;
   scope: string;
   scopeFacets?: readonly ScopedSearchOption[];
@@ -77,7 +76,6 @@ export function SearchBox({
   placeholder = "bottles, distillers, brands…",
   placement = "overlay",
   query,
-  resultCount,
   resultQuery = query,
   scope,
   scopeFacets,
@@ -331,18 +329,6 @@ export function SearchBox({
                   </FilterPanel>
                 </div>
               ) : null}
-              {status === "ready" && resultCount !== undefined ? (
-                <p
-                  aria-live="polite"
-                  {...stylex.props(
-                    foundationStyles.rowTitle,
-                    styles.databaseCount,
-                  )}
-                >
-                  {resultCount.toLocaleString("en-US")}{" "}
-                  {resultCount === 1 ? "result" : "results"}
-                </p>
-              ) : null}
               {expanded ? (
                 <SearchResults
                   activeId={typeaheadNavigation ? activeId : undefined}
@@ -459,17 +445,6 @@ const styles = stylex.create({
   databaseSearchControl: {
     minWidth: 0,
     flex: 1,
-  },
-  databaseCount: {
-    marginTop: space.x4,
-    marginRight: 0,
-    marginBottom: 0,
-    marginLeft: 0,
-    paddingBottom: space.x3,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
-    color: colors.ink,
   },
   databaseFacets: {
     minWidth: 0,

--- a/apps/web/src/components/searchBox.test.tsx
+++ b/apps/web/src/components/searchBox.test.tsx
@@ -3,45 +3,6 @@ import { describe, expect, it } from "vitest";
 
 import { SearchBox } from "./searchBox.stylex";
 
-function renderDatabaseSearch({
-  resultCount,
-  status,
-}: {
-  resultCount?: number;
-  status: "ready" | "searching";
-}) {
-  return renderToStaticMarkup(
-    <SearchBox
-      emptyText={status === "ready" ? "Nothing matches this query." : undefined}
-      groups={[]}
-      onQueryChange={() => undefined}
-      onScopeChange={() => undefined}
-      placement="database"
-      query="lagavulin"
-      resultCount={resultCount}
-      scope="all"
-      scopes={[{ label: "Everything", value: "all" }]}
-      status={status}
-      statusText="Searching bottles, brands, and producers…"
-    />,
-  );
-}
-
-describe("SearchBox database result count", () => {
-  it("does not show an unsettled count while searching", () => {
-    const html = renderDatabaseSearch({ resultCount: 0, status: "searching" });
-
-    expect(html).not.toContain("0 results");
-    expect(html).toContain("Searching bottles, brands, and producers");
-  });
-
-  it("shows zero after the search settles", () => {
-    const html = renderDatabaseSearch({ resultCount: 0, status: "ready" });
-
-    expect(html).toContain("0 results");
-  });
-});
-
 describe("SearchBox database empty state", () => {
   it("shows recent searches when the query is empty", () => {
     const html = renderToStaticMarkup(


### PR DESCRIPTION
Search now returns the first matches without first counting every match. Searches across bottles, series, members, and producers run at the same time, while choosing a type searches only that type. The page also removes its extra quarter-second wait and replaces older browser requests as people type. Ranking, exact matches, alternate names, spelling suggestions, member privacy, and “See all” behavior remain unchanged.

This changes the search API: each result group now returns `hasMore` instead of `total`, and `scopeTotals` and `includeFacets` are removed. Callers that displayed counts should use `hasMore` only to decide whether to show “See all.” Search checks, web checks, and five full browser flows pass.
