### PR TITLE
perf(web): prefetch bottle tabs

### DIFF
--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -427,6 +427,7 @@ export function BottlePageFrameClient({
             ariaLabel="Bottle sections"
             currentHref={currentHref}
             items={getTabs(bottle)}
+            prefetch
           />
         </div>
         <div {...stylex.props(styles.overview)}>{children}</div>

--- a/apps/web/src/components/pageTabs.stylex.tsx
+++ b/apps/web/src/components/pageTabs.stylex.tsx
@@ -20,10 +20,17 @@ export type PageTabsProps = {
   ariaLabel: string;
   currentHref: string;
   items: readonly [PageTabItem, ...PageTabItem[]];
+  /** Overrides Next's automatic prefetch behavior for every tab. */
+  prefetch?: boolean | null;
 };
 
 /** Shows peer destinations within one page or section. */
-export function PageTabs({ ariaLabel, currentHref, items }: PageTabsProps) {
+export function PageTabs({
+  ariaLabel,
+  currentHref,
+  items,
+  prefetch,
+}: PageTabsProps) {
   return (
     <nav aria-label={ariaLabel} {...stylex.props(styles.tabs)}>
       {items.map((item) => {
@@ -34,6 +41,7 @@ export function PageTabs({ ariaLabel, currentHref, items }: PageTabsProps) {
             aria-current={current ? "page" : undefined}
             href={item.href}
             key={item.href}
+            prefetch={prefetch}
             {...stylex.props(
               foundationStyles.interactive,
               styles.tab,


### PR DESCRIPTION
Bottle detail pages now fully prefetch the small Overview, Tastings, and Prices tab set so moving between those high-intent destinations can reuse a complete route payload instead of waiting for dynamic route data after each click. Other `PageTabs` instances keep Next.js's automatic prefetch behavior.
