### PR TITLE
docs(catalog): record Springbank Open Day repair

### DIFF
--- a/docs/research/catalog-research-examples-2026-09.md
+++ b/docs/research/catalog-research-examples-2026-09.md
@@ -28,6 +28,56 @@ Sources found in earlier Peated catalog tasks. Recheck each site before use.
 | Suntory and Yamazaki | [Essence](https://www.suntory.co.jp/whisky/essence/), [Hibiki](https://www.suntory.co.jp/whisky/hibiki/portfolio/), [Hakushu](https://www.suntory.co.jp/whisky/hakushu/lineup/), [global news](https://www.suntoryglobalspirits.com/news), Whisky Auctioneer                                                                                                                                       | Japanese pages listed more than global pages                               |
 | Wolves Whiskey       | [Producer archive](https://wolveswhiskeyca.com/collections/archive), Shopify product data, [TTB COLA](https://www.ttbonline.gov/colasonline/publicSearchColasBasic.do), PR Newswire, venue shops                                                                                                                                                                                                   | Venue releases and collaborations were missing from the main archive       |
 
+## Springbank Open Day naming repair — September 5, 2026
+
+This production repair covered the 32 existing Springbank, Longrow, and
+Hazelburn Bottles returned by the `springbank open day` search after Series
+membership was repaired. It included the ordinary Open Day releases, the 2020
+Virtual Open Day replacements, and the 2021 Online Tasting Week replacements.
+The scope was the existing naming set, not a full historical Bottle backfill.
+Source-confirmed Springbank releases from 2010, 2014, 2017, and 2022 were not
+created during this repair.
+
+- The producer's December 2025 [Washback Bar menu](https://www.springbank.scot/wp-content/uploads/sites/2/2025/12/The-Washback-Bar-Menu-December-2025.pdf)
+  groups the releases under Open Day and lists the Brand, age, event year,
+  maturation, and strength for Springbank, Longrow, and Hazelburn releases from
+  2018 through 2025, including the 2020 and 2021 replacement events. The menu
+  supports keeping age and year out of the stable Bottle name, but it is not a
+  complete historical inventory.
+- Whisky Auctioneer's [Springbank](https://whiskyauctioneer.com/learn/explore-whisky/series/springbank-open-day-bottlings),
+  [Longrow](https://whiskyauctioneer.com/learn/explore-whisky/series/longrow-springbank-open-day-bottlings),
+  and [Hazelburn](https://whiskyauctioneer.com/learn/explore-whisky/series/hazelburn-springbank-open-day-bottlings)
+  Series pages and exact Bottle pages supplied label-backed event names and
+  years. Their Series inventories are useful gap finders but do not prove that
+  every annual release is listed.
+- The 2026 set was checked against the exact [set listing](https://whiskyinternationalonline.com/products/campbeltown-malts-festival-open-day-2026-springbank-longrow-hazelburn-set)
+  and [Springbank auction record](https://www.scotchwhiskyauctions.com/auctions/230-the-181st-auction/885012-springbank-30-year-old-open-day-2026-35cl/).
+  These establish the shared 2026 event descriptor and the three distinct ages
+  and strengths.
+- The 2021 Longrow identity was checked against its exact
+  [Whisky Auctioneer record](https://whiskyauctioneer.com/learn/explore-whisky/bottles/longrow-17-year-old-online-tasting-week-may-2021)
+  and [Whiskybase record](https://www.whiskybase.com/whiskies/whisky/180545/longrow-17-year-old?language=en).
+  Both support Online Tasting Week 2021, age 17, 50.5% ABV, fresh rum casks,
+  and an outturn of 1,025; this repair changed only its name, edition, and
+  Series membership.
+- Two Longrow duplicate pairs remain pending explicit merge approval. B2545
+  and B53899 describe the same 15-year-old 2004/2019 fresh-rum release; the
+  [Whiskyfun Longrow index](https://www.whiskyfun.com/Longrow.html) confirms
+  the 2004 vintage, 2019 release, 15-year age, and 52.4% ABV. B2904 and B53897
+  describe the same 13-year-old 2005/2018 refill-port release; the exact
+  [contemporary review](https://maltklaus.net/dailydram/2018/08/22/tasting-longrow-open-day-2018-13-yo-refill-port/)
+  confirms the 2005 vintage, 2018 bottling, age, 58.7% ABV, refill-port cask,
+  and 1,096-bottle outturn. The older IDs each own an accepted import reference,
+  so they are the recommended survivors.
+- Fifteen Bottles were updated, one Springbank Open Day Series was created, and
+  the Longrow and Hazelburn Series descriptions were updated. Fifteen Bottle
+  records needed no naming change. No Bottle images were copied because the
+  useful producer, retailer, and auction pages did not state reusable image
+  rights. Every changed Bottle was re-fetched with its edit context, aliases,
+  and references; all groups contained one Bottle, and the final Series counts
+  were 13 Longrow, 9 Hazelburn, and 8 Springbank releases before duplicate
+  merges.
+
 ## Ardbeg — September 5, 2026
 
 The production review started with 204 active Bottles whose Brand was Ardbeg.


### PR DESCRIPTION
Records the evidence and production outcome of the Springbank, Longrow, and Hazelburn Open Day naming repair.

The research entry captures the normalized event names and edition years, verified Series membership, source coverage and limits, and the two duplicate pairs that still require separate merge approval. This PR is documentation-only; the catalog edits are already live.

Validated with `pnpm exec prettier --check docs/research/catalog-research-examples-2026-09.md`.
