### PR TITLE
fix(web): correct review structured data

### DIFF
--- a/apps/web/src/app/(app)/bottles/[bottleId]/(overview)/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/(overview)/page.tsx
@@ -1,9 +1,13 @@
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
-import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import {
+  getAnonymousServerClient,
+  getPublicPageServerClient,
+} from "@peated/web/lib/orpc/client.server";
 import { getQueryClient } from "@peated/web/lib/orpc/query";
 import { getPageBottleList } from "@peated/web/lib/publicCatalog.server";
+import { serializeMemberReviewStructuredData } from "@peated/web/lib/reviewSeo";
 import { getBottleSeoMetadata } from "@peated/web/lib/seoMetadata";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import type { Metadata } from "next";
@@ -25,17 +29,24 @@ export default async function BottlePage(props: {
   const { bottleId } = await props.params;
   const bottle = await getBottlePage(parseCatalogRouteId(bottleId));
   const queryClient = getQueryClient();
-  const { client } = await getPublicPageServerClient();
+  const [{ client }, { client: anonymousClient }] = await Promise.all([
+    getPublicPageServerClient(),
+    getAnonymousServerClient(),
+  ]);
   const orpc = createTanstackQueryUtils(client);
+  const anonymousOrpc = createTanstackQueryUtils(anonymousClient);
   const seriesQuery = bottle.series
     ? bottleOverviewQueries.series(orpc, bottle.series.id)
     : null;
 
-  await Promise.all([
+  const [, , publicMemberReviews] = await Promise.all([
     queryClient.prefetchQuery(
       orpc.bottles.flavorProfile.queryOptions({ input: { bottle: bottle.id } }),
     ),
     queryClient.prefetchQuery(bottleOverviewQueries.reviews(orpc, bottle.id)),
+    queryClient.fetchQuery(
+      bottleOverviewQueries.memberReviews(anonymousOrpc, bottle.id),
+    ),
     queryClient.prefetchQuery(bottleOverviewQueries.tastings(orpc, bottle.id)),
     ...(seriesQuery
       ? [
@@ -46,10 +57,22 @@ export default async function BottlePage(props: {
         ]
       : []),
   ]);
+  const firstPublicReview = publicMemberReviews.results[0];
+  const structuredData = firstPublicReview
+    ? serializeMemberReviewStructuredData({ ...firstPublicReview, bottle })
+    : null;
 
   return (
-    <HydrationBoundary state={dehydrate(queryClient)}>
-      <BottleOverviewClient />
-    </HydrationBoundary>
+    <>
+      {structuredData && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: structuredData }}
+        />
+      )}
+      <HydrationBoundary state={dehydrate(queryClient)}>
+        <BottleOverviewClient />
+      </HydrationBoundary>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottleOverviewQueries.ts
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottleOverviewQueries.ts
@@ -10,6 +10,10 @@ export const bottleOverviewQueries = {
     orpc.externalReviews.list.queryOptions({
       input: { bottle: bottleId, limit: 3, sort: "recent" },
     }),
+  memberReviews: (orpc: ORPCQueryUtils, bottleId: number) =>
+    orpc.memberReviews.list.queryOptions({
+      input: { bottle: bottleId, limit: 3 },
+    }),
   series: (orpc: ORPCQueryUtils, seriesId?: number) => ({
     ...orpc.bottles.list.queryOptions({
       input: { limit: 4, series: seriesId, sort: "-release" },

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -36,7 +36,10 @@ import {
 } from "@peated/web/lib/addBottle";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getBottleReleasePlacement } from "@peated/web/lib/bottleMetadata";
-import { getTastingFeedItems } from "@peated/web/lib/communityFeed";
+import {
+  getMemberReviewFeedItems,
+  getTastingFeedItems,
+} from "@peated/web/lib/communityFeed";
 import { logTelemetryError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { selectOtherSeriesBottles } from "@peated/web/lib/seriesBottleRail";
@@ -442,6 +445,9 @@ export function BottleOverviewClient() {
   const externalReviewsQuery = useQuery(
     bottleOverviewQueries.reviews(orpc, bottle.id),
   );
+  const memberReviewsQuery = useQuery(
+    bottleOverviewQueries.memberReviews(orpc, bottle.id),
+  );
   const tastingsQuery = useQuery(
     bottleOverviewQueries.tastings(orpc, bottle.id),
   );
@@ -456,6 +462,10 @@ export function BottleOverviewClient() {
     externalReviewsQuery.data?.results
       .map(getCriticReview)
       .filter((review): review is CriticReviewProps => review !== null) ?? [];
+  const memberReviews = getMemberReviewFeedItems(
+    memberReviewsQuery.data?.results ?? [],
+    bottle,
+  );
   const tastings = getTastingFeedItems(tastingsQuery.data?.results ?? []);
   const recommendations =
     recommendationsQuery.data?.results.map((recommendation) =>
@@ -487,13 +497,21 @@ export function BottleOverviewClient() {
   ) : null;
   const mainPending =
     !criticReviews.length &&
+    !memberReviews.length &&
     !tastings.length &&
-    (externalReviewsQuery.isPending || tastingsQuery.isPending);
+    (externalReviewsQuery.isPending ||
+      memberReviewsQuery.isPending ||
+      tastingsQuery.isPending);
   const mainFailed =
     !criticReviews.length &&
+    !memberReviews.length &&
     !tastings.length &&
     !mainPending &&
-    Boolean(externalReviewsQuery.error && tastingsQuery.error);
+    Boolean(
+      externalReviewsQuery.error &&
+      memberReviewsQuery.error &&
+      tastingsQuery.error,
+    );
   const mainState = mainPending ? (
     <LoadingList label="Loading bottle reviews and tastings" rows={3} />
   ) : mainFailed ? (
@@ -501,12 +519,13 @@ export function BottleOverviewClient() {
       heading="Reviews and tastings are unavailable"
       onRetry={() => {
         void externalReviewsQuery.refetch();
+        void memberReviewsQuery.refetch();
         void tastingsQuery.refetch();
       }}
     >
       We could not load this bottle's reviews or tastings. Try again.
     </SectionError>
-  ) : !criticReviews.length && !tastings.length ? (
+  ) : !criticReviews.length && !memberReviews.length && !tastings.length ? (
     <EmptyState
       action={
         <ButtonLink
@@ -522,7 +541,7 @@ export function BottleOverviewClient() {
       }
       heading="No reviews or tastings yet"
     >
-      This bottle has no published critic reviews or community tastings.
+      This bottle has no published reviews or community tastings.
     </EmptyState>
   ) : null;
 
@@ -541,6 +560,7 @@ export function BottleOverviewClient() {
           url: bottle.imageUrl,
         }}
         mainState={mainState}
+        memberReviews={memberReviews}
         moreTastingsHref={`${getBottleUrl(bottle)}/tastings`}
         recommendationState={
           recommendationsQuery.isPending ? (
@@ -560,7 +580,10 @@ export function BottleOverviewClient() {
       />
 
       {recommendationsQuery.error ||
-      (!mainFailed && (externalReviewsQuery.error || tastingsQuery.error)) ? (
+      (!mainFailed &&
+        (externalReviewsQuery.error ||
+          memberReviewsQuery.error ||
+          tastingsQuery.error)) ? (
         <p
           role="status"
           {...stylex.props(foundationStyles.metadata, styles.partialError)}

--- a/apps/web/src/app/(app)/bottles/[bottleId]/layout.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/layout.tsx
@@ -1,14 +1,11 @@
-import type { ReactNode } from "react";
-import type { Product, WithContext } from "schema-dts";
-
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
-import { summarize } from "@peated/web/lib/markdown";
+import { serializeBottleStructuredData } from "@peated/web/lib/catalogStructuredData";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
 import { getBottleSeoMetadata } from "@peated/web/lib/seoMetadata";
 import { getSession } from "@peated/web/lib/session.server";
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 
 import { BottlePageFrameClient } from "./bottlePageClient.stylex";
 
@@ -33,39 +30,12 @@ export default async function BottleLayout(props: {
     const { client } = await getServerClient();
     bottle = await client.bottles.details({ bottle: canonicalBottle.id });
   }
-  const title = formatBottleDisplayName(bottle);
-  const jsonLd: WithContext<Product> = {
-    "@context": "https://schema.org",
-    "@type": "Product",
-    name: title,
-    image: bottle.imageUrl ?? undefined,
-    description: summarize(bottle.description || "", 200),
-    brand: { "@type": "Brand", name: bottle.brand.name },
-    aggregateRating:
-      bottle.scoreCount > 0 && bottle.medianScore !== null
-        ? {
-            "@type": "AggregateRating",
-            ratingValue: bottle.medianScore,
-            bestRating: 100,
-            worstRating: 0,
-            reviewCount: bottle.scoreCount,
-          }
-        : undefined,
-    offers: bottle.lastPrice
-      ? {
-          "@type": "AggregateOffer",
-          offerCount: 1,
-          lowPrice: bottle.lastPrice.price / 100,
-          highPrice: bottle.lastPrice.price / 100,
-          priceCurrency: bottle.lastPrice.currency,
-        }
-      : undefined,
-  };
+  const structuredData = serializeBottleStructuredData(bottle);
 
   return (
     <>
       <script
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: structuredData }}
         type="application/ld+json"
       />
       <BottlePageFrameClient initialBottle={bottle}>

--- a/apps/web/src/app/(app)/reviews/[reviewId]/page.tsx
+++ b/apps/web/src/app/(app)/reviews/[reviewId]/page.tsx
@@ -1,7 +1,10 @@
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
+import {
+  getMemberReviewSeoMetadata,
+  serializeMemberReviewStructuredData,
+} from "@peated/web/lib/reviewSeo";
 import { cache } from "react";
 
 import { ReviewDetail, ReviewRail } from "./reviewDetail.stylex";
@@ -18,21 +21,7 @@ export async function generateMetadata(props: {
 }) {
   const { reviewId } = await props.params;
   const review = await getReview(Number(reviewId));
-  const title = `${formatBottleDisplayName(review.bottle)} — review by ${review.createdBy.username}`;
-
-  return {
-    title,
-    description: review.notes,
-    openGraph: {
-      title,
-      description: review.notes,
-      images: review.imageUrl ? [review.imageUrl] : undefined,
-    },
-    twitter: {
-      card: review.imageUrl ? "summary_large_image" : "summary",
-      images: review.imageUrl ? [review.imageUrl] : undefined,
-    },
-  };
+  return getMemberReviewSeoMetadata(review);
 }
 
 export default async function ReviewPage(props: {
@@ -40,6 +29,7 @@ export default async function ReviewPage(props: {
 }) {
   const { reviewId } = await props.params;
   const review = await getReview(Number(reviewId));
+  const structuredData = serializeMemberReviewStructuredData(review);
   const { client } = await getPublicPageServerClient();
   const [memberTastings, memberReviews, externalReviews] = await Promise.all([
     client.tastings.list({ user: review.createdBy.id, limit: 4 }),
@@ -59,6 +49,12 @@ export default async function ReviewPage(props: {
       }
       railBehavior="stack"
     >
+      {structuredData && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: structuredData }}
+        />
+      )}
       <ReviewDetail review={review} />
     </PageColumns>
   );

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -43,7 +43,11 @@ import { uploadImageAfterSave } from "@peated/web/lib/imageUpload";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import type { TastingTagSuggestion } from "@peated/web/lib/tastingForm";
-import { getBottleUrl, getTastingUrl } from "@peated/web/lib/urls";
+import {
+  getBottleUrl,
+  getMemberReviewUrl,
+  getTastingUrl,
+} from "@peated/web/lib/urls";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { BookOpen, Eye, Plus, RotateCcw, Search, Wine } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -904,7 +908,7 @@ function AddBottleFlowContent() {
     });
 
     flash("Review saved.", "info");
-    router.push(`/reviews/${review.id}`);
+    router.push(getMemberReviewUrl(review));
   }
 
   if (requestedBottleKey && handledBottleKey !== requestedBottleKey) {

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -37,6 +37,7 @@ export type BottleOverviewProps = {
   flavorProfile?: ReactNode;
   image: BottleOverviewImage;
   mainState?: ReactNode;
+  memberReviews?: readonly CommunityFeedItem[];
   moreTastingsHref?: string;
   recommendationHeading?: string;
   recommendationState?: ReactNode;
@@ -54,6 +55,7 @@ export function BottleOverview({
   flavorProfile,
   image,
   mainState,
+  memberReviews = [],
   moreTastingsHref,
   recommendationHeading = "If you liked this",
   recommendationState,
@@ -101,6 +103,16 @@ export function BottleOverview({
             </section>
           ) : null}
 
+          {memberReviews.length ? (
+            <section {...stylex.props(styles.section)}>
+              <SectionHeading>Member reviews</SectionHeading>
+              <CommunityFeed
+                ariaLabel="Bottle member reviews"
+                items={memberReviews}
+              />
+            </section>
+          ) : null}
+
           {tastings.length ? (
             <section {...stylex.props(styles.section)}>
               <SectionHeading>Tastings</SectionHeading>
@@ -121,7 +133,9 @@ export function BottleOverview({
             </section>
           ) : null}
 
-          {!criticReviews.length && !tastings.length ? mainState : null}
+          {!criticReviews.length && !memberReviews.length && !tastings.length
+            ? mainState
+            : null}
         </div>
       </div>
 

--- a/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
@@ -10,7 +10,7 @@ import {
   TastingRating,
 } from "@peated/web/components";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
-import { getTastingUrl } from "@peated/web/lib/urls";
+import { getMemberReviewUrl, getTastingUrl } from "@peated/web/lib/urls";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 import { BottleRailSection } from "./bottleRailSection.stylex";
@@ -146,7 +146,7 @@ export function TastingReviewRail({
               <RailListItem
                 key={`member-${review.id}`}
                 end={`${review.score}/100`}
-                href={`/reviews/${review.id}`}
+                href={getMemberReviewUrl(review)}
                 metadata={`Member · ${dateFormatter.format(new Date(review.updatedAt))}`}
                 title={review.createdBy.username}
               />

--- a/apps/web/src/lib/catalogStructuredData.test.ts
+++ b/apps/web/src/lib/catalogStructuredData.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  serializeBottleStructuredData,
   serializeCountryStructuredData,
   serializeRegionStructuredData,
   serializeSeriesStructuredData,
@@ -7,6 +8,45 @@ import {
 
 describe("catalog structured data", () => {
   const country = { name: "Scotland", slug: "scotland", description: null };
+  it("marks up a Product without the combined median as an aggregate rating", () => {
+    const data = JSON.parse(
+      serializeBottleStructuredData({
+        id: 42,
+        name: "16-year-old",
+        brand: { name: "Lagavulin" },
+        description: "A smoky Islay single malt.",
+        imageUrl: "https://images.peated.com/lagavulin.jpg",
+        lastPrice: { currency: "USD", price: 8999 },
+      }),
+    );
+
+    expect(data).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "Product",
+      name: "Lagavulin 16-year-old",
+      url: expect.stringContaining("/bottles/42-lagavulin-16-year-old"),
+      offers: {
+        "@type": "AggregateOffer",
+        lowPrice: 89.99,
+        highPrice: 89.99,
+        priceCurrency: "USD",
+      },
+    });
+    expect(data).not.toHaveProperty("aggregateRating");
+  });
+
+  it("escapes Bottle text in structured data", () => {
+    const json = serializeBottleStructuredData({
+      id: 42,
+      name: '</script><script>alert("bottle")</script>',
+      brand: { name: "Example" },
+      description: '</script><script>alert("description")</script>',
+      imageUrl: null,
+      lastPrice: null,
+    });
+    expect(json).not.toContain("<");
+  });
+
   it("describes countries and regions with their browse hierarchy", () => {
     const countryData = JSON.parse(serializeCountryStructuredData(country));
     expect(countryData).toMatchObject({

--- a/apps/web/src/lib/catalogStructuredData.ts
+++ b/apps/web/src/lib/catalogStructuredData.ts
@@ -1,4 +1,9 @@
+import {
+  formatBottleDisplayName,
+  type BottleDisplayNameSource,
+} from "@peated/server/lib/bottleDisplayName";
 import config from "@peated/web/config";
+import { summarize } from "./markdown";
 import {
   getCountrySeoMetadata,
   getRegionSeoMetadata,
@@ -6,12 +11,55 @@ import {
 } from "./seoMetadata";
 import {
   getBottleSeriesUrl,
+  getBottleUrl,
   getCountryUrl,
   getEntityUrl,
   getRegionUrl,
 } from "./urls";
 
 type Breadcrumb = { name: string; url: string };
+
+type BottleStructuredDataSource = BottleDisplayNameSource & {
+  id: number;
+  brand: { name: string };
+  description: string | null;
+  imageUrl: string | null;
+  lastPrice: {
+    currency: string;
+    price: number;
+  } | null;
+};
+
+/** Product markup only contains claims that are visible and owned by Peated. */
+export function serializeBottleStructuredData(
+  bottle: BottleStructuredDataSource,
+): string {
+  const title = formatBottleDisplayName(bottle);
+  const bottleUrl = new URL(getBottleUrl(bottle), config.URL_PREFIX).href;
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "Product",
+    "@id": `${bottleUrl}#product`,
+    url: bottleUrl,
+    name: title,
+    image: bottle.imageUrl ?? undefined,
+    description: summarize(bottle.description || "", 200) || undefined,
+    brand: { "@type": "Brand", name: bottle.brand.name },
+    // Google forbids aggregates that include ratings from other sites. Peated's
+    // saved Bottle score combines member and critic reviews, so it is omitted.
+    offers: bottle.lastPrice
+      ? {
+          "@type": "AggregateOffer",
+          offerCount: 1,
+          lowPrice: bottle.lastPrice.price / 100,
+          highPrice: bottle.lastPrice.price / 100,
+          priceCurrency: bottle.lastPrice.currency,
+        }
+      : undefined,
+  };
+
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
 
 function serializeCollectionPage({
   name,

--- a/apps/web/src/lib/communityFeed.test.ts
+++ b/apps/web/src/lib/communityFeed.test.ts
@@ -1,11 +1,16 @@
 import {
   mockActivity,
   mockExternalReview,
+  mockMemberReview,
   mockTasting,
 } from "@peated/server/orpc/mock/fixtures";
 import { describe, expect, test } from "vitest";
 
-import { getCommunityFeedItems, getTastingFeedItems } from "./communityFeed";
+import {
+  getCommunityFeedItems,
+  getMemberReviewFeedItems,
+  getTastingFeedItems,
+} from "./communityFeed";
 import { getTastingUrl } from "./urls";
 
 const session = mockActivity.find((item) => item.type === "tasting_session")!;
@@ -153,6 +158,28 @@ describe("getTastingFeedItems", () => {
     expect(withoutPhoto?.bottles[0]).toMatchObject({
       imageFit: "contain",
       imageUrl: mockTasting.bottle.imageUrl,
+    });
+  });
+});
+
+describe("getMemberReviewFeedItems", () => {
+  test("maps a member review to a visible Bottle review row", () => {
+    const [item] = getMemberReviewFeedItems(
+      [mockMemberReview],
+      mockMemberReview.bottle,
+    );
+
+    expect(item).toMatchObject({
+      kind: "member_review",
+      actor: mockMemberReview.createdBy.username,
+      action: "reviewed",
+      href: `/reviews/${mockMemberReview.id}`,
+      bottles: [
+        {
+          description: expect.stringContaining("Freshly poured"),
+          score: { value: mockMemberReview.score, scale: 100 },
+        },
+      ],
     });
   });
 });

--- a/apps/web/src/lib/communityFeed.ts
+++ b/apps/web/src/lib/communityFeed.ts
@@ -4,11 +4,16 @@ import type {
   CommunityFeedItem,
 } from "@peated/web/components/communityFeed.stylex";
 import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
-import { getBottleUrl, getTastingUrl } from "@peated/web/lib/urls";
+import {
+  getBottleUrl,
+  getMemberReviewUrl,
+  getTastingUrl,
+} from "@peated/web/lib/urls";
 
 type CriticReview = Outputs["externalReviews"]["list"]["results"][number];
 type Activity = Outputs["activity"]["list"]["results"][number];
 type Bottle = Outputs["bottles"]["list"]["results"][number];
+type MemberReview = Outputs["memberReviews"]["list"]["results"][number];
 type Tasting = Outputs["tastings"]["list"]["results"][number];
 
 function feedBottle(bottle: Bottle): CommunityFeedBottle {
@@ -48,6 +53,31 @@ export function getTastingFeedItems(
   tastings: readonly Tasting[],
 ): CommunityFeedItem[] {
   return tastings.map((tasting) => tastingFeedItem(tasting));
+}
+
+/** Maps public member reviews to the shared activity rows on a Bottle page. */
+export function getMemberReviewFeedItems(
+  reviews: readonly MemberReview[],
+  bottle: Bottle,
+): CommunityFeedItem[] {
+  return reviews.map((review) => ({
+    id: `member-review-${review.id}`,
+    kind: "member_review",
+    actor: review.createdBy.username,
+    actorHref: `/users/${review.createdBy.username}`,
+    actorImageUrl: review.createdBy.pictureUrl,
+    action: "reviewed",
+    date: review.createdAt,
+    href: getMemberReviewUrl(review),
+    bottles: [
+      {
+        ...feedBottle(bottle),
+        id: String(review.id),
+        score: { value: review.score, scale: 100 },
+        description: getPreview(review.notes),
+      },
+    ],
+  }));
 }
 
 export function getCommunityFeedItems({
@@ -131,7 +161,7 @@ export function getCommunityFeedItems({
           kind: "member_review",
           action: "reviewed",
           date: entry.createdAt,
-          href: `/reviews/${entry.review.id}`,
+          href: getMemberReviewUrl(entry.review),
           bottles: [
             {
               ...feedBottle(entry.review.bottle),

--- a/apps/web/src/lib/reviewSeo.test.ts
+++ b/apps/web/src/lib/reviewSeo.test.ts
@@ -1,0 +1,91 @@
+import { mockMemberReview } from "@peated/server/orpc/mock/fixtures";
+import config from "@peated/web/config";
+import { describe, expect, it } from "vitest";
+
+import {
+  getMemberReviewSeoMetadata,
+  serializeMemberReviewStructuredData,
+} from "./reviewSeo";
+
+describe("member review SEO", () => {
+  it("publishes canonical article metadata for a public review", () => {
+    const metadata = getMemberReviewSeoMetadata(mockMemberReview);
+
+    expect(metadata).toMatchObject({
+      title: expect.stringContaining("review by"),
+      description: expect.stringContaining("Freshly poured"),
+      alternates: { canonical: `/reviews/${mockMemberReview.id}` },
+      authors: [
+        {
+          name: mockMemberReview.createdBy.username,
+          url: `/users/${mockMemberReview.createdBy.username}`,
+        },
+      ],
+      openGraph: {
+        type: "article",
+        publishedTime: mockMemberReview.createdAt,
+        modifiedTime: mockMemberReview.updatedAt,
+      },
+      twitter: { card: "summary_large_image" },
+    });
+    expect(metadata.description?.length).toBeLessThanOrEqual(160);
+  });
+
+  it("marks up the reviewed Product and exact member score", () => {
+    const data = JSON.parse(
+      serializeMemberReviewStructuredData(mockMemberReview)!,
+    );
+
+    expect(data).toMatchObject({
+      "@context": "https://schema.org",
+      "@type": "Review",
+      url: `${config.URL_PREFIX}/reviews/${mockMemberReview.id}`,
+      datePublished: mockMemberReview.createdAt,
+      dateModified: mockMemberReview.updatedAt,
+      author: {
+        "@type": "Person",
+        name: mockMemberReview.createdBy.username,
+      },
+      reviewBody: mockMemberReview.notes,
+      reviewRating: {
+        "@type": "Rating",
+        ratingValue: mockMemberReview.score,
+        bestRating: 100,
+        worstRating: 0,
+      },
+      itemReviewed: {
+        "@type": "Product",
+        name: expect.any(String),
+        url: expect.stringContaining("/bottles/"),
+        brand: {
+          "@type": "Brand",
+          name: mockMemberReview.bottle.brand.name,
+        },
+      },
+    });
+  });
+
+  it("escapes member text and excludes private reviews", () => {
+    const unsafe = {
+      ...mockMemberReview,
+      notes: '</script><script>alert("review")</script>',
+      createdBy: {
+        ...mockMemberReview.createdBy,
+        username: '</script><script>alert("author")</script>',
+      },
+    };
+    const json = serializeMemberReviewStructuredData(unsafe)!;
+    expect(json).not.toContain("<");
+    expect(JSON.parse(json).reviewBody).toBe(unsafe.notes);
+
+    const privateReview = {
+      ...mockMemberReview,
+      createdBy: { ...mockMemberReview.createdBy, private: true },
+    };
+    expect(getMemberReviewSeoMetadata(privateReview)).toEqual({
+      title: "Private review",
+      robots: { index: false, follow: false },
+    });
+    expect(serializeMemberReviewStructuredData(privateReview)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/reviewSeo.ts
+++ b/apps/web/src/lib/reviewSeo.ts
@@ -1,0 +1,126 @@
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
+import type { Outputs } from "@peated/server/orpc/router";
+import config from "@peated/web/config";
+import type { Metadata } from "next";
+
+import { getBottleUrl, getMemberReviewUrl } from "./urls";
+
+type MemberReview = Outputs["memberReviews"]["details"];
+type MemberReviewSeoSource = Pick<
+  MemberReview,
+  "id" | "score" | "notes" | "imageUrl" | "createdAt" | "updatedAt"
+> & {
+  bottle: Parameters<typeof getBottleUrl>[0] & {
+    brand: { name: string };
+    imageUrl: string | null;
+  };
+  createdBy: Pick<MemberReview["createdBy"], "username" | "private">;
+};
+
+export function getMemberReviewSeoMetadata(
+  review: MemberReviewSeoSource,
+): Metadata {
+  if (review.createdBy.private) {
+    return {
+      title: "Private review",
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const bottleName = formatBottleDisplayName(review.bottle);
+  const title = `${bottleName} — review by ${review.createdBy.username}`;
+  const notes = review.notes?.replace(/\s+/g, " ").trim();
+  const summary =
+    notes ||
+    `${review.createdBy.username} scored ${bottleName} ${review.score} out of 100.`;
+  const description =
+    summary.length > 160 ? `${summary.slice(0, 157).trimEnd()}...` : summary;
+  const url = getMemberReviewUrl(review);
+  const authorUrl = `/users/${encodeURIComponent(review.createdBy.username)}`;
+  const imageUrl = review.imageUrl || review.bottle.imageUrl;
+  const images = imageUrl
+    ? [
+        {
+          url: imageUrl,
+          alt: review.imageUrl ? title : `${bottleName} bottle`,
+        },
+      ]
+    : undefined;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    authors: [{ name: review.createdBy.username, url: authorUrl }],
+    openGraph: {
+      type: "article",
+      locale: "en_US",
+      siteName: "Peated",
+      title,
+      description,
+      url,
+      publishedTime: review.createdAt,
+      modifiedTime: review.updatedAt,
+      authors: [new URL(authorUrl, config.URL_PREFIX).href],
+      images,
+    },
+    twitter: {
+      card: review.imageUrl ? "summary_large_image" : "summary",
+      title,
+      description,
+      images,
+    },
+  };
+}
+
+/** Review SEO owns attribution: private activity must never enter structured data. */
+export function serializeMemberReviewStructuredData(
+  review: MemberReviewSeoSource,
+): string | null {
+  if (review.createdBy.private) return null;
+
+  const bottleName = formatBottleDisplayName(review.bottle);
+  const reviewUrl = new URL(getMemberReviewUrl(review), config.URL_PREFIX).href;
+  const bottleUrl = new URL(getBottleUrl(review.bottle), config.URL_PREFIX)
+    .href;
+  const title = `${bottleName} — review by ${review.createdBy.username}`;
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "Review",
+    "@id": `${reviewUrl}#review`,
+    name: title,
+    url: reviewUrl,
+    mainEntityOfPage: reviewUrl,
+    datePublished: review.createdAt,
+    dateModified: review.updatedAt,
+    author: {
+      "@type": "Person",
+      name: review.createdBy.username,
+      url: new URL(
+        `/users/${encodeURIComponent(review.createdBy.username)}`,
+        config.URL_PREFIX,
+      ).href,
+    },
+    reviewBody: review.notes?.trim() || undefined,
+    image: review.imageUrl || undefined,
+    reviewRating: {
+      "@type": "Rating",
+      ratingValue: review.score,
+      bestRating: 100,
+      worstRating: 0,
+    },
+    itemReviewed: {
+      "@type": "Product",
+      "@id": `${bottleUrl}#product`,
+      name: bottleName,
+      image: review.bottle.imageUrl || undefined,
+      url: bottleUrl,
+      brand: {
+        "@type": "Brand",
+        name: review.bottle.brand.name,
+      },
+    },
+  };
+
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}

--- a/apps/web/src/lib/tastingSeo.test.ts
+++ b/apps/web/src/lib/tastingSeo.test.ts
@@ -52,7 +52,7 @@ describe("tasting SEO", () => {
     const data = JSON.parse(
       serializeTastingStructuredData({ ...tasting, notes })!,
     );
-    expect(data.mainEntity.text).toBe(notes);
+    expect(data.reviewBody).toBe(notes);
   });
 
   it.each([null, "", " \n\t "])(
@@ -94,31 +94,30 @@ describe("tasting SEO", () => {
     expect(metadata.twitter).toMatchObject({ card: "summary" });
   });
 
-  it("attributes the tasting and identifies the bottle without inventing a review score", () => {
+  it("marks up the tasting as an unscored review without inventing a numeric score", () => {
     const data = JSON.parse(serializeTastingStructuredData(tasting)!);
     expect(data).toMatchObject({
       "@context": "https://schema.org",
-      "@type": "WebPage",
+      "@type": "Review",
       url: `${config.URL_PREFIX}/tastings/123-lagavulin-16-year-old`,
-      mainEntity: {
-        "@type": "CreativeWork",
-        datePublished: tasting.createdAt,
-        author: {
-          "@type": "Person",
-          name: "alice",
-          url: `${config.URL_PREFIX}/users/alice`,
-        },
-        text: tasting.notes,
-        image: tasting.imageUrl,
-        about: {
-          "@type": "Product",
-          name: "Lagavulin 16-year-old",
-          url: `${config.URL_PREFIX}/bottles/42-lagavulin-16-year-old`,
-        },
+      datePublished: tasting.createdAt,
+      author: {
+        "@type": "Person",
+        name: "alice",
+        url: `${config.URL_PREFIX}/users/alice`,
+      },
+      reviewBody: tasting.notes,
+      image: tasting.imageUrl,
+      itemReviewed: {
+        "@type": "Product",
+        name: "Lagavulin 16-year-old",
+        image: tasting.bottle.imageUrl,
+        url: `${config.URL_PREFIX}/bottles/42-lagavulin-16-year-old`,
+        brand: { "@type": "Brand", name: "Lagavulin" },
       },
     });
-    expect(data.mainEntity).not.toHaveProperty("reviewRating");
-    expect(data.mainEntity.about).not.toHaveProperty("aggregateRating");
+    expect(data).not.toHaveProperty("reviewRating");
+    expect(data.itemReviewed).not.toHaveProperty("aggregateRating");
   });
 
   it("safely serializes member text containing HTML and script delimiters", () => {
@@ -130,8 +129,8 @@ describe("tasting SEO", () => {
       createdBy: { ...tasting.createdBy, username },
     })!;
     expect(json).not.toContain("<");
-    expect(JSON.parse(json).mainEntity.text).toBe(notes);
-    expect(JSON.parse(json).mainEntity.author.name).toBe(username);
+    expect(JSON.parse(json).reviewBody).toBe(notes);
+    expect(JSON.parse(json).author.name).toBe(username);
   });
 
   it("omits private content from metadata and structured data", () => {

--- a/apps/web/src/lib/tastingSeo.ts
+++ b/apps/web/src/lib/tastingSeo.ts
@@ -79,33 +79,37 @@ export function serializeTastingStructuredData(
 
   const bottleName = formatBottleDisplayName(tasting.bottle);
   const url = new URL(getTastingUrl(tasting), config.URL_PREFIX).href;
+  const bottleUrl = new URL(getBottleUrl(tasting.bottle), config.URL_PREFIX)
+    .href;
   const title = `${bottleName} — tasting by ${tasting.createdBy.username}`;
   const data = {
     "@context": "https://schema.org",
-    "@type": "WebPage",
-    "@id": url,
+    "@type": "Review",
+    "@id": `${url}#review`,
     url,
     name: title,
-    mainEntity: {
-      // Ratings owns this distinction: a tasting is a personal record, not a scored Review.
-      "@type": "CreativeWork",
-      name: title,
-      mainEntityOfPage: url,
-      datePublished: tasting.createdAt,
-      author: {
-        "@type": "Person",
-        name: tasting.createdBy.username,
-        url: new URL(
-          `/users/${encodeURIComponent(tasting.createdBy.username)}`,
-          config.URL_PREFIX,
-        ).href,
-      },
-      text: tasting.notes?.trim() || undefined,
-      image: tasting.imageUrl || undefined,
-      about: {
-        "@type": "Product",
-        name: bottleName,
-        url: new URL(getBottleUrl(tasting.bottle), config.URL_PREFIX).href,
+    mainEntityOfPage: url,
+    datePublished: tasting.createdAt,
+    author: {
+      "@type": "Person",
+      name: tasting.createdBy.username,
+      url: new URL(
+        `/users/${encodeURIComponent(tasting.createdBy.username)}`,
+        config.URL_PREFIX,
+      ).href,
+    },
+    reviewBody: tasting.notes?.trim() || undefined,
+    image: tasting.imageUrl || undefined,
+    // Ratings owns the score: a named tasting rating must not become a numeric reviewRating.
+    itemReviewed: {
+      "@type": "Product",
+      "@id": `${bottleUrl}#product`,
+      name: bottleName,
+      image: tasting.bottle.imageUrl || undefined,
+      url: bottleUrl,
+      brand: {
+        "@type": "Brand",
+        name: tasting.bottle.brand.name,
       },
     },
   };

--- a/apps/web/src/lib/urls.test.ts
+++ b/apps/web/src/lib/urls.test.ts
@@ -4,6 +4,7 @@ import {
   getBottleUrl,
   getEntityKindSearchUrl,
   getEntityUrl,
+  getMemberReviewUrl,
   getTastingUrl,
 } from "./urls";
 
@@ -22,6 +23,10 @@ describe("public catalog URLs", () => {
     expect(getTastingUrl({ id: 456, bottle })).toBe(
       "/tastings/456-lagavulin-16-year-old",
     );
+  });
+
+  it("uses the member review collection and ID", () => {
+    expect(getMemberReviewUrl({ id: 789 })).toBe("/reviews/789");
   });
 
   it.each([

--- a/apps/web/src/lib/urls.ts
+++ b/apps/web/src/lib/urls.ts
@@ -28,6 +28,12 @@ export function getTastingUrl(tasting: {
   return `/tastings/${tasting.id}-${slug}`;
 }
 
+export function getMemberReviewUrl(review: {
+  id: number;
+}): `/reviews/${number}` {
+  return `/reviews/${review.id}`;
+}
+
 export function getBottleSeriesUrl(series: {
   id: number;
   fullName: string;

--- a/docs/architecture/ratings.md
+++ b/docs/architecture/ratings.md
@@ -79,9 +79,10 @@ remain valid. Web links, canonical metadata, structured data, and sitemaps use
 the current slug.
 
 Search descriptions summarize the notes or fall back to the bottle,
-author, and optional rating name. Structured data describes an authored
-`CreativeWork` about a Bottle, without converting tasting bands to review
-scores.
+author, and optional rating name. Structured data uses schema.org's broad
+`Review` type for the authored tasting note about a Bottle. It does not add a
+numeric `reviewRating` because tasting ratings are named categories, not review
+scores. This search representation does not change the stored Tasting model.
 
 The tasting sitemap reads through the anonymous API and includes only public
 tasting URLs. It uses the total tasting count as an upper bound, so private
@@ -93,6 +94,11 @@ not expose a reliable edit timestamp.
 `member_review` owns member scores. A member can have at most one review for an
 exact Bottle. Saving again updates that review. A Bottle merge keeps the review
 with the latest `updatedAt`. A larger review ID breaks an exact time tie.
+
+Public member review pages expose schema.org `Review` data with the stored
+0–100 score. Bottle overview pages show recent public member reviews and may
+reference one in structured data. Private members' reviews never enter search
+metadata or structured data.
 
 Review privacy controls attribution only. A private member's review is hidden
 from people who cannot view that member's activity. Its score still enters the
@@ -167,6 +173,11 @@ data. Application code calls them `legacySimpleRatingAverage` and
 `scoreCount` is the sum of the two score counts in the API. The score and range
 stay `null` when no counted scores exist. The median uses the lower middle value
 when the count is even.
+
+Bottle structured data does not expose this combined median as an
+`AggregateRating`. Search engines define that value as an average and prohibit
+aggregating ratings from other sites, while Peated's Bottle summary is a median
+of member and eligible external review scores.
 
 Bottle presentation derives one rating from these saved summaries. When a
 review median exists, its matching band supplies the label and the median stays


### PR DESCRIPTION
Bottle pages now publish Product markup without treating the combined median as an `AggregateRating`, show recent public member reviews, and attach a real member `Review` when one is available. Member-review pages publish canonical and social metadata plus scored `Review` JSON-LD, while tasting pages publish unscored `Review` markup without converting named tasting bands into numeric scores. Private reviews remain excluded from search metadata and structured data.

This keeps search claims aligned with Peated's ratings model: Bottle summaries combine member and eligible external scores and use a median, so they are not valid Google aggregate ratings. The new review markup is tied to visible Peated content and safely serialized.
