### PR TITLE
feat(web): improve add bottle search prefills

### DIFF
--- a/apps/web/src/app/(layout-free)/bottles/new/createBottleInitialData.test.ts
+++ b/apps/web/src/app/(layout-free)/bottles/new/createBottleInitialData.test.ts
@@ -1,5 +1,68 @@
 import { describe, expect, test } from "vitest";
-import { mergeCreateBottleInitialData } from "./createBottleInitialData";
+import {
+  applyLeadingBrandMatch,
+  getLeadingEntityPrefixes,
+  mergeCreateBottleInitialData,
+} from "./createBottleInitialData";
+
+describe("getLeadingEntityPrefixes", () => {
+  test("returns longest-first prefixes that leave a bottle name", () => {
+    expect(getLeadingEntityPrefixes("The Macallan 18 Year Old")).toEqual([
+      "The Macallan 18 Year",
+      "The Macallan 18",
+      "The Macallan",
+      "The",
+    ]);
+    expect(getLeadingEntityPrefixes("Lagavulin")).toEqual([]);
+  });
+});
+
+describe("applyLeadingBrandMatch", () => {
+  test("uses the longest unambiguous leading Entity and keeps the remainder", () => {
+    expect(
+      applyLeadingBrandMatch({ name: "The Macallan 18 Year Old" }, [
+        { prefix: "The Macallan", results: [{ id: 101, name: "Macallan" }] },
+        { prefix: "The", results: [{ id: 102, name: "The Lakes" }] },
+      ]),
+    ).toEqual({
+      brand: { id: 101, name: "Macallan" },
+      name: "18 Year Old",
+    });
+  });
+
+  test("does not guess when a reference is ambiguous", () => {
+    const initialData = { name: "Lagavulin 16" };
+
+    expect(
+      applyLeadingBrandMatch(initialData, [
+        {
+          prefix: "Lagavulin",
+          results: [
+            { id: 101, name: "Lagavulin" },
+            { id: 102, name: "Lagavulin Independent" },
+          ],
+        },
+      ]),
+    ).toBe(initialData);
+  });
+
+  test("preserves an explicit brand", () => {
+    expect(
+      applyLeadingBrandMatch(
+        { brand: { id: 101, name: "Chosen Brand" }, name: "Lagavulin 16" },
+        [
+          {
+            prefix: "Lagavulin",
+            results: [{ id: 102, name: "Lagavulin" }],
+          },
+        ],
+      ),
+    ).toEqual({
+      brand: { id: 101, name: "Chosen Brand" },
+      name: "Lagavulin 16",
+    });
+  });
+});
 
 describe("mergeCreateBottleInitialData", () => {
   test("preserves unresolved entity names when another entity id loads", () => {

--- a/apps/web/src/app/(layout-free)/bottles/new/createBottleInitialData.ts
+++ b/apps/web/src/app/(layout-free)/bottles/new/createBottleInitialData.ts
@@ -1,6 +1,48 @@
 import type { BottleFormInitialData } from "@peated/web/components/bottleForm";
 import { buildBottleProposalDraft } from "@peated/web/lib/bottleProposalDraft";
 
+const MAX_LEADING_ENTITY_WORDS = 6;
+
+export function getLeadingEntityPrefixes(name: string): string[] {
+  const words = name.trim().split(/\s+/);
+  const prefixWordCount = Math.min(words.length - 1, MAX_LEADING_ENTITY_WORDS);
+
+  return Array.from({ length: Math.max(0, prefixWordCount) }, (_, index) =>
+    words.slice(0, prefixWordCount - index).join(" "),
+  );
+}
+
+export function applyLeadingBrandMatch<T extends { name: string }>(
+  initialData: BottleFormInitialData,
+  matches: ReadonlyArray<{
+    prefix: string;
+    results: readonly T[];
+  }>,
+): BottleFormInitialData {
+  if (initialData.brand || !initialData.name) return initialData;
+
+  const normalizedName = initialData.name.trim().replace(/\s+/g, " ");
+  // Whisky Identity Model: only one stored Entity reference may prefill Brand.
+  const match = matches.find(({ prefix, results }) => {
+    const normalizedPrefix = prefix.trim().replace(/\s+/g, " ");
+    return (
+      results.length === 1 &&
+      normalizedName
+        .toLocaleLowerCase()
+        .startsWith(`${normalizedPrefix.toLocaleLowerCase()} `)
+    );
+  });
+  const brand = match?.results[0];
+  if (!match || !brand) return initialData;
+
+  const name = normalizedName
+    .slice(match.prefix.trim().replace(/\s+/g, " ").length)
+    .replace(/^[\s:–—|/-]+/, "");
+  if (!name) return initialData;
+
+  return { ...initialData, brand, name };
+}
+
 export function mergeCreateBottleInitialData({
   initialData,
   proposalData,

--- a/apps/web/src/app/(layout-free)/bottles/new/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/new/page.tsx
@@ -13,10 +13,13 @@ import { getAddBottleHref } from "@peated/web/lib/addBottle";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getBottleUrl } from "@peated/web/lib/urls";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
 import { redirect, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
-import { mergeCreateBottleInitialData } from "./createBottleInitialData";
+import {
+  applyLeadingBrandMatch,
+  getLeadingEntityPrefixes,
+  mergeCreateBottleInitialData,
+} from "./createBottleInitialData";
 
 type ReturnAction = "catalog" | "choose" | "library" | "tasting" | "view";
 
@@ -106,15 +109,12 @@ function CreateBottleForm() {
   const releaseYear = prefill.releaseYear ?? null;
   const category = prefill.category ?? null;
   const canReviewProposal = !!(user?.mod || user?.admin);
+  const leadingEntityPrefixes =
+    !brand && !brandName && !proposalId ? getLeadingEntityPrefixes(name) : [];
 
   if (proposalId && user && !canReviewProposal) {
     redirect("/errors/unauthorized");
   }
-
-  const needsToLoad = Boolean(
-    distiller || brand || bottler || series || proposalId,
-  );
-  const [loading, setLoading] = useState<boolean>(needsToLoad);
 
   const initialFormData: BottleFormInitialData = { name };
   if (pendingImageUrl) initialFormData.imageUrl = pendingImageUrl;
@@ -141,9 +141,6 @@ function CreateBottleForm() {
   if (prefill.maturation) initialFormData.maturation = prefill.maturation;
   if (prefill.caskNumber) initialFormData.caskNumber = prefill.caskNumber;
   if (prefill.outturn) initialFormData.outturn = prefill.outturn;
-
-  const [initialData, setInitialData] =
-    useState<BottleFormInitialData>(initialFormData);
 
   const distillerQuery = useQuery({
     ...orpc.entities.details.queryOptions({
@@ -175,44 +172,43 @@ function CreateBottleForm() {
     }),
     enabled: !!proposalId && canReviewProposal,
   });
-
-  useEffect(() => {
-    if (
-      loading &&
-      !distillerQuery.isLoading &&
-      !brandQuery.isLoading &&
-      !bottlerQuery.isLoading &&
-      !seriesQuery.isLoading &&
-      (!proposalId || !proposalQuery.isLoading)
-    ) {
-      const proposalData = proposalQuery.data?.proposedBottle;
-      setInitialData((initialData) =>
-        mergeCreateBottleInitialData({
-          initialData,
-          proposalData,
-          proposalImageUrl: proposalQuery.data?.price.imageUrl,
-          distiller: distillerQuery.data,
-          brand: brandQuery.data,
-          bottler: bottlerQuery.data,
-          series: seriesQuery.data,
-        }),
-      );
-      setLoading(false);
-    }
-  }, [
-    loading,
-    proposalId,
-    proposalQuery.isLoading,
-    proposalQuery.data,
-    distillerQuery.isLoading,
-    distillerQuery.data,
-    brandQuery.isLoading,
-    brandQuery.data,
-    bottlerQuery.isLoading,
-    bottlerQuery.data,
-    seriesQuery.isLoading,
-    seriesQuery.data,
-  ]);
+  const leadingEntityQueries = useQueries({
+    queries: leadingEntityPrefixes.map((prefix) => ({
+      ...orpc.entities.list.queryOptions({
+        input: {
+          limit: 2,
+          name: prefix,
+          query: "",
+          sort: "rank",
+        },
+      }),
+      staleTime: 5 * 60_000,
+    })),
+  });
+  const leadingEntityQueriesLoading = leadingEntityQueries.some(
+    (query) => query.isLoading,
+  );
+  const leadingEntityMatches = leadingEntityPrefixes.map((prefix, index) => ({
+    prefix,
+    results: leadingEntityQueries[index]?.data?.results ?? [],
+  }));
+  const loading = Boolean(
+    distillerQuery.isLoading ||
+    brandQuery.isLoading ||
+    bottlerQuery.isLoading ||
+    seriesQuery.isLoading ||
+    leadingEntityQueriesLoading ||
+    (proposalId && proposalQuery.isLoading),
+  );
+  const initialData = mergeCreateBottleInitialData({
+    initialData: applyLeadingBrandMatch(initialFormData, leadingEntityMatches),
+    proposalData: proposalQuery.data?.proposedBottle,
+    proposalImageUrl: proposalQuery.data?.price.imageUrl,
+    distiller: distillerQuery.data,
+    brand: brandQuery.data,
+    bottler: bottlerQuery.data,
+    series: seriesQuery.data,
+  });
 
   const bottleCreateMutation = useMutation(
     orpc.bottles.create.mutationOptions(),

--- a/apps/web/src/components/bottleCreateCandidates.stories.tsx
+++ b/apps/web/src/components/bottleCreateCandidates.stories.tsx
@@ -97,6 +97,11 @@ export const EntryNotices: Story = {
         newSinceReview
         onReview={() => undefined}
       />
+      <BottleCreateCandidateSummary
+        count={2}
+        loading
+        onReview={() => undefined}
+      />
     </StoryStack>
   ),
 };

--- a/apps/web/src/components/bottleCreateCandidates.stylex.tsx
+++ b/apps/web/src/components/bottleCreateCandidates.stylex.tsx
@@ -11,10 +11,12 @@ export type BottleCreateCandidate =
 
 export function BottleCreateCandidateSummary({
   count,
+  loading = false,
   newSinceReview = false,
   onReview,
 }: {
   count: number;
+  loading?: boolean;
   newSinceReview?: boolean;
   onReview: () => void;
 }) {
@@ -22,7 +24,7 @@ export function BottleCreateCandidateSummary({
     count === 1 ? "bottle" : "bottles"
   }`;
   return (
-    <div {...stylex.props(styles.summary)}>
+    <div aria-busy={loading || undefined} {...stylex.props(styles.summary)}>
       <p
         aria-live="polite"
         role="status"
@@ -32,6 +34,7 @@ export function BottleCreateCandidateSummary({
       </p>
       <Button
         aria-label={`Review ${bottleCount} that may match this one`}
+        disabled={loading}
         onClick={onReview}
         size="sm"
         type="button"

--- a/apps/web/src/components/bottleCreateCandidates.test.tsx
+++ b/apps/web/src/components/bottleCreateCandidates.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { BottleCreateCandidateSummary } from "./bottleCreateCandidates.stylex";
+
+describe("BottleCreateCandidateSummary", () => {
+  test("keeps the summary in place while its matches update", () => {
+    const html = renderToStaticMarkup(
+      <BottleCreateCandidateSummary
+        count={2}
+        loading
+        onReview={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("2 bottles may match this one.");
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain('disabled=""');
+    expect(html).toContain("Review");
+  });
+});

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -55,7 +55,7 @@ import {
 } from "@peated/web/lib/formHelpers";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { zodResolver } from "@peated/web/lib/zodResolver";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery } from "@tanstack/react-query";
 import { WandSparkles } from "lucide-react";
 import {
   useEffect,
@@ -604,6 +604,7 @@ export default function BottleForm({
       input: debouncedCandidateInput,
     }),
     enabled: candidateEnabled,
+    placeholderData: keepPreviousData,
     staleTime: 5 * 60_000,
   });
   const candidateInputPending =
@@ -854,11 +855,12 @@ export default function BottleForm({
               ) : null}
               {isCreate &&
               onUseExistingBottle &&
+              candidateEnabled &&
               candidateResults.isSuccess &&
-              !candidateCheckLoading &&
               hasUnreviewedCandidates ? (
                 <BottleCreateCandidateSummary
                   count={unreviewedCandidates.length}
+                  loading={candidateCheckLoading}
                   newSinceReview={reviewedCandidateIds.size > 0}
                   onReview={() => openCandidateReview()}
                 />


### PR DESCRIPTION
The Add Bottle form now resolves the longest unique leading Entity reference from incoming search text. For example, “Lagavulin 16” selects Lagavulin as the Brand and uses “16” as the Bottle name, while explicit prefills and ambiguous matches remain unchanged.

Possible-match notices now retain their previous results while a new check runs. Review is briefly disabled during the refresh, keeping the notice mounted and preventing the form from jumping as someone types.
