### PR TITLE
fix(activity): group library adds and cover feed images

### DIFF
--- a/apps/server/src/lib/activityFeed.ts
+++ b/apps/server/src/lib/activityFeed.ts
@@ -10,6 +10,7 @@ import type {
 import {
   bottles,
   collectionBottles,
+  collections,
   externalReviewArticles,
   externalReviewPublications,
   externalReviews,
@@ -40,6 +41,8 @@ export {
 } from "./activityCursor";
 
 export const COLLECTION_PREVIEW_LIMIT = 4;
+// Activity feed rule: a collection-add session ends after six hours of inactivity.
+export const COLLECTION_ADD_SESSION_INACTIVITY_HOURS = 6;
 export const SECONDARY_ENTRY_LIMIT_WITH_PRIMARY = 2;
 export const TASTING_SESSION_INACTIVITY_HOURS = 3;
 
@@ -237,6 +240,160 @@ function markedTastingsSql({
         AND ${tastings.createdAt} <= ${snapshotAt}
     ) ordered_tastings
   `;
+}
+
+function markedCollectionAdditionsSql({
+  userCondition,
+  snapshotAt,
+}: {
+  userCondition: SQL<unknown>;
+  snapshotAt: Date;
+}) {
+  return sql`
+    SELECT
+      ordered_additions.id,
+      ordered_additions.collection_id,
+      ordered_additions.created_at,
+      CASE
+        WHEN ordered_additions.previous_created_at IS NULL
+          OR ordered_additions.created_at - ordered_additions.previous_created_at
+            > (${COLLECTION_ADD_SESSION_INACTIVITY_HOURS} * INTERVAL '1 hour')
+        THEN 1
+        ELSE 0
+      END AS is_session_start
+    FROM (
+      SELECT
+        ${collectionBottles.id} AS id,
+        ${collectionBottles.collectionId} AS collection_id,
+        ${collectionBottles.createdAt} AS created_at,
+        LAG(${collectionBottles.createdAt}) OVER (
+          PARTITION BY ${collectionBottles.collectionId}
+          ORDER BY ${collectionBottles.createdAt}, ${collectionBottles.id}
+        ) AS previous_created_at
+      FROM ${collectionBottles}
+      INNER JOIN ${collections}
+        ON ${collections.id} = ${collectionBottles.collectionId}
+      INNER JOIN ${users} ON ${users.id} = ${collections.createdById}
+      WHERE ${userCondition}
+        AND ${collectionBottles.createdAt} <= ${snapshotAt.toISOString()}::timestamp
+    ) ordered_additions
+  `;
+}
+
+function numberedCollectionAdditionsSql({
+  userCondition,
+  snapshotAt,
+}: {
+  userCondition: SQL<unknown>;
+  snapshotAt: Date;
+}) {
+  return sql`
+    SELECT
+      marked_additions.*,
+      SUM(marked_additions.is_session_start) OVER (
+        PARTITION BY marked_additions.collection_id
+        ORDER BY marked_additions.created_at, marked_additions.id
+        ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+      ) AS session_number
+    FROM (
+      ${markedCollectionAdditionsSql({ userCondition, snapshotAt })}
+    ) marked_additions
+  `;
+}
+
+/** Counts collection-add sessions inside one activity snapshot. */
+export async function countCollectionAddGroups({
+  userCondition,
+  snapshotAt,
+}: {
+  userCondition: SQL<unknown>;
+  snapshotAt: Date;
+}) {
+  const result = await db.execute<{ count: string }>(sql`
+    SELECT COUNT(*) AS count
+    FROM (
+      SELECT 1
+      FROM (
+        ${numberedCollectionAdditionsSql({ userCondition, snapshotAt })}
+      ) numbered_additions
+      GROUP BY
+        numbered_additions.collection_id,
+        numbered_additions.session_number
+    ) collection_add_groups
+  `);
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+type CollectionAddGroupRow = {
+  collection_id: number | string;
+  window_start: string;
+  window_end: string;
+  total_items: string;
+};
+
+/** Pages collection additions without splitting a six-hour activity session. */
+export async function getCollectionAddGroups({
+  userCondition,
+  snapshotAt,
+  offset,
+  limit,
+}: {
+  userCondition: SQL<unknown>;
+  snapshotAt: Date;
+  offset: number;
+  limit: number;
+}): Promise<CollectionAddGroup[]> {
+  if (!limit) return [];
+
+  return await db.transaction(
+    async (tx) => {
+      const result = await tx.execute<CollectionAddGroupRow>(sql`
+        SELECT
+          numbered_additions.collection_id,
+          MIN(numbered_additions.created_at)::text AS window_start,
+          MAX(numbered_additions.created_at)::text AS window_end,
+          COUNT(numbered_additions.id) AS total_items
+        FROM (
+          ${numberedCollectionAdditionsSql({ userCondition, snapshotAt })}
+        ) numbered_additions
+        GROUP BY
+          numbered_additions.collection_id,
+          numbered_additions.session_number
+        ORDER BY window_end DESC, numbered_additions.collection_id DESC
+        OFFSET ${offset}
+        LIMIT ${limit}
+      `);
+
+      const collectionIds = result.rows.map((row) => Number(row.collection_id));
+      if (!collectionIds.length) return [];
+
+      const collectionRows = await tx
+        .select({ collection: collections, user: users })
+        .from(collections)
+        .innerJoin(users, eq(users.id, collections.createdById))
+        .where(inArray(collections.id, collectionIds));
+      const collectionById = new Map(
+        collectionRows.map((row) => [row.collection.id, row]),
+      );
+
+      return result.rows.map((row): CollectionAddGroup => {
+        const target = collectionById.get(Number(row.collection_id));
+        if (!target) {
+          throw new Error(
+            `Activity references missing Collection ${row.collection_id}.`,
+          );
+        }
+        return {
+          collection: target.collection,
+          user: target.user,
+          windowStart: row.window_start,
+          windowEnd: row.window_end,
+          totalItems: Number(row.total_items),
+        };
+      });
+    },
+    { accessMode: "read only", isolationLevel: "repeatable read" },
+  );
 }
 
 /** Counts primary feed entries inside one activity snapshot. */

--- a/apps/server/src/orpc/routes/activity/list.test.ts
+++ b/apps/server/src/orpc/routes/activity/list.test.ts
@@ -68,6 +68,61 @@ describe("GET /activity", () => {
         },
       ]);
     });
+
+    test(`groups additions across midnight within six hours in ${feed} feed`, async ({
+      fixtures,
+    }) => {
+      const user = await fixtures.User();
+      const collection = await fixtures.Collection({
+        name: "Library",
+        createdById: user.id,
+      });
+      const bottles = await Promise.all([
+        fixtures.Bottle(),
+        fixtures.Bottle(),
+        fixtures.Bottle(),
+      ]);
+      await insertCollectionBottles([
+        {
+          collectionId: collection.id,
+          bottleId: bottles[0].id,
+          createdAt: new Date("2026-01-03T23:00:00Z"),
+        },
+        {
+          collectionId: collection.id,
+          bottleId: bottles[1].id,
+          createdAt: new Date("2026-01-04T02:00:00Z"),
+        },
+        {
+          collectionId: collection.id,
+          bottleId: bottles[2].id,
+          createdAt: new Date("2026-01-04T09:00:01Z"),
+        },
+      ]);
+
+      const result =
+        feed === "global"
+          ? await routerClient.activity.list({ filter: "global", limit: 10 })
+          : await routerClient.users.activity.list({
+              user: user.username,
+              limit: 10,
+            });
+
+      expect(result.results).toMatchObject([
+        {
+          type: "collection_add",
+          totalItems: 1,
+          windowStart: "2026-01-04T09:00:01.000Z",
+          windowEnd: "2026-01-04T09:00:01.000Z",
+        },
+        {
+          type: "collection_add",
+          totalItems: 2,
+          windowStart: "2026-01-03T23:00:00.000Z",
+          windowEnd: "2026-01-04T02:00:00.000Z",
+        },
+      ]);
+    });
   }
 
   test("returns tastings and grouped collection additions", async ({

--- a/apps/server/src/orpc/routes/activity/list.ts
+++ b/apps/server/src/orpc/routes/activity/list.ts
@@ -1,39 +1,26 @@
-import { db } from "@peated/server/db";
-import {
-  collectionBottles,
-  collections,
-  follows,
-  users,
-} from "@peated/server/db/schema";
+import { follows, users } from "@peated/server/db/schema";
 import {
   composeActivity,
+  countCollectionAddGroups,
   countPrimaryActivity,
   encodeActivityCursor,
   getActivitySourceWindow,
+  getCollectionAddGroups,
   getPrimaryActivity,
   parseActivityCursor,
   serializeCollectionAddEntries,
   serializePrimaryActivityEntries,
-  type CollectionAddGroup,
 } from "@peated/server/lib/activityFeed";
 import { implement } from "@peated/server/orpc";
 import activityListContract from "@peated/server/orpc/contracts/activity/list";
 import type { SQL } from "drizzle-orm";
-import { and, desc, eq, lte, or, sql } from "drizzle-orm";
+import { eq, or, sql } from "drizzle-orm";
 
 // Main activity is read-time composition over authoritative source tables. The
 // route owns visibility filtering; shared helpers own entry shaping/throttling.
 // The local filter intentionally mirrors the existing global feed until product
 // semantics define what local activity should mean.
 type ActivityFilter = "global" | "friends" | "local";
-
-type CollectionAddGroupRow = {
-  collection: typeof collections.$inferSelect;
-  user: typeof users.$inferSelect;
-  windowStart: string;
-  windowEnd: string;
-  totalItems: string;
-};
 
 function visibleActivityUserCondition({
   filter,
@@ -85,31 +72,18 @@ export default implement(activityListContract).handler(async function ({
   const activityCursor = input.cursor
     ? parseActivityCursor(input.cursor)!
     : { page: 1, snapshotAt: new Date() };
-  const collectionBucket = sql<Date>`DATE_TRUNC('day', ${collectionBottles.createdAt})`;
-  const collectionGroupCreatedAt = sql<Date>`MAX(${collectionBottles.createdAt})`;
 
-  const [totalPrimary, secondaryCountResult] = await Promise.all([
+  const [totalPrimary, totalSecondary] = await Promise.all([
     countPrimaryActivity({
       includeCriticReviews,
       userCondition,
       snapshotAt: activityCursor.snapshotAt,
     }),
-    db.execute<{ count: string }>(sql`
-        SELECT COUNT(*) as count
-        FROM (
-          SELECT 1
-          FROM ${collectionBottles}
-          INNER JOIN ${collections}
-            ON ${collections.id} = ${collectionBottles.collectionId}
-          INNER JOIN ${users}
-            ON ${users.id} = ${collections.createdById}
-          WHERE ${userCondition}
-            AND ${collectionBottles.createdAt} <= ${activityCursor.snapshotAt}
-          GROUP BY ${users.id}, ${collections.id}, DATE_TRUNC('day', ${collectionBottles.createdAt})
-        ) activity_groups
-      `),
+    countCollectionAddGroups({
+      userCondition,
+      snapshotAt: activityCursor.snapshotAt,
+    }),
   ]);
-  const totalSecondary = Number(secondaryCountResult.rows[0]?.count ?? 0);
   const sourceWindow = getActivitySourceWindow({
     cursor: activityCursor.page,
     limit: input.limit,
@@ -125,30 +99,12 @@ export default implement(activityListContract).handler(async function ({
       limit: sourceWindow.primaryLimit,
       offset: sourceWindow.primaryOffset,
     }),
-    db
-      .select({
-        collection: collections,
-        user: users,
-        windowStart: sql<string>`MIN(${collectionBottles.createdAt})::text`,
-        windowEnd: sql<string>`MAX(${collectionBottles.createdAt})::text`,
-        totalItems: sql<string>`COUNT(${collectionBottles.id})`,
-      })
-      .from(collectionBottles)
-      .innerJoin(
-        collections,
-        eq(collections.id, collectionBottles.collectionId),
-      )
-      .innerJoin(users, eq(users.id, collections.createdById))
-      .where(
-        and(
-          userCondition,
-          lte(collectionBottles.createdAt, activityCursor.snapshotAt),
-        ),
-      )
-      .groupBy(users.id, collections.id, collectionBucket)
-      .orderBy(desc(collectionGroupCreatedAt))
-      .limit(sourceWindow.secondaryLimit)
-      .offset(sourceWindow.secondaryOffset),
+    getCollectionAddGroups({
+      userCondition,
+      snapshotAt: activityCursor.snapshotAt,
+      limit: sourceWindow.secondaryLimit,
+      offset: sourceWindow.secondaryOffset,
+    }),
   ]);
 
   const primaryEntries = await serializePrimaryActivityEntries(
@@ -156,15 +112,7 @@ export default implement(activityListContract).handler(async function ({
     context.user,
   );
   const secondaryEntries = await serializeCollectionAddEntries({
-    groups: collectionGroupRows.map(
-      (row: CollectionAddGroupRow): CollectionAddGroup => ({
-        collection: row.collection,
-        user: row.user,
-        windowStart: row.windowStart,
-        windowEnd: row.windowEnd,
-        totalItems: Number(row.totalItems),
-      }),
-    ),
+    groups: collectionGroupRows,
     currentUser: context.user,
   });
 

--- a/apps/server/src/orpc/routes/users/activity/list.ts
+++ b/apps/server/src/orpc/routes/users/activity/list.ts
@@ -1,31 +1,21 @@
 import { db } from "@peated/server/db";
-import {
-  collectionBottles,
-  collections,
-  users,
-} from "@peated/server/db/schema";
+import { users } from "@peated/server/db/schema";
 import {
   composeActivity,
+  countCollectionAddGroups,
   countPrimaryActivity,
   encodeActivityCursor,
   getActivitySourceWindow,
+  getCollectionAddGroups,
   getPrimaryActivity,
   parseActivityCursor,
   serializeCollectionAddEntries,
   serializePrimaryActivityEntries,
-  type CollectionAddGroup,
 } from "@peated/server/lib/activityFeed";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
 import { implement } from "@peated/server/orpc";
 import userActivityListContract from "@peated/server/orpc/contracts/users/activity/list";
-import { and, desc, eq, lte, sql } from "drizzle-orm";
-
-type CollectionAddGroupRow = {
-  collection: typeof collections.$inferSelect;
-  windowStart: string;
-  windowEnd: string;
-  totalItems: string;
-};
+import { eq } from "drizzle-orm";
 
 export default implement(userActivityListContract).handler(async function ({
   input,
@@ -52,27 +42,16 @@ export default implement(userActivityListContract).handler(async function ({
     ? parseActivityCursor(input.cursor)!
     : { page: 1, snapshotAt: new Date() };
   const userCondition = eq(users.id, user.id);
-  const collectionBucket = sql<Date>`DATE_TRUNC('day', ${collectionBottles.createdAt})`;
-  const collectionGroupCreatedAt = sql<Date>`MAX(${collectionBottles.createdAt})`;
-  const [totalPrimary, secondaryCountResult] = await Promise.all([
+  const [totalPrimary, totalSecondary] = await Promise.all([
     countPrimaryActivity({
       userCondition,
       snapshotAt: activityCursor.snapshotAt,
     }),
-    db.execute<{ count: string }>(sql`
-        SELECT COUNT(*) as count
-        FROM (
-          SELECT 1
-          FROM ${collectionBottles}
-          INNER JOIN ${collections}
-            ON ${collections.id} = ${collectionBottles.collectionId}
-            AND ${collections.createdById} = ${user.id}
-          WHERE ${collectionBottles.createdAt} <= ${activityCursor.snapshotAt}
-          GROUP BY ${collections.id}, DATE_TRUNC('day', ${collectionBottles.createdAt})
-        ) activity_groups
-      `),
+    countCollectionAddGroups({
+      userCondition,
+      snapshotAt: activityCursor.snapshotAt,
+    }),
   ]);
-  const totalSecondary = Number(secondaryCountResult.rows[0]?.count ?? 0);
   const sourceWindow = getActivitySourceWindow({
     cursor: activityCursor.page,
     limit: input.limit,
@@ -87,26 +66,12 @@ export default implement(userActivityListContract).handler(async function ({
       limit: sourceWindow.primaryLimit,
       offset: sourceWindow.primaryOffset,
     }),
-    db
-      .select({
-        collection: collections,
-        windowStart: sql<string>`MIN(${collectionBottles.createdAt})::text`,
-        windowEnd: sql<string>`MAX(${collectionBottles.createdAt})::text`,
-        totalItems: sql<string>`COUNT(${collectionBottles.id})`,
-      })
-      .from(collectionBottles)
-      .innerJoin(
-        collections,
-        and(
-          eq(collections.id, collectionBottles.collectionId),
-          eq(collections.createdById, user.id),
-        ),
-      )
-      .where(lte(collectionBottles.createdAt, activityCursor.snapshotAt))
-      .groupBy(collections.id, collectionBucket)
-      .orderBy(desc(collectionGroupCreatedAt))
-      .limit(sourceWindow.secondaryLimit)
-      .offset(sourceWindow.secondaryOffset),
+    getCollectionAddGroups({
+      userCondition,
+      snapshotAt: activityCursor.snapshotAt,
+      limit: sourceWindow.secondaryLimit,
+      offset: sourceWindow.secondaryOffset,
+    }),
   ]);
 
   const primaryEntries = await serializePrimaryActivityEntries(
@@ -114,15 +79,7 @@ export default implement(userActivityListContract).handler(async function ({
     context.user,
   );
   const secondaryEntries = await serializeCollectionAddEntries({
-    groups: collectionGroupRows.map(
-      (row: CollectionAddGroupRow): CollectionAddGroup => ({
-        collection: row.collection,
-        user,
-        windowStart: row.windowStart,
-        windowEnd: row.windowEnd,
-        totalItems: Number(row.totalItems),
-      }),
-    ),
+    groups: collectionGroupRows,
     currentUser: context.user,
   });
 

--- a/apps/web/src/components/communityFeed.stories.tsx
+++ b/apps/web/src/components/communityFeed.stories.tsx
@@ -27,16 +27,19 @@ function withStoryImages(
     return {
       ...item,
       actorImageUrl: null,
-      bottles: item.bottles.map((bottle) => ({
-        ...bottle,
-        imageFit: item.kind === "tasting" && tastingPhoto ? "cover" : "contain",
-        imageUrl:
+      bottles: item.bottles.map((bottle) => {
+        const imageUrl =
           item.kind === "collection_add"
-            ? null
+            ? OblongTastingPhoto.src
             : item.kind === "tasting"
               ? tastingPhoto
-              : SquareTastingPhoto.src,
-      })),
+              : SquareTastingPhoto.src;
+        return {
+          ...bottle,
+          imageFit: imageUrl ? "cover" : "contain",
+          imageUrl,
+        };
+      }),
     };
   });
 }
@@ -48,7 +51,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Shared by activity and full-width tasting lists on the homepage, activity, bottle, brand or producer, and member pages. Map activity with getCommunityFeedItems and tasting lists with getTastingFeedItems. Each card includes the author and links to the activity. Bottle titles still link to their bottles. Tastings and reviews use the standard three-line bottle identity; library additions use compact, single-line bottle rows. Critic bylines are optional; library status is omitted.",
+          "Shared by activity and full-width tasting lists on the homepage, activity, bottle, brand or producer, and member pages. Map activity with getCommunityFeedItems and tasting lists with getTastingFeedItems. Each card includes the author and links to the activity. Bottle titles still link to their bottles. Feed images cover their frames. Tastings and reviews use the standard three-line bottle identity; library additions use compact, single-line bottle rows. Critic bylines are optional; library status is omitted.",
       },
     },
   },

--- a/apps/web/src/lib/communityFeed.test.ts
+++ b/apps/web/src/lib/communityFeed.test.ts
@@ -137,7 +137,7 @@ describe("getTastingFeedItems", () => {
     });
   });
 
-  test("covers a tasting photo and contains the catalog fallback", () => {
+  test("covers tasting photos and catalog fallbacks", () => {
     const photoUrl = "https://images.peated.com/tasting.jpg";
     const [withPhoto] = getTastingFeedItems([
       { ...mockTasting, imageUrl: photoUrl },
@@ -151,7 +151,7 @@ describe("getTastingFeedItems", () => {
       imageUrl: photoUrl,
     });
     expect(withoutPhoto?.bottles[0]).toMatchObject({
-      imageFit: "contain",
+      imageFit: "cover",
       imageUrl: mockTasting.bottle.imageUrl,
     });
   });
@@ -186,6 +186,9 @@ test("includes all four activity types, makes one card per tasting, and omits li
         (bottle) => !("status" in bottle) && !("isLibrary" in bottle),
       ),
     ).toBe(true);
+    expect(item.bottles.every((bottle) => bottle.imageFit === "cover")).toBe(
+      true,
+    );
   }
   const dates = items.map((item) => Date.parse(item.date));
   expect(dates).toEqual([...dates].sort((a, b) => b - a));

--- a/apps/web/src/lib/communityFeed.ts
+++ b/apps/web/src/lib/communityFeed.ts
@@ -11,11 +11,13 @@ type Activity = Outputs["activity"]["list"]["results"][number];
 type Bottle = Outputs["bottles"]["list"]["results"][number];
 type Tasting = Outputs["tastings"]["list"]["results"][number];
 
+/** Activity feed rule: real images crop to fill their fixed thumbnail frame. */
 function feedBottle(bottle: Bottle): CommunityFeedBottle {
   return {
     id: bottle.peatedId,
     ...getBottleIdentityProps(bottle),
     href: getBottleUrl(bottle),
+    imageFit: "cover",
     imageUrl: bottle.imageUrl,
   };
 }
@@ -35,7 +37,6 @@ function tastingFeedItem(tasting: Tasting, id = String(tasting.id)) {
         ...feedBottle(tasting.bottle),
         id: String(tasting.id),
         description: getPreview(tasting.notes),
-        imageFit: tasting.imageUrl ? "cover" : "contain",
         imageUrl: tasting.imageUrl ?? tasting.bottle.imageUrl,
         ratingBand: tasting.ratingBand,
       },


### PR DESCRIPTION
Library additions now stay in one activity entry while consecutive saves are no more than six hours apart, including when they cross UTC midnight. The global and profile feeds share the same session query so their grouping and pagination counts stay aligned.

Activity thumbnails now crop real images to fill their frames, including bottle-image fallbacks used by tastings and library entries. This cover behavior is scoped to community feeds, so bottle imagery elsewhere keeps its existing contained presentation. Regression coverage exercises both feed endpoints and the image mapper, and the Storybook examples cover full-size and compact frames.
