### PR TITLE
fix(home): balance and cache activity feed

### DIFF
--- a/apps/web/src/app/(app)/_components/home/homeActivity.test.ts
+++ b/apps/web/src/app/(app)/_components/home/homeActivity.test.ts
@@ -1,0 +1,75 @@
+import type { CommunityFeedItem } from "@peated/web/components/communityFeed.stylex";
+import { expect, test } from "vitest";
+import { selectHomeActivityItems } from "./homeActivity";
+
+function activityItem({
+  id,
+  kind,
+  hour,
+}: {
+  id: string;
+  kind: CommunityFeedItem["kind"];
+  hour: number;
+}): CommunityFeedItem {
+  return {
+    id,
+    kind,
+    actor: "Member",
+    action: "added activity",
+    date: `2026-09-05T${String(hour).padStart(2, "0")}:00:00.000Z`,
+    bottles: [],
+  };
+}
+
+test("shows the newest five when critic and community activity are represented", () => {
+  const items = [
+    activityItem({ id: "community-6", kind: "tasting", hour: 6 }),
+    activityItem({ id: "critic-5", kind: "critic_review", hour: 5 }),
+    activityItem({ id: "community-4", kind: "member_review", hour: 4 }),
+    activityItem({ id: "community-3", kind: "collection_add", hour: 3 }),
+    activityItem({ id: "critic-2", kind: "critic_review", hour: 2 }),
+    activityItem({ id: "community-1", kind: "tasting", hour: 1 }),
+  ];
+
+  expect(selectHomeActivityItems(items).map((item) => item.id)).toEqual([
+    "community-6",
+    "critic-5",
+    "community-4",
+    "community-3",
+    "critic-2",
+  ]);
+});
+
+test("includes the newest community item when critic reviews fill the newest five", () => {
+  const items = [
+    ...[6, 5, 4, 3, 2].map((hour) =>
+      activityItem({ id: `critic-${hour}`, kind: "critic_review", hour }),
+    ),
+    activityItem({ id: "community-1", kind: "tasting", hour: 1 }),
+  ];
+
+  expect(selectHomeActivityItems(items).map((item) => item.id)).toEqual([
+    "critic-6",
+    "critic-5",
+    "critic-4",
+    "critic-3",
+    "community-1",
+  ]);
+});
+
+test("includes the newest critic review when community activity fills the newest five", () => {
+  const items = [
+    ...[6, 5, 4, 3, 2].map((hour) =>
+      activityItem({ id: `community-${hour}`, kind: "tasting", hour }),
+    ),
+    activityItem({ id: "critic-1", kind: "critic_review", hour: 1 }),
+  ];
+
+  expect(selectHomeActivityItems(items).map((item) => item.id)).toEqual([
+    "community-6",
+    "community-5",
+    "community-4",
+    "community-3",
+    "critic-1",
+  ]);
+});

--- a/apps/web/src/app/(app)/_components/home/homeActivity.ts
+++ b/apps/web/src/app/(app)/_components/home/homeActivity.ts
@@ -1,0 +1,27 @@
+import type { CommunityFeedItem } from "@peated/web/components/communityFeed.stylex";
+
+const HOME_ACTIVITY_LIMIT = 5;
+
+/** Homepage rule: represent both critic reviews and community activity when available. */
+export function selectHomeActivityItems(
+  items: readonly CommunityFeedItem[],
+): CommunityFeedItem[] {
+  const ordered = [...items].sort(
+    (left, right) => Date.parse(right.date) - Date.parse(left.date),
+  );
+  const selected = ordered.slice(0, HOME_ACTIVITY_LIMIT);
+
+  if (selected.length < 2) return selected;
+
+  const missingItem = selected.every((item) => item.kind === "critic_review")
+    ? ordered.find((item) => item.kind !== "critic_review")
+    : selected.every((item) => item.kind !== "critic_review")
+      ? ordered.find((item) => item.kind === "critic_review")
+      : undefined;
+
+  if (!missingItem) return selected;
+
+  return [...selected.slice(0, -1), missingItem].sort(
+    (left, right) => Date.parse(right.date) - Date.parse(left.date),
+  );
+}

--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -33,6 +33,7 @@ import {
   publicHomeQueries,
 } from "@peated/web/lib/orpc/homeQueries";
 import { getEntityUrl } from "@peated/web/lib/urls";
+import { selectHomeActivityItems } from "./homeActivity";
 import { HomeEventCallout } from "./homeEventCallout.stylex";
 import {
   PublicHomeContentLayout,
@@ -188,20 +189,20 @@ function LatestReleases() {
 
 function Activity() {
   const orpc = useORPC();
-  const externalReviews = useQuery(publicHomeQueries.recentReviews(orpc));
-  const activity = useQuery(publicHomeQueries.memberActivity(orpc));
+  const communityActivity = useQuery(publicHomeQueries.communityActivity(orpc));
+  const criticReviews = useQuery(publicHomeQueries.criticReviews(orpc));
 
-  if (activity.isPending && externalReviews.isPending) {
+  if (communityActivity.isPending && criticReviews.isPending) {
     return <HomeActivityFeedLoading />;
   }
 
-  if (activity.error && externalReviews.error) {
+  if (communityActivity.error && criticReviews.error) {
     return (
       <SectionError
         heading="Activity is unavailable"
         onRetry={() => {
-          void activity.refetch();
-          void externalReviews.refetch();
+          void communityActivity.refetch();
+          void criticReviews.refetch();
         }}
       >
         We couldn't load the latest activity. The rest of the database is still
@@ -210,16 +211,16 @@ function Activity() {
     );
   }
 
-  const memberActivity = activity.data?.results ?? [];
-  const criticReviews = externalReviews.data?.results ?? [];
-  const items = getCommunityFeedItems({
-    criticReviews,
-    activity: memberActivity,
-  });
+  const items = selectHomeActivityItems(
+    getCommunityFeedItems({
+      criticReviews: criticReviews.data?.results ?? [],
+      activity: communityActivity.data?.results ?? [],
+    }),
+  );
 
   return items.length ? (
     <HomeActivityFeed>
-      <CommunityFeed ariaLabel="Recent activity" items={items} limit={3} />
+      <CommunityFeed ariaLabel="Recent activity" items={items} />
     </HomeActivityFeed>
   ) : null;
 }

--- a/apps/web/src/app/(app)/homeActivity.server.ts
+++ b/apps/web/src/app/(app)/homeActivity.server.ts
@@ -1,0 +1,47 @@
+"server only";
+
+import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import type { ORPCQueryUtils } from "@peated/web/lib/orpc/context";
+import {
+  homeActivityCriteria,
+  publicHomeQueries,
+} from "@peated/web/lib/orpc/homeQueries";
+import type { QueryClient } from "@tanstack/react-query";
+import { unstable_cache } from "next/cache";
+
+const FIVE_MINUTES_IN_SECONDS = 5 * 60;
+
+// Web caching rule: shared homepage activity always uses an anonymous client.
+const loadPublicHomeCommunityActivity = unstable_cache(
+  async () => {
+    const { client } = await createAnonymousServerClient();
+    return client.activity.list(homeActivityCriteria.community);
+  },
+  ["public-home-community-activity"],
+  { revalidate: FIVE_MINUTES_IN_SECONDS },
+);
+
+const loadPublicHomeCriticReviews = unstable_cache(
+  async () => {
+    const { client } = await createAnonymousServerClient();
+    return client.externalReviews.list(homeActivityCriteria.critics);
+  },
+  ["public-home-critic-reviews"],
+  { revalidate: FIVE_MINUTES_IN_SECONDS },
+);
+
+export async function loadPublicHomeActivity(
+  queryClient: QueryClient,
+  orpc: ORPCQueryUtils,
+) {
+  await Promise.all([
+    queryClient.prefetchQuery({
+      ...publicHomeQueries.communityActivity(orpc),
+      queryFn: loadPublicHomeCommunityActivity,
+    }),
+    queryClient.prefetchQuery({
+      ...publicHomeQueries.criticReviews(orpc),
+      queryFn: loadPublicHomeCriticReviews,
+    }),
+  ]);
+}

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -17,6 +17,7 @@ import { Suspense } from "react";
 
 import { PublicHomeContent } from "./_components/home/publicHome.stylex";
 import { PublicHomeContentLoading } from "./_components/home/publicHomeLayout.stylex";
+import { loadPublicHomeActivity } from "./homeActivity.server";
 import { loadPublicHomeLocations } from "./homeLocations.server";
 import { HomePageClient } from "./homePageClient";
 
@@ -51,8 +52,7 @@ async function HomeContent() {
       queryFn: getPublicStats,
     }),
     queryClient.prefetchQuery(publicHomeQueries.events(orpc)),
-    queryClient.prefetchQuery(publicHomeQueries.memberActivity(orpc)),
-    queryClient.prefetchQuery(publicHomeQueries.recentReviews(orpc)),
+    loadPublicHomeActivity(queryClient, orpc),
     queryClient.prefetchQuery(publicHomeQueries.releases(orpc)),
     loadPublicHomeLocations(queryClient, orpc),
     ...(session.user

--- a/apps/web/src/lib/orpc/homeQueries.ts
+++ b/apps/web/src/lib/orpc/homeQueries.ts
@@ -27,6 +27,14 @@ export const homeLocationCriteria = {
   } satisfies Inputs["regions"]["list"],
 };
 
+export const homeActivityCriteria = {
+  community: { limit: 5 } satisfies Inputs["activity"]["list"],
+  critics: {
+    limit: 5,
+    sort: "recent",
+  } satisfies Inputs["externalReviews"]["list"],
+};
+
 export const publicHomeQueries = {
   stats: (orpc: ORPCQueryUtils) =>
     orpc.stats.queryOptions({
@@ -42,17 +50,17 @@ export const publicHomeQueries = {
     orpc.events.list.queryOptions({
       input: { limit: 1, onlyUpcoming: true, sort: "date" },
     }),
-  memberActivity: (orpc: ORPCQueryUtils) =>
+  communityActivity: (orpc: ORPCQueryUtils) =>
     orpc.activity.list.queryOptions({
-      input: { limit: 3 },
+      input: homeActivityCriteria.community,
     }),
   releases: (orpc: ORPCQueryUtils) =>
     orpc.bottles.list.queryOptions({
       input: { limit: 5, sort: "-release" },
     }),
-  recentReviews: (orpc: ORPCQueryUtils) =>
+  criticReviews: (orpc: ORPCQueryUtils) =>
     orpc.externalReviews.list.queryOptions({
-      input: { limit: 3, sort: "recent" },
+      input: homeActivityCriteria.critics,
     }),
   countries: (orpc: ORPCQueryUtils) =>
     orpc.countries.list.queryOptions({

--- a/docs/architecture/web-caching.md
+++ b/docs/architecture/web-caching.md
@@ -25,6 +25,8 @@ headers prove it.
   The endpoint sends `no-store` to avoid an extra HTTP cache lifetime.
 - `homeLocations.server.ts` caches the homepage country and region lists
   for one hour. Visitors and members use the same public data.
+- `homeActivity.server.ts` caches the homepage community activity and critic
+  review pools for five minutes. Shared reads always use an anonymous client.
 - `publicCatalog.server.ts` caches anonymous entity summaries and first-page
   entity/series bottle lists for five minutes. Keys include entity, series,
   distillery view, sort, and limit. Members, searches, extra filters, later


### PR DESCRIPTION
Homepage Activity now shows five recent items and represents both critic reviews and community contributions when both are available. The selector keeps the newest five by default and only replaces the oldest visible item when all five come from one side.

Both candidate pools use a five-minute shared server cache backed by anonymous API reads. This keeps the homepage cache safe for signed-in visitors while preserving partial results if either activity source is temporarily unavailable.
