### PR TITLE
style(web): prioritize bottle catalog search

### DIFF
--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -12,6 +12,7 @@ import { addBottleRowActions } from "@peated/web/components/bottleRowActions.sty
 import {
   BottleCatalogFilters,
   BottleCatalogList,
+  BottleCatalogSearch,
   type BottleCatalogFilterOption,
 } from "@peated/web/components/pages/bottleCatalog.stylex";
 import { CatalogPage } from "@peated/web/components/pages/catalogPage.stylex";
@@ -234,6 +235,12 @@ export function BottleCatalogPageClient({
           searchParams,
           bottleList.rel.prevCursor,
         )}
+        search={
+          <BottleCatalogSearch
+            onSubmit={(value) => updateParams({ query: value.trim() })}
+            query={displayedSearchParams.get("query") ?? ""}
+          />
+        }
         sort={sort}
         sortOptions={sortOptions}
         total={bottleList.total}

--- a/apps/web/src/components/filterPanel.stylex.tsx
+++ b/apps/web/src/components/filterPanel.stylex.tsx
@@ -23,6 +23,7 @@ export type FilterPanelProps = {
   children: ReactNode;
   onClear?: () => void;
   query?: FilterQueryProps;
+  queryVisibility?: "all" | "narrow";
 };
 
 /** Keeps a page's filters visible on wide screens and disclosed on narrow ones. */
@@ -31,6 +32,7 @@ export function FilterPanel({
   children,
   onClear,
   query,
+  queryVisibility = "all",
 }: FilterPanelProps) {
   const contentId = useId();
   const [open, setOpen] = useState(false);
@@ -48,7 +50,13 @@ export function FilterPanel({
   return (
     <section aria-label={ariaLabel} {...stylex.props(styles.root)}>
       {query ? (
-        <FilterQueryForm filterToggle={toggle} {...query} />
+        queryVisibility === "narrow" ? (
+          <div {...stylex.props(styles.narrowQuery)}>
+            <FilterQueryForm filterToggle={toggle} {...query} />
+          </div>
+        ) : (
+          <FilterQueryForm filterToggle={toggle} {...query} />
+        )
       ) : (
         <button
           aria-controls={contentId}
@@ -65,7 +73,10 @@ export function FilterPanel({
         id={contentId}
         {...stylex.props(
           styles.content,
-          query && styles.contentAfterQuery,
+          query &&
+            (queryVisibility === "narrow"
+              ? styles.contentAfterNarrowQuery
+              : styles.contentAfterQuery),
           open && styles.contentOpen,
         )}
       >
@@ -281,6 +292,15 @@ const styles = stylex.create({
   },
   contentAfterQuery: {
     marginTop: space.x4,
+  },
+  contentAfterNarrowQuery: {
+    marginTop: { default: 0, [NARROW]: space.x4 },
+  },
+  narrowQuery: {
+    display: "none",
+    [NARROW]: {
+      display: "block",
+    },
   },
   contentOpen: {
     [NARROW]: {

--- a/apps/web/src/components/pages/bottleCatalog.stories.tsx
+++ b/apps/web/src/components/pages/bottleCatalog.stories.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { mockBottles } from "@peated/server/orpc/mock/fixtures";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+
+import { StoryCanvas } from "../storyFixtures.stylex";
+import {
+  BottleCatalogFilters,
+  BottleCatalogList,
+  BottleCatalogSearch,
+} from "./bottleCatalog.stylex";
+import { CatalogPage } from "./catalogPage.stylex";
+
+const meta = {
+  title: "Pages/Bottle Catalog",
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="page">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Bottle search leads the results column on wide screens. On narrow screens it returns to the filter panel beside the filter toggle, while Category and Age statement remain discoverable.",
+      },
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+  render: () => <BottleCatalogExample />,
+};
+
+function BottleCatalogExample() {
+  const [filters, setFilters] = useState({
+    ageBand: "",
+    category: "",
+    query: "",
+  });
+
+  function updateFilter(name: "ageBand" | "category", value: string) {
+    setFilters((current) => ({ ...current, [name]: value }));
+  }
+
+  function clearFilters() {
+    setFilters({ ageBand: "", category: "", query: "" });
+  }
+
+  return (
+    <CatalogPage
+      filters={
+        <BottleCatalogFilters
+          age=""
+          ageBand={filters.ageBand}
+          ageBandOptions={[
+            { label: "NAS", value: "nas" },
+            { label: "12–17 years", value: "12_17" },
+            { label: "18–24 years", value: "18_24" },
+          ]}
+          category={filters.category}
+          categoryOptions={[
+            { label: "Single malt", value: "single_malt" },
+            { label: "Blended malt", value: "blended_malt" },
+            { label: "Bourbon", value: "bourbon" },
+          ]}
+          onChange={updateFilter}
+          onClear={clearFilters}
+          onQuerySubmit={(query) =>
+            setFilters((current) => ({ ...current, query }))
+          }
+          query={filters.query}
+        />
+      }
+      title="Bottles"
+    >
+      <BottleCatalogList
+        items={mockBottles
+          .slice(0, 4)
+          .map((bottle) => toBottleListItem(bottle, { includeRatings: true }))}
+        onSortChange={() => undefined}
+        page={1}
+        search={
+          <BottleCatalogSearch
+            onSubmit={(query) =>
+              setFilters((current) => ({ ...current, query }))
+            }
+            query={filters.query}
+          />
+        }
+        sort="-release"
+        sortOptions={[
+          { label: "Latest release", value: "-release" },
+          { label: "Highest score", value: "-score" },
+        ]}
+        total={mockBottles.length}
+      />
+    </CatalogPage>
+  );
+}

--- a/apps/web/src/components/pages/bottleCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/bottleCatalog.stylex.tsx
@@ -11,11 +11,15 @@ import {
   EmptyState,
   FacetGroup,
   FilterPanel,
+  FilterQuery,
   ListToolbar,
   type BottleListItem,
   type ListSortOption,
 } from "..";
+import { space } from "../../styles/tokens.stylex";
 import { CatalogPageLoading } from "./catalogPage.stylex";
+
+const NARROW = "@media (max-width: 759px)";
 
 export type BottleCatalogListProps = {
   emptyAction?: ReactNode;
@@ -28,6 +32,7 @@ export type BottleCatalogListProps = {
   page: number;
   pending?: boolean;
   previousHref?: string;
+  search?: ReactNode;
   sort: string;
   sortOptions: readonly [ListSortOption, ...ListSortOption[]];
   total?: number;
@@ -45,12 +50,14 @@ export function BottleCatalogList({
   page,
   pending = false,
   previousHref,
+  search,
   sort,
   sortOptions,
   total,
 }: BottleCatalogListProps) {
   return (
     <section aria-label="Bottle catalog" {...stylex.props(styles.catalog)}>
+      {search}
       <ListToolbar
         count={items.length}
         noun="bottle"
@@ -97,6 +104,26 @@ export function BottleCatalogList({
   );
 }
 
+/** Keeps bottle-name search primary on wide catalog layouts. */
+export function BottleCatalogSearch({
+  onSubmit,
+  query,
+}: {
+  onSubmit: (value: string) => void;
+  query: string;
+}) {
+  return (
+    <div {...stylex.props(styles.desktopSearch)}>
+      <FilterQuery
+        label="Find a bottle"
+        onSubmit={onSubmit}
+        placeholder="Name, brand, or release"
+        query={query}
+      />
+    </div>
+  );
+}
+
 export type BottleCatalogFilterOption = {
   label: string;
   value: string;
@@ -138,6 +165,7 @@ export function BottleCatalogFilters({
         placeholder: "Name, brand, or release",
         query,
       }}
+      queryVisibility="narrow"
     >
       <FacetGroup
         label="Category"
@@ -162,5 +190,11 @@ export function BottleCatalogLoading() {
 const styles = stylex.create({
   catalog: {
     minWidth: 0,
+  },
+  desktopSearch: {
+    marginBottom: space.x4,
+    [NARROW]: {
+      display: "none",
+    },
   },
 });

--- a/apps/web/src/components/pages/catalogPage.stylex.tsx
+++ b/apps/web/src/components/pages/catalogPage.stylex.tsx
@@ -57,7 +57,7 @@ export function CatalogPageLoading({
   return (
     <CatalogPage
       action={action ? <span {...stylex.props(styles.loadingAction)} /> : null}
-      filters={<CatalogFiltersLoading />}
+      filters={<CatalogFiltersLoading query={variant === "bottle"} />}
       navigation={
         navigation ? (
           <div {...stylex.props(styles.loadingNavigation)}>
@@ -69,6 +69,12 @@ export function CatalogPageLoading({
       title={title}
     >
       <div {...stylex.props(styles.loadingResults)}>
+        {variant === "bottle" ? (
+          <div {...stylex.props(styles.loadingSearch)}>
+            <LoadingPlaceholder preset="metadata" />
+            <span {...stylex.props(styles.loadingSearchControl)} />
+          </div>
+        ) : null}
         <div {...stylex.props(styles.loadingToolbar)}>
           <LoadingPlaceholder preset="text" />
           <span {...stylex.props(styles.loadingSort)} />
@@ -83,7 +89,7 @@ export function CatalogPageLoading({
   );
 }
 
-function CatalogFiltersLoading() {
+function CatalogFiltersLoading({ query }: { query: boolean }) {
   return (
     <div
       aria-busy="true"
@@ -92,7 +98,7 @@ function CatalogFiltersLoading() {
       {...stylex.props(styles.loadingFilterPanel)}
     >
       <LoadingPlaceholder preset="metadata" />
-      <span {...stylex.props(styles.loadingFilterControl)} />
+      {query ? <span {...stylex.props(styles.loadingFilterControl)} /> : null}
       <div {...stylex.props(styles.loadingFacet)}>
         <LoadingPlaceholder delay={1} preset="metadata" />
         {([0, 1, 2, 3] as const).map((delay) => (
@@ -149,6 +155,21 @@ const styles = stylex.create({
     flexDirection: "column",
     gap: space.x4,
   },
+  loadingSearch: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space.x2,
+    [NARROW]: {
+      display: "none",
+    },
+  },
+  loadingSearchControl: {
+    display: "block",
+    width: "min(100%, 520px)",
+    height: "34px",
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.surface,
+  },
   loadingAction: {
     width: "104px",
     height: "34px",
@@ -189,11 +210,14 @@ const styles = stylex.create({
     borderColor: colors.hairline,
   },
   loadingFilterControl: {
-    display: "block",
+    display: "none",
     width: "100%",
     height: "38px",
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.surface,
+    [NARROW]: {
+      display: "block",
+    },
   },
   loadingFacet: {
     display: "flex",


### PR DESCRIPTION
Bottle search now leads the results column on desktop, while Category and Age statement remain in the filter rail. Mobile keeps the existing combined search and filter control, and the loading state follows the same responsive placement.

The catalog Storybook example documents both compositions and keeps query state shared across the responsive controls.

Refs #1064
