### PR TITLE
perf(search): defer possible matches

### DIFF
--- a/apps/server/src/orpc/contracts/search.ts
+++ b/apps/server/src/orpc/contracts/search.ts
@@ -197,6 +197,12 @@ export default contract
           .array(z.enum(SEARCH_SCOPE_LIST))
           .default([...SEARCH_SCOPE_LIST]),
         limit: z.coerce.number().gte(1).lte(50).default(3),
+        suggestions: z
+          .enum(["include", "exclude", "only"])
+          .default("include")
+          .describe(
+            "Include possible matches after an empty result, leave them out, or return only possible matches",
+          ),
       })
       .strict(),
   )

--- a/apps/server/src/orpc/mock/routes/search.ts
+++ b/apps/server/src/orpc/mock/routes/search.ts
@@ -15,6 +15,14 @@ import {
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.search.handler(async ({ input, context }) => {
+  if (input.suggestions === "only") {
+    return SearchOutputSchema.parse({
+      query: input.query,
+      exact: null,
+      groups: [],
+      nearest: [],
+    });
+  }
   const groups: MockOutputs["search"]["groups"] = [];
   const entities = mockEntities.map((entity) =>
     mockEntityFor(Boolean(context.user), entity),

--- a/apps/server/src/orpc/routes/search.test.ts
+++ b/apps/server/src/orpc/routes/search.test.ts
@@ -379,6 +379,39 @@ describe("GET /search", () => {
     ]);
   });
 
+  test("can return an empty result without waiting for possible matches", async ({
+    fixtures,
+  }) => {
+    await fixtures.Bottle({ name: "Laphroaig" });
+
+    const data = await routerClient.search({
+      query: "Laphroaigg",
+      scopes: ["bottles"],
+      suggestions: "exclude",
+    });
+
+    expect(data.groups).toMatchObject([
+      { type: "bottles", hasMore: false, results: [] },
+    ]);
+    expect(data.nearest).toEqual([]);
+  });
+
+  test("can return only possible matches", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle({ name: "Laphroaig" });
+
+    const data = await routerClient.search({
+      query: "Laphroaigg",
+      scopes: ["bottles"],
+      suggestions: "only",
+    });
+
+    expect(data.exact).toBeNull();
+    expect(data.groups).toEqual([]);
+    expect(data.nearest).toMatchObject([
+      { type: "bottles", result: { id: bottle.id } },
+    ]);
+  });
+
   test("resolves Bottle, Entity, and Series Peated ID tombstones directly", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/search.ts
+++ b/apps/server/src/orpc/routes/search.ts
@@ -127,6 +127,7 @@ type SearchInput = {
   query: string;
   scopes: SearchScope[];
   limit: number;
+  suggestions: "exclude" | "include" | "only";
 };
 
 function normalizeText(value: string) {
@@ -785,6 +786,21 @@ async function readSearchRows(
     (scope) =>
       input.scopes.includes(scope) && (scope !== "members" || !!context.user),
   );
+  if (input.suggestions === "only") {
+    const nearest =
+      input.query && !parsePeatedId(input.query)
+        ? await Sentry.startSpan(
+            { name: "search.nearest", op: "function" },
+            () => findNearest(db, context, scopes, input.query),
+          )
+        : [];
+    return {
+      query: input.query,
+      exact: null,
+      groups: [],
+      nearest,
+    };
+  }
   const exact = await Sentry.startSpan(
     { name: "search.resolve_exact", op: "function" },
     () => findExact(db, context, input.query, scopes),
@@ -809,7 +825,7 @@ async function readSearchRows(
   );
   const hasMatches = groups.some((group) => group.results.length > 0);
   const nearest =
-    input.query && !hasMatches
+    input.suggestions === "include" && input.query && !hasMatches
       ? await Sentry.startSpan({ name: "search.nearest", op: "function" }, () =>
           findNearest(db, context, scopes, input.query),
         )

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -101,6 +101,8 @@ let collectionBottleId = 1;
 let pendingUploadId = 1;
 let releasePageReady = Promise.resolve();
 let releasePage = () => {};
+let searchSuggestionsReady = Promise.resolve();
+let releaseSearchSuggestions = () => {};
 
 const bottleCheckMock = createBottleCheckMock({
   exactMatchedBottleId,
@@ -163,6 +165,24 @@ const server = http.createServer(async (request, response) => {
     url.pathname === "/__test/release-pages/resume"
   ) {
     releasePage();
+    response.writeHead(204, corsHeaders).end();
+    return;
+  }
+  if (
+    request.method === "POST" &&
+    url.pathname === "/__test/search-suggestions/hold"
+  ) {
+    searchSuggestionsReady = new Promise((resolve) => {
+      releaseSearchSuggestions = resolve;
+    });
+    response.writeHead(204, corsHeaders).end();
+    return;
+  }
+  if (
+    request.method === "POST" &&
+    url.pathname === "/__test/search-suggestions/resume"
+  ) {
+    releaseSearchSuggestions();
     response.writeHead(204, corsHeaders).end();
     return;
   }
@@ -510,6 +530,25 @@ async function handleRpcRequest({ request, response, url }) {
             ? exactSearchBottle
             : existingBottle,
       );
+      if (input?.query === "playwright typo") {
+        if (input?.suggestions === "only") {
+          await searchSuggestionsReady;
+          sendRpcResponse(response, {
+            query: input.query,
+            exact: null,
+            groups: [],
+            nearest: [{ type: "bottles", result: bottle }],
+          });
+          return true;
+        }
+        sendRpcResponse(response, {
+          query: input.query,
+          exact: null,
+          groups: [{ type: "bottles", hasMore: false, results: [] }],
+          nearest: [],
+        });
+        return true;
+      }
       sendRpcResponse(response, {
         query: input.query ?? "",
         exact: null,

--- a/apps/web/e2e/search.spec.ts
+++ b/apps/web/e2e/search.spec.ts
@@ -1,0 +1,27 @@
+import { mockApiServer } from "./rpc-fixtures.mjs";
+import { expect, test } from "./test";
+
+test.describe("Search", () => {
+  test("shows an empty result before loading a possible match", async ({
+    page,
+    request,
+  }) => {
+    await request.post(`${mockApiServer}/__test/search-suggestions/hold`);
+    try {
+      await page.goto("/search?intent=choose&q=playwright%20typo");
+
+      await expect(
+        page.getByText("Nothing matches “playwright typo”.", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("region", { name: "Did you mean?" }),
+      ).toHaveCount(0);
+    } finally {
+      await request.post(`${mockApiServer}/__test/search-suggestions/resume`);
+    }
+
+    await expect(
+      page.getByRole("region", { name: "Did you mean?" }),
+    ).toBeVisible();
+  });
+});

--- a/apps/web/src/app/(app)/search/page.tsx
+++ b/apps/web/src/app/(app)/search/page.tsx
@@ -86,6 +86,7 @@ export default async function SearchPage(props: {
           limit: searchLimit,
           query,
           scopes: [...searchScopes],
+          suggestions: "exclude",
         })
       : undefined,
   ]);

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -341,6 +341,16 @@ function exactMatchesScope(exact: SearchExact, scope: SearchScope) {
   );
 }
 
+function hasSearchResults(response: SearchResponse, scope: SearchScope) {
+  return Boolean(
+    (response.exact && exactMatchesScope(response.exact, scope)) ||
+    response.groups.some(
+      (group) =>
+        groupMatchesScope(group.type, scope) && group.results.length > 0,
+    ),
+  );
+}
+
 function getSearchSnapshot(
   response: SearchResponse,
   query: string,
@@ -348,13 +358,7 @@ function getSearchSnapshot(
   bottleOptions: BottleItemOptions,
   showMoreLinks: boolean,
 ): SearchSnapshot {
-  const hasResults = Boolean(
-    (response.exact && exactMatchesScope(response.exact, scope)) ||
-    response.groups.some(
-      (group) =>
-        groupMatchesScope(group.type, scope) && group.results.length > 0,
-    ),
-  );
+  const hasResults = hasSearchResults(response, scope);
   return {
     emptyText: hasResults
       ? undefined
@@ -450,6 +454,7 @@ export function Search({
   const activeRequest = useRef<AbortController | undefined>(undefined);
   const latestRequest = useRef(0);
   const initialSearchStarted = useRef(Boolean(initialSnapshot));
+  const initialSuggestionsStarted = useRef(false);
   const previousInitialQuery = useRef(initialQuery);
   const previousInitialScope = useRef(initialScope);
   const effectiveScope = availableScopeDefinitions.some(
@@ -466,6 +471,35 @@ export function Search({
   const availableScopeFacets = currentSnapshot
     ? availableScopeDefinitions
     : undefined;
+
+  const loadSuggestions = useCallback(
+    async (
+      nextQuery: string,
+      nextScope: SearchScope,
+      requestId: number,
+      request: AbortController,
+    ) => {
+      const response = await orpc.search.call(
+        {
+          query: nextQuery,
+          scopes: [...getApiScopes(nextScope, Boolean(user))],
+          suggestions: "only",
+        },
+        { signal: request.signal },
+      );
+      if (latestRequest.current !== requestId) return;
+      setSnapshot(
+        getSearchSnapshot(
+          response,
+          nextQuery,
+          nextScope,
+          { getBottleHref, showRatings: showBottleRatings },
+          placement === "database" || placement === "overlay",
+        ),
+      );
+    },
+    [getBottleHref, orpc, placement, showBottleRatings, user],
+  );
 
   const runSearch = useCallback(
     async (nextQuery: string, nextScope: SearchScope) => {
@@ -489,6 +523,7 @@ export function Search({
             limit: placement === "database" && nextScope !== "all" ? 50 : limit,
             query: trimmedQuery,
             scopes: [...getApiScopes(nextScope, Boolean(user))],
+            suggestions: "exclude",
           },
           { signal: request.signal },
         );
@@ -503,6 +538,14 @@ export function Search({
           ),
         );
         setStatus("ready");
+        if (!hasSearchResults(response, nextScope)) {
+          try {
+            await loadSuggestions(trimmedQuery, nextScope, requestId, request);
+          } catch {
+            // Search owns possible matches as optional help. A failure must not
+            // replace a completed empty result with an error.
+          }
+        }
       } catch {
         if (request.signal.aborted) return;
         if (latestRequest.current !== requestId) return;
@@ -513,7 +556,15 @@ export function Search({
         }
       }
     },
-    [getBottleHref, limit, orpc, placement, showBottleRatings, user],
+    [
+      getBottleHref,
+      limit,
+      loadSuggestions,
+      orpc,
+      placement,
+      showBottleRatings,
+      user,
+    ],
   );
   const debouncedSearch = useDebounceCallback(runSearch, SEARCH_DEBOUNCE_MS);
 
@@ -537,6 +588,43 @@ export function Search({
     initialSearchStarted.current = true;
     void runSearch(initialQuery, effectiveScope);
   }, [effectiveScope, initialQuery, runSearch]);
+
+  useEffect(() => {
+    if (
+      initialSuggestionsStarted.current ||
+      !initialResponse ||
+      !initialSnapshot ||
+      initialResponse.nearest.length ||
+      hasSearchResults(initialResponse, resolvedInitialScope)
+    ) {
+      return;
+    }
+    initialSuggestionsStarted.current = true;
+    const requestId = latestRequest.current + 1;
+    latestRequest.current = requestId;
+    const request = new AbortController();
+    activeRequest.current = request;
+    void loadSuggestions(
+      initialQuery.trim(),
+      resolvedInitialScope,
+      requestId,
+      request,
+    )
+      .catch(() => {
+        // The initial empty result is already complete without possible matches.
+      })
+      .finally(() => {
+        if (activeRequest.current === request) {
+          activeRequest.current = undefined;
+        }
+      });
+  }, [
+    initialQuery,
+    initialResponse,
+    initialSnapshot,
+    loadSuggestions,
+    resolvedInitialScope,
+  ]);
 
   useEffect(() => {
     if (previousInitialQuery.current === initialQuery) return;


### PR DESCRIPTION
Search pages now show real results or the empty state as soon as the main lookup completes. When nothing matches, the existing “Did you mean?” results load in a second request and update the same result panel. Typing a new query cancels both requests, and a failed possible-match request leaves the completed empty state in place.

The search API adds an optional mode for including, excluding, or returning only possible matches. Its default preserves the existing single-response behavior for other callers. A browser test deliberately holds the second response to prove that the empty state appears first.
