### PR TITLE
feat(profile): show more recent activity

### DIFF
--- a/apps/web/src/app/(app)/users/[username]/page.tsx
+++ b/apps/web/src/app/(app)/users/[username]/page.tsx
@@ -19,7 +19,7 @@ export default async function ProfileOverviewPage(props: {
   const queryClient = getQueryClient();
   const orpc = createTanstackQueryUtils(client);
   const [activityList, badgePage] = await Promise.all([
-    client.users.activity.list({ limit: 3, user: user.id }),
+    client.users.activity.list({ limit: 10, user: user.id }),
     client.users.badgeList({ cursor: 1, limit: 100, user: user.id }),
     queryClient.prefetchQuery(profileQueries.tastingStats(orpc, user.id)),
   ]);

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
@@ -74,7 +74,7 @@ export function ProfileOverviewPageClient({
   const activity = getCommunityFeedItems({
     activity: initialActivityList.results,
     criticReviews: [],
-  }).slice(0, 3);
+  }).slice(0, 10);
 
   return (
     <ProfileOverviewLayout


### PR DESCRIPTION
Member profile overviews now show up to 10 recent activities instead of 3. The server fetch and rendered feed use the same limit, while the dedicated activity page and its pagination remain unchanged.
