### PR TITLE
fix(scraper): space requests evenly and pause blocked sites

### DIFF
--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -63,93 +63,95 @@ export const SERVING_STYLE_LIST = ["neat", "rocks", "splash"] as const;
 export const RESERVED_COLLECTION_SLUGS = ["default", "library"] as const;
 export type ReservedCollectionSlug = (typeof RESERVED_COLLECTION_SLUGS)[number];
 
+// `initialRunEvery` applies only when a site is first added. Change an existing
+// schedule through the admin API.
 export const EXTERNAL_SITE_DEFINITIONS = {
   // Astor stays manual-only while its non-browser catalog behavior is checked.
-  astorwines: { name: "Astor Wines", runEvery: null },
+  astorwines: { name: "Astor Wines", initialRunEvery: null },
   // Berry Bros. & Rudd does not run automatically because robots.txt does not
   // allow its search page.
-  berrybrosrudd: { name: "Berry Bros. & Rudd", runEvery: null },
-  bruichladdich: { name: "Bruichladdich", runEvery: 10080 },
-  cadenheads: { name: "Cadenheads", runEvery: 10080 },
-  compassbox: { name: "Compass Box", runEvery: 10080 },
-  decadentdrinks: { name: "Decadent Drinks", runEvery: 10080 },
-  douglaslaing: { name: "Douglas Laing", runEvery: 10080 },
-  dramfool: { name: "Dramfool", runEvery: 10080 },
-  edradour: { name: "Edradour", runEvery: 10080 },
-  finedrams: { name: "Fine Drams", runEvery: 10080 },
-  glenallachie: { name: "The GlenAllachie", runEvery: 10080 },
-  gordonmacphail: { name: "Gordon Macphail", runEvery: 10080 },
-  healthyspirits: { name: "Healthy Spirits", runEvery: 10080 },
-  kilchoman: { name: "Kilchoman", runEvery: 10080 },
-  masterofmalt: { name: "Master of Malt", runEvery: 10080 },
-  missionliquor: { name: "Mission Liquor", runEvery: 10080 },
-  ncnean: { name: "Nc'nean", runEvery: 10080 },
-  northstarspirits: { name: "North Star", runEvery: 10080 },
-  reservebar: { name: "ReserveBar", runEvery: 10080 },
-  singlecasknation: { name: "Single Cask Nation", runEvery: 10080 },
-  smws: { name: "The Scotch Malt Whisky Society", runEvery: 10080 },
+  berrybrosrudd: { name: "Berry Bros. & Rudd", initialRunEvery: null },
+  bruichladdich: { name: "Bruichladdich", initialRunEvery: 10080 },
+  cadenheads: { name: "Cadenheads", initialRunEvery: 10080 },
+  compassbox: { name: "Compass Box", initialRunEvery: 10080 },
+  decadentdrinks: { name: "Decadent Drinks", initialRunEvery: 10080 },
+  douglaslaing: { name: "Douglas Laing", initialRunEvery: 10080 },
+  dramfool: { name: "Dramfool", initialRunEvery: 10080 },
+  edradour: { name: "Edradour", initialRunEvery: 10080 },
+  finedrams: { name: "Fine Drams", initialRunEvery: 10080 },
+  glenallachie: { name: "The GlenAllachie", initialRunEvery: 10080 },
+  gordonmacphail: { name: "Gordon Macphail", initialRunEvery: 10080 },
+  healthyspirits: { name: "Healthy Spirits", initialRunEvery: 10080 },
+  kilchoman: { name: "Kilchoman", initialRunEvery: 10080 },
+  masterofmalt: { name: "Master of Malt", initialRunEvery: 10080 },
+  missionliquor: { name: "Mission Liquor", initialRunEvery: 10080 },
+  ncnean: { name: "Nc'nean", initialRunEvery: 10080 },
+  northstarspirits: { name: "North Star", initialRunEvery: 10080 },
+  reservebar: { name: "ReserveBar", initialRunEvery: 10080 },
+  singlecasknation: { name: "Single Cask Nation", initialRunEvery: 10080 },
+  smws: { name: "The Scotch Malt Whisky Society", initialRunEvery: 10080 },
   smwsa: {
     name: "The Scotch Malt Whisky Society (America)",
-    runEvery: 10080,
+    initialRunEvery: 10080,
   },
-  thompsonbros: { name: "Thompson Bros.", runEvery: 10080 },
+  thompsonbros: { name: "Thompson Bros.", initialRunEvery: 10080 },
   // Total Wine requires an interactive human-verification challenge. Its
   // traffic target remains disabled while existing data stays visible.
-  totalwine: { name: "Total Wines", runEvery: null },
-  woodencork: { name: "Wooden Cork", runEvery: 10080 },
+  totalwine: { name: "Total Wines", initialRunEvery: null },
+  woodencork: { name: "Wooden Cork", initialRunEvery: 10080 },
   bourbonculture: {
     name: "Bourbon Culture",
-    runEvery: 1440,
+    initialRunEvery: 1440,
     content: "reviews",
   },
   dramface: {
     name: "Dramface",
-    runEvery: 1440,
+    initialRunEvery: 1440,
     content: "reviews",
   },
   fredminnick: {
     name: "Fred Minnick",
-    runEvery: 1440,
+    initialRunEvery: 1440,
     content: "reviews",
   },
   whiskeyreviewer: {
     name: "The Whiskey Reviewer",
-    runEvery: 1440,
+    initialRunEvery: 1440,
     content: "reviews",
   },
   whiskyadvocate: {
     name: "Whisky Advocate",
-    runEvery: null,
+    initialRunEvery: null,
     content: "reviews",
   },
   whiskyfun: {
     name: "Whiskyfun",
-    runEvery: 1440,
+    initialRunEvery: 1440,
     content: "reviews",
   },
   whiskysaga: {
     name: "Whisky Saga",
-    runEvery: 1440,
+    initialRunEvery: 1440,
     content: "reviews",
   },
   whiskystudy: {
     name: "The Whisky Study",
-    runEvery: 1440,
+    initialRunEvery: 1440,
     content: "reviews",
   },
   whiskynotes: {
     name: "WhiskyNotes",
-    runEvery: 1440,
+    initialRunEvery: 1440,
     content: "reviews",
   },
   wordsofwhisky: {
     name: "Words of Whisky",
-    runEvery: 1440,
+    initialRunEvery: 1440,
     content: "reviews",
   },
   // WhiskyWorld does not run automatically because the site blocks our
   // robots.txt check.
-  whiskyworld: { name: "The Whisky World", runEvery: null },
+  whiskyworld: { name: "The Whisky World", initialRunEvery: null },
 } as const;
 
 type RegisteredExternalSiteKey = keyof typeof EXTERNAL_SITE_DEFINITIONS;

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -146,7 +146,8 @@ export const EXTERNAL_SITE_DEFINITIONS = {
     runEvery: 1440,
     content: "reviews",
   },
-  whiskyworld: { name: "The Whisky World", runEvery: 10080 },
+  // WhiskyWorld stays manual-only because the site returns 403 for robots.txt.
+  whiskyworld: { name: "The Whisky World", runEvery: null },
 } as const;
 
 type RegisteredExternalSiteKey = keyof typeof EXTERNAL_SITE_DEFINITIONS;

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -66,7 +66,8 @@ export type ReservedCollectionSlug = (typeof RESERVED_COLLECTION_SLUGS)[number];
 export const EXTERNAL_SITE_DEFINITIONS = {
   // Astor stays manual-only while its non-browser catalog behavior is checked.
   astorwines: { name: "Astor Wines", runEvery: null },
-  // Berry Bros. & Rudd stays manual-only because robots.txt disallows its search page.
+  // Berry Bros. & Rudd does not run automatically because robots.txt does not
+  // allow its search page.
   berrybrosrudd: { name: "Berry Bros. & Rudd", runEvery: null },
   bruichladdich: { name: "Bruichladdich", runEvery: 10080 },
   cadenheads: { name: "Cadenheads", runEvery: 10080 },
@@ -146,7 +147,8 @@ export const EXTERNAL_SITE_DEFINITIONS = {
     runEvery: 1440,
     content: "reviews",
   },
-  // WhiskyWorld stays manual-only because the site returns 403 for robots.txt.
+  // WhiskyWorld does not run automatically because the site blocks our
+  // robots.txt check.
   whiskyworld: { name: "The Whisky World", runEvery: null },
 } as const;
 

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -66,7 +66,8 @@ export type ReservedCollectionSlug = (typeof RESERVED_COLLECTION_SLUGS)[number];
 export const EXTERNAL_SITE_DEFINITIONS = {
   // Astor stays manual-only while its non-browser catalog behavior is checked.
   astorwines: { name: "Astor Wines", runEvery: null },
-  berrybrosrudd: { name: "Berry Bros. & Rudd", runEvery: 10080 },
+  // Berry Bros. & Rudd stays manual-only because robots.txt disallows its search page.
+  berrybrosrudd: { name: "Berry Bros. & Rudd", runEvery: null },
   bruichladdich: { name: "Bruichladdich", runEvery: 10080 },
   cadenheads: { name: "Cadenheads", runEvery: 10080 },
   compassbox: { name: "Compass Box", runEvery: 10080 },

--- a/apps/server/src/lib/externalSites.test.ts
+++ b/apps/server/src/lib/externalSites.test.ts
@@ -8,7 +8,7 @@ import { eq } from "drizzle-orm";
 import { expect, test } from "vitest";
 import { syncExternalSites } from "./externalSites";
 
-test("syncs code-owned external-site definitions", async () => {
+test("adds missing sites without replacing existing schedules", async () => {
   const nextRunAt = new Date("2026-08-14T12:00:00Z");
   const [existing] = await db
     .insert(externalSites)
@@ -40,7 +40,10 @@ test("syncs code-owned external-site definitions", async () => {
     .select()
     .from(externalSites)
     .where(eq(externalSites.type, "finedrams"));
-  expect(fineDrams).toMatchObject(EXTERNAL_SITE_DEFINITIONS.finedrams);
+  expect(fineDrams).toMatchObject({
+    name: EXTERNAL_SITE_DEFINITIONS.finedrams.name,
+    runEvery: EXTERNAL_SITE_DEFINITIONS.finedrams.initialRunEvery,
+  });
 
   const publications = await db.select().from(externalReviewPublications);
   expect(publications).toHaveLength(10);

--- a/apps/server/src/lib/externalSites.ts
+++ b/apps/server/src/lib/externalSites.ts
@@ -17,7 +17,7 @@ export class ExternalSiteNotFoundError extends Error {
   }
 }
 
-/** Keeps durable foreign-key rows aligned with the code-owned scraper list. */
+/** Adds missing site rows without replacing schedules changed by an admin. */
 export async function syncExternalSites() {
   await db.transaction(async (tx) => {
     for (const [key, definition] of Object.entries(EXTERNAL_SITE_DEFINITIONS)) {
@@ -27,7 +27,7 @@ export async function syncExternalSites() {
         .values({
           type: siteKey,
           name: definition.name,
-          runEvery: definition.runEvery,
+          runEvery: definition.initialRunEvery,
         })
         .onConflictDoUpdate({
           target: externalSites.type,

--- a/apps/server/src/orpc/routes/external-sites/health.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.test.ts
@@ -112,6 +112,7 @@ test("health list reports source inventory, runtime, and latest execution", asyn
         {
           key: "decadentdrinks",
           enabled: true,
+          minimumSpacingMs: 12_000,
           origins: [
             {
               origin: "https://decadent-drinks.com",

--- a/apps/server/src/orpc/routes/external-sites/health.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.ts
@@ -23,7 +23,7 @@ import {
   type ExternalSiteScrapeTargetSchema,
 } from "@peated/server/schemas";
 import { getScraperRegistration } from "@peated/server/scraper";
-import { getRequestSpacingMs } from "@peated/server/scraper/definitions";
+import { getRequestDelayMs } from "@peated/server/scraper/definitions";
 import {
   serializeExternalReviewPublication,
   serializeExternalSite,
@@ -203,7 +203,7 @@ async function getHealthForSites(
         blockedUntil: row.blockedUntil?.toISOString() ?? null,
         coolingDown:
           row.blockedUntil !== null && row.blockedUntil.getTime() > now,
-        minimumSpacingMs: getRequestSpacingMs(row),
+        minimumSpacingMs: getRequestDelayMs(row),
         requestsPerWindow: row.requestsPerWindow,
         windowMs: row.windowMs,
         origins: [],

--- a/apps/server/src/orpc/routes/external-sites/health.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.ts
@@ -23,6 +23,7 @@ import {
   type ExternalSiteScrapeTargetSchema,
 } from "@peated/server/schemas";
 import { getScraperRegistration } from "@peated/server/scraper";
+import { getRequestSpacingMs } from "@peated/server/scraper/definitions";
 import {
   serializeExternalReviewPublication,
   serializeExternalSite,
@@ -202,7 +203,7 @@ async function getHealthForSites(
         blockedUntil: row.blockedUntil?.toISOString() ?? null,
         coolingDown:
           row.blockedUntil !== null && row.blockedUntil.getTime() > now,
-        minimumSpacingMs: row.minimumSpacingMs,
+        minimumSpacingMs: getRequestSpacingMs(row),
         requestsPerWindow: row.requestsPerWindow,
         windowMs: row.windowMs,
         origins: [],

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -61,9 +61,10 @@ bridge dependency when converting it to a native adapter, then move it out of
 Use the same target for multiple sources only when they share a remote
 operator's capacity. Use multiple exact origins under that target when one
 operator intentionally serves an integration from several hosts. Never infer
-this grouping from a registrable domain. Stricter limits need no exception;
-less restrictive spacing, window, or quota requires a reviewed rationale in
-the code-owned definition.
+this grouping from a registrable domain. The runtime spreads every request
+allowance across its full window: 60 requests per hour means at most one
+request per minute. A longer minimum delay slows that rate further. A faster
+rate requires a reviewed rationale in the code-owned definition.
 
 ## Scrape sources
 

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -58,19 +58,20 @@ active scraper session; new sources must not use it. Remove a legacy source's
 bridge dependency when converting it to a native adapter, then move it out of
 `adapters/legacy/`.
 
-Use the same target for multiple sources only when they share a remote
-operator's capacity. Use multiple exact origins under that target when one
-operator intentionally serves an integration from several hosts. Never infer
-this grouping from a registrable domain. The runtime spreads every request
-allowance across its full window: 60 requests per hour means at most one
-request per minute. A longer minimum delay slows that rate further. A faster
-rate requires a reviewed rationale in the code-owned definition.
+Give sources the same target only when the same organization runs them and they
+must share one request limit. A target may list several web addresses when that
+organization uses more than one host. Do not group sites from their domain
+names alone.
+
+Set `requestsPerHour` for each target. The scraper waits between requests so
+they fill the hour evenly: 60 per hour means one request per minute. A value
+above 60 needs a short reason.
 
 ## Scrape sources
 
 Admins can add a review or store-price source in Admin → Scrapers. These
-sources use the same run, request, robots, limit, retry, validation, and sink
-boundaries as code-owned sources.
+sources use the same runs, requests, robots.txt checks, limits, retries,
+validation, and saving code as built-in sources.
 
 To replace an existing scraper, follow
 [Move an existing scraper to saved rules](../../../../docs/operations/configured-scraper-migration.md).
@@ -110,8 +111,8 @@ The setup agent submits this same rule shape, and the saved revision and parser
 use it directly. There is no setup-only translation step.
 Rules do not support
 scripts, custom code, arbitrary request headers, browser automation, numbered
-page templates, infinite scrolling, or cross-origin discovery. Add a code-owned
-adapter when a source needs those capabilities.
+page templates, infinite scrolling, or links to another website. Add a built-in
+adapter when a source needs one of those features.
 
 Adding a source starts AI setup. The server reads the main page, up to four
 likely list pages on the same website, and any optional example review or

--- a/apps/server/src/scraper/configured/createScraper.eval.test.ts
+++ b/apps/server/src/scraper/configured/createScraper.eval.test.ts
@@ -133,8 +133,8 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
           },
           context,
         );
-        // This origin is owned by the test. Keep pacing enabled without making
-        // the live-model suite wait a minute between fixture requests.
+        // The test controls this local site. One request per second keeps the
+        // check quick while still testing the wait between requests.
         await db
           .update(scrapeTargets)
           .set({ minimumSpacingMs: 1_000, requestsPerWindow: 3_600 })

--- a/apps/server/src/scraper/configured/createScraper.eval.test.ts
+++ b/apps/server/src/scraper/configured/createScraper.eval.test.ts
@@ -5,6 +5,7 @@ import {
   externalReviews,
   externalSiteRuns,
   memberReviews,
+  scrapeTargets,
 } from "@peated/server/db/schema";
 import { loadScoredExternalReviews } from "@peated/server/externalReviews/scoredReviews";
 import { isAIGatewayConfigured } from "@peated/server/lib/openaiClient";
@@ -32,18 +33,20 @@ import { AI_INSTRUCTIONS_VERSION } from "./setupAgent";
 import { reviewWebsites, startReviewWebsite } from "./testWebsites";
 
 let fixtureWebsite: Awaited<ReturnType<typeof startReviewWebsite>> | undefined;
-let workerRuntime: WorkerRuntime;
+let workerRuntime: WorkerRuntime | undefined;
 
 async function clearQueue(queue: WorkerRuntime["queues"][number]) {
   await queue.obliterate({ force: true });
 }
 
 async function waitForWorker() {
+  if (!workerRuntime) throw new Error("Worker runtime is not running.");
+  const runtime = workerRuntime;
   const deadline = Date.now() + 290_000;
   let idleChecks = 0;
   while (Date.now() < deadline) {
     const counts = await Promise.all(
-      workerRuntime.queues.map(async (queue) => ({
+      runtime.queues.map(async (queue) => ({
         pending: await queue.getJobCountByTypes(
           "active",
           "delayed",
@@ -82,14 +85,14 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
       await Promise.all(queues.map(clearQueue));
       await Promise.all(queues.map((queue) => queue.close()));
       useQueueWorkerDispatch();
-      workerRuntime = await startWorkerRuntime();
     });
     afterAll(async () => {
-      await workerRuntime.close();
       await gracefulShutdown();
       installInMemoryWorkerDispatch();
     });
     afterEach(async () => {
+      await workerRuntime?.close();
+      workerRuntime = undefined;
       await fixtureWebsite?.close();
       fixtureWebsite = undefined;
     });
@@ -130,6 +133,13 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
           },
           context,
         );
+        // This origin is owned by the test. Keep pacing enabled without making
+        // the live-model suite wait a minute between fixture requests.
+        await db
+          .update(scrapeTargets)
+          .set({ minimumSpacingMs: 1_000, requestsPerWindow: 3_600 })
+          .where(eq(scrapeTargets.key, source.site.type));
+        workerRuntime = await startWorkerRuntime();
         expect(source).toMatchObject({
           enabled: false,
           activeRevisionId: null,

--- a/apps/server/src/scraper/configured/prepareExistingSource.ts
+++ b/apps/server/src/scraper/configured/prepareExistingSource.ts
@@ -21,7 +21,7 @@ export type ExistingSourceDefinition = {
   origin: string;
 };
 
-/** Locks and checks one code-owned source before its records are inspected. */
+/** Locks and checks one built-in source before reading its records. */
 export async function inspectExistingSource(
   tx: AnyTransaction,
   definition: ExistingSourceDefinition,

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -541,11 +541,11 @@ test("follows a bounded next-page selector", async () => {
 });
 
 test("resumes configured previews without rereading completed pages", async () => {
-  const { pinned, revision, site } = await setupPreview("h1", true);
+  const { pinned, revision } = await setupPreview("h1", true);
   await db
-    .update(scrapeTargets)
-    .set({ requestsPerWindow: 3, windowMs: 60_000 })
-    .where(eq(scrapeTargets.key, site.type));
+    .update(externalSiteRuns)
+    .set({ requestLimit: 3 })
+    .where(eq(externalSiteRuns.id, pinned.run.id));
   const fetchImpl = previewFetch(true);
   const clock = controllableClock();
 

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -100,6 +100,7 @@ test("creates a site and its admin-owned request rows", async () => {
       key: "reviews-example",
       managedBy: "admin",
       enabled: true,
+      minimumSpacingMs: 60_000,
     }),
   ]);
   expect(await db.select().from(scrapeOrigins)).toEqual([

--- a/apps/server/src/scraper/configured/service.ts
+++ b/apps/server/src/scraper/configured/service.ts
@@ -18,7 +18,10 @@ import { ExternalSiteKeySchema } from "@peated/server/schemas/externalSites";
 import slugify from "@sindresorhus/slugify";
 import { and, desc, eq, max } from "drizzle-orm";
 import { z } from "zod";
-import { DEFAULT_SCRAPER_REQUEST_POLICY } from "../definitions";
+import {
+  DEFAULT_SCRAPER_REQUEST_POLICY,
+  getRequestSpacingMs,
+} from "../definitions";
 import type { ScrapeSourcePreviewResult } from "./preview";
 import {
   SCRAPE_RULES_VERSION,
@@ -90,7 +93,7 @@ export async function createSiteWithScrapeSource(
         key,
         managedBy: "admin",
         enabled: true,
-        minimumSpacingMs: DEFAULT_SCRAPER_REQUEST_POLICY.minimumSpacingMs,
+        minimumSpacingMs: getRequestSpacingMs(DEFAULT_SCRAPER_REQUEST_POLICY),
         requestsPerWindow: DEFAULT_SCRAPER_REQUEST_POLICY.requestsPerWindow,
         windowMs: DEFAULT_SCRAPER_REQUEST_POLICY.windowMs,
         timeoutMs: DEFAULT_SCRAPER_REQUEST_POLICY.timeoutMs,

--- a/apps/server/src/scraper/configured/service.ts
+++ b/apps/server/src/scraper/configured/service.ts
@@ -19,8 +19,8 @@ import slugify from "@sindresorhus/slugify";
 import { and, desc, eq, max } from "drizzle-orm";
 import { z } from "zod";
 import {
-  DEFAULT_SCRAPER_REQUEST_POLICY,
-  getRequestSpacingMs,
+  DEFAULT_SCRAPER_SETTINGS,
+  getHourlyRequestSettings,
 } from "../definitions";
 import type { ScrapeSourcePreviewResult } from "./preview";
 import {
@@ -93,12 +93,10 @@ export async function createSiteWithScrapeSource(
         key,
         managedBy: "admin",
         enabled: true,
-        minimumSpacingMs: getRequestSpacingMs(DEFAULT_SCRAPER_REQUEST_POLICY),
-        requestsPerWindow: DEFAULT_SCRAPER_REQUEST_POLICY.requestsPerWindow,
-        windowMs: DEFAULT_SCRAPER_REQUEST_POLICY.windowMs,
-        timeoutMs: DEFAULT_SCRAPER_REQUEST_POLICY.timeoutMs,
-        maxResponseBytes: DEFAULT_SCRAPER_REQUEST_POLICY.maxResponseBytes,
-        maxRetries: DEFAULT_SCRAPER_REQUEST_POLICY.maxRetries,
+        ...getHourlyRequestSettings(DEFAULT_SCRAPER_SETTINGS.requestsPerHour),
+        timeoutMs: DEFAULT_SCRAPER_SETTINGS.timeoutMs,
+        maxResponseBytes: DEFAULT_SCRAPER_SETTINGS.maxResponseBytes,
+        maxRetries: DEFAULT_SCRAPER_SETTINGS.maxRetries,
       });
       await tx.insert(scrapeOrigins).values({
         origin,

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -3,6 +3,7 @@ import {
   scrapeOrigins,
   scrapeSourceRevisions,
   scrapeSourceRuns,
+  scrapeTargets,
   users,
 } from "@peated/server/db/schema";
 import { isAIGatewayConfigured } from "@peated/server/lib/openaiClient";
@@ -171,6 +172,12 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         name: "Price Fixture",
         sampleUrls: [],
       });
+      // This origin is owned by the test. Keep pacing enabled without making
+      // the live-model suite wait a minute between fixture requests.
+      await db
+        .update(scrapeTargets)
+        .set({ minimumSpacingMs: 1_000, requestsPerWindow: 3_600 })
+        .where(eq(scrapeTargets.key, site.type));
       await db
         .update(scrapeOrigins)
         .set({

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -172,8 +172,8 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         name: "Price Fixture",
         sampleUrls: [],
       });
-      // This origin is owned by the test. Keep pacing enabled without making
-      // the live-model suite wait a minute between fixture requests.
+      // The test controls this local site. One request per second keeps the
+      // check quick while still testing the wait between requests.
       await db
         .update(scrapeTargets)
         .set({ minimumSpacingMs: 1_000, requestsPerWindow: 3_600 })

--- a/apps/server/src/scraper/configured/target.ts
+++ b/apps/server/src/scraper/configured/target.ts
@@ -5,7 +5,6 @@ import {
   scrapeOrigins,
 } from "@peated/server/db/schema";
 import { and, eq } from "drizzle-orm";
-import { getRequestSpacingMs } from "../definitions";
 import type { ScrapeOriginDefinition, ScrapeTargetDefinition } from "../types";
 
 function toOrigin(origin: ScrapeOrigin): ScrapeOriginDefinition {
@@ -41,7 +40,7 @@ export async function loadScrapeSourceTarget(
   return {
     key: target.key,
     enabled: target.enabled,
-    minimumSpacingMs: getRequestSpacingMs(target),
+    minimumSpacingMs: target.minimumSpacingMs,
     requestsPerWindow: target.requestsPerWindow,
     windowMs: target.windowMs,
     timeoutMs: target.timeoutMs,

--- a/apps/server/src/scraper/configured/target.ts
+++ b/apps/server/src/scraper/configured/target.ts
@@ -5,6 +5,7 @@ import {
   scrapeOrigins,
 } from "@peated/server/db/schema";
 import { and, eq } from "drizzle-orm";
+import { getRequestSpacingMs } from "../definitions";
 import type { ScrapeOriginDefinition, ScrapeTargetDefinition } from "../types";
 
 function toOrigin(origin: ScrapeOrigin): ScrapeOriginDefinition {
@@ -40,7 +41,7 @@ export async function loadScrapeSourceTarget(
   return {
     key: target.key,
     enabled: target.enabled,
-    minimumSpacingMs: target.minimumSpacingMs,
+    minimumSpacingMs: getRequestSpacingMs(target),
     requestsPerWindow: target.requestsPerWindow,
     windowMs: target.windowMs,
     timeoutMs: target.timeoutMs,

--- a/apps/server/src/scraper/coordinator.test.ts
+++ b/apps/server/src/scraper/coordinator.test.ts
@@ -197,7 +197,7 @@ test("expires crashed leases without allowing stale release to clear a successor
   expect(target?.leaseToken).toBe("successor");
 });
 
-test("enforces spacing, fixed-window quota, and the run budget", async () => {
+test("spreads requests across the window and enforces the run budget", async () => {
   await db.insert(scrapeTargets).values({
     ...baseTarget,
     minimumSpacingMs: 1_000,
@@ -226,7 +226,7 @@ test("enforces spacing, fixed-window quota, and the run budget", async () => {
     }),
   ).toMatchObject({ granted: false, reason: "target_spacing" });
 
-  const secondAt = new Date("2026-08-18T12:00:01Z");
+  const secondAt = new Date("2026-08-18T12:30:00Z");
   const second = await acquireScrapePermit({
     runId: run.id,
     targetKey: baseTarget.key,
@@ -239,19 +239,23 @@ test("enforces spacing, fixed-window quota, and the run budget", async () => {
     token: second.token,
     now: secondAt,
   });
+  await db
+    .update(scrapeTargets)
+    .set({ nextRequestAt: null })
+    .where(eq(scrapeTargets.key, baseTarget.key));
   const otherRun = await createRun({ siteKey: "whiskyworld" });
   expect(
     await acquireScrapePermit({
       runId: otherRun.id,
       targetKey: baseTarget.key,
-      now: new Date("2026-08-18T12:00:02Z"),
+      now: new Date("2026-08-18T12:30:01Z"),
     }),
   ).toMatchObject({ granted: false, reason: "target_quota" });
   expect(
     await acquireScrapePermit({
       runId: run.id,
       targetKey: baseTarget.key,
-      now: new Date("2026-08-18T12:00:02Z"),
+      now: new Date("2026-08-18T12:30:01Z"),
     }),
   ).toMatchObject({ granted: false, reason: "run_budget" });
 });

--- a/apps/server/src/scraper/coordinator.test.ts
+++ b/apps/server/src/scraper/coordinator.test.ts
@@ -197,13 +197,13 @@ test("expires crashed leases without allowing stale release to clear a successor
   expect(target?.leaseToken).toBe("successor");
 });
 
-test("spreads requests across the window and enforces the run budget", async () => {
+test("spaces requests evenly across the target window", async () => {
   await db.insert(scrapeTargets).values({
     ...baseTarget,
     minimumSpacingMs: 1_000,
     requestsPerWindow: 2,
   });
-  const run = await createRun({ requestLimit: 2 });
+  const run = await createRun({ requestLimit: 3 });
   const startedAt = new Date("2026-08-18T12:00:00Z");
   const first = await acquireScrapePermit({
     runId: run.id,
@@ -239,10 +239,16 @@ test("spreads requests across the window and enforces the run budget", async () 
     token: second.token,
     now: secondAt,
   });
-  await db
-    .update(scrapeTargets)
-    .set({ nextRequestAt: null })
-    .where(eq(scrapeTargets.key, baseTarget.key));
+});
+
+test("enforces the saved target limit and run limit", async () => {
+  const startedAt = new Date("2026-08-18T12:00:00Z");
+  await db.insert(scrapeTargets).values({
+    ...baseTarget,
+    requestsPerWindow: 2,
+    windowStartedAt: startedAt,
+    windowRequestCount: 2,
+  });
   const otherRun = await createRun({ siteKey: "whiskyworld" });
   expect(
     await acquireScrapePermit({
@@ -251,6 +257,16 @@ test("spreads requests across the window and enforces the run budget", async () 
       now: new Date("2026-08-18T12:30:01Z"),
     }),
   ).toMatchObject({ granted: false, reason: "target_quota" });
+
+  await db
+    .update(scrapeTargets)
+    .set({ windowRequestCount: 0 })
+    .where(eq(scrapeTargets.key, baseTarget.key));
+  const run = await createRun({ requestLimit: 2 });
+  await db
+    .update(externalSiteRuns)
+    .set({ sliceRequestCount: 2 })
+    .where(eq(externalSiteRuns.id, run.id));
   expect(
     await acquireScrapePermit({
       runId: run.id,

--- a/apps/server/src/scraper/coordinator.ts
+++ b/apps/server/src/scraper/coordinator.ts
@@ -6,7 +6,7 @@ import {
 } from "@peated/server/db/schema";
 import { and, eq } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
-import { getRequestSpacingMs } from "./definitions";
+import { getRequestDelayMs } from "./definitions";
 
 const LEASE_TIMEOUT_PADDING_MS = 5_000;
 const INITIAL_RATE_LIMIT_COOLDOWN_MS = 60_000;
@@ -188,8 +188,7 @@ export async function acquireScrapePermit({
         .set({
           windowStartedAt,
           windowRequestCount: windowRequestCount + 1,
-          // Scraper traffic policy: spread each allowance across its full window.
-          nextRequestAt: addMs(now, getRequestSpacingMs(target)),
+          nextRequestAt: addMs(now, getRequestDelayMs(target)),
           leaseToken: token,
           leaseExpiresAt: addMs(
             now,

--- a/apps/server/src/scraper/coordinator.ts
+++ b/apps/server/src/scraper/coordinator.ts
@@ -6,6 +6,7 @@ import {
 } from "@peated/server/db/schema";
 import { and, eq } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
+import { getRequestSpacingMs } from "./definitions";
 
 const LEASE_TIMEOUT_PADDING_MS = 5_000;
 const INITIAL_RATE_LIMIT_COOLDOWN_MS = 60_000;
@@ -187,7 +188,8 @@ export async function acquireScrapePermit({
         .set({
           windowStartedAt,
           windowRequestCount: windowRequestCount + 1,
-          nextRequestAt: addMs(now, target.minimumSpacingMs),
+          // Scraper traffic policy: spread each allowance across its full window.
+          nextRequestAt: addMs(now, getRequestSpacingMs(target)),
           leaseToken: token,
           leaseExpiresAt: addMs(
             now,

--- a/apps/server/src/scraper/definitions.test.ts
+++ b/apps/server/src/scraper/definitions.test.ts
@@ -71,46 +71,40 @@ test("allows sources to share one target and a target to declare several origins
   expect(registry.targets.get("operator")?.origins).toHaveLength(2);
 });
 
-test("accepts stricter policies without an exception", () => {
+test("accepts a lower hourly limit without a reason", () => {
   expect(
     defineScrapeTarget({
       key: "slow-operator",
-      minimumSpacingMs: 120_000,
-      requestsPerWindow: 50,
+      requestsPerHour: 30,
       origins: [{ origin: "https://example.com", robots: { mode: "enforce" } }],
     }),
-  ).toMatchObject({ minimumSpacingMs: 120_000, requestsPerWindow: 50 });
+  ).toMatchObject({ minimumSpacingMs: 120_000, requestsPerWindow: 30 });
 });
 
-test("spreads a request allowance across its full window", () => {
+test("spaces the hourly limit evenly", () => {
   const target = defineScrapeTarget({
     key: "slow-operator",
-    minimumSpacingMs: 1_000,
-    requestsPerWindow: 10,
+    requestsPerHour: 10,
     origins: [{ origin: "https://example.com", robots: { mode: "enforce" } }],
   });
 
   expect(target.minimumSpacingMs).toBe(6 * 60_000);
 });
 
-test("requires a rationale for a less restrictive policy", () => {
+test("requires a reason for a higher hourly limit", () => {
   expect(() =>
     defineScrapeTarget({
       key: "fast-operator",
-      minimumSpacingMs: 1_000,
-      requestsPerWindow: 3_600,
+      requestsPerHour: 3_600,
       origins: [{ origin: "https://example.com", robots: { mode: "enforce" } }],
     }),
-  ).toThrow(/requires a rationale/);
+  ).toThrow(/requires a reason/);
 
   expect(
     defineScrapeTarget({
       key: "fast-operator",
-      minimumSpacingMs: 1_000,
-      requestsPerWindow: 3_600,
-      policyException: {
-        rationale: "The provider explicitly documents this request cadence.",
-      },
+      requestsPerHour: 3_600,
+      fasterRateReason: "The provider allows one request per second.",
       origins: [{ origin: "https://example.com", robots: { mode: "enforce" } }],
     }).minimumSpacingMs,
   ).toBe(1_000);

--- a/apps/server/src/scraper/definitions.test.ts
+++ b/apps/server/src/scraper/definitions.test.ts
@@ -33,7 +33,7 @@ test("applies conservative target and run defaults", () => {
 
   expect(target).toMatchObject({
     enabled: true,
-    minimumSpacingMs: 2_000,
+    minimumSpacingMs: 60_000,
     requestsPerWindow: 60,
     windowMs: 3_600_000,
     timeoutMs: 30_000,
@@ -75,11 +75,22 @@ test("accepts stricter policies without an exception", () => {
   expect(
     defineScrapeTarget({
       key: "slow-operator",
-      minimumSpacingMs: 5_000,
+      minimumSpacingMs: 120_000,
       requestsPerWindow: 50,
       origins: [{ origin: "https://example.com", robots: { mode: "enforce" } }],
     }),
-  ).toMatchObject({ minimumSpacingMs: 5_000, requestsPerWindow: 50 });
+  ).toMatchObject({ minimumSpacingMs: 120_000, requestsPerWindow: 50 });
+});
+
+test("spreads a request allowance across its full window", () => {
+  const target = defineScrapeTarget({
+    key: "slow-operator",
+    minimumSpacingMs: 1_000,
+    requestsPerWindow: 10,
+    origins: [{ origin: "https://example.com", robots: { mode: "enforce" } }],
+  });
+
+  expect(target.minimumSpacingMs).toBe(6 * 60_000);
 });
 
 test("requires a rationale for a less restrictive policy", () => {
@@ -87,6 +98,7 @@ test("requires a rationale for a less restrictive policy", () => {
     defineScrapeTarget({
       key: "fast-operator",
       minimumSpacingMs: 1_000,
+      requestsPerWindow: 3_600,
       origins: [{ origin: "https://example.com", robots: { mode: "enforce" } }],
     }),
   ).toThrow(/requires a rationale/);
@@ -95,6 +107,7 @@ test("requires a rationale for a less restrictive policy", () => {
     defineScrapeTarget({
       key: "fast-operator",
       minimumSpacingMs: 1_000,
+      requestsPerWindow: 3_600,
       policyException: {
         rationale: "The provider explicitly documents this request cadence.",
       },

--- a/apps/server/src/scraper/definitions.ts
+++ b/apps/server/src/scraper/definitions.ts
@@ -16,17 +16,25 @@ export class ScraperTargetDisabledError extends Error {
   }
 }
 
-export const DEFAULT_SCRAPER_REQUEST_POLICY = Object.freeze({
-  minimumSpacingMs: 2_000,
-  requestsPerWindow: 60,
-  windowMs: 60 * 60_000,
+export const DEFAULT_SCRAPER_SETTINGS = Object.freeze({
+  requestsPerHour: 60,
   requestLimit: 100,
   timeoutMs: 30_000,
   maxResponseBytes: 10 * 1024 * 1024,
   maxRetries: 2,
 });
 
-export function getRequestSpacingMs(
+const ONE_HOUR_MS = 60 * 60_000;
+
+export function getHourlyRequestSettings(requestsPerHour: number) {
+  return {
+    minimumSpacingMs: Math.ceil(ONE_HOUR_MS / requestsPerHour),
+    requestsPerWindow: requestsPerHour,
+    windowMs: ONE_HOUR_MS,
+  };
+}
+
+export function getRequestDelayMs(
   target: Pick<
     ScrapeTargetDefinition,
     "minimumSpacingMs" | "requestsPerWindow" | "windowMs"
@@ -44,7 +52,7 @@ const DefinitionKeySchema = z
   .max(64)
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
 
-const RationaleSchema = z.string().trim().min(10).max(500);
+const ReasonSchema = z.string().trim().min(10).max(500);
 const HeaderNameSchema = z
   .string()
   .trim()
@@ -63,7 +71,7 @@ const RobotsPolicySchema = z.discriminatedUnion("mode", [
   z
     .object({
       mode: z.literal("not_applicable"),
-      rationale: RationaleSchema,
+      rationale: ReasonSchema,
     })
     .strict(),
 ]);
@@ -94,56 +102,43 @@ const TargetDefinitionSchema = z
   .object({
     key: DefinitionKeySchema,
     enabled: z.boolean().default(true),
-    minimumSpacingMs: z
-      .number()
-      .int()
-      .nonnegative()
-      .default(DEFAULT_SCRAPER_REQUEST_POLICY.minimumSpacingMs),
-    requestsPerWindow: z
+    requestsPerHour: z
       .number()
       .int()
       .positive()
-      .default(DEFAULT_SCRAPER_REQUEST_POLICY.requestsPerWindow),
-    windowMs: z
-      .number()
-      .int()
-      .positive()
-      .default(DEFAULT_SCRAPER_REQUEST_POLICY.windowMs),
+      .default(DEFAULT_SCRAPER_SETTINGS.requestsPerHour),
     timeoutMs: z
       .number()
       .int()
       .positive()
-      .max(DEFAULT_SCRAPER_REQUEST_POLICY.timeoutMs)
-      .default(DEFAULT_SCRAPER_REQUEST_POLICY.timeoutMs),
+      .max(DEFAULT_SCRAPER_SETTINGS.timeoutMs)
+      .default(DEFAULT_SCRAPER_SETTINGS.timeoutMs),
     maxResponseBytes: z
       .number()
       .int()
       .positive()
-      .max(DEFAULT_SCRAPER_REQUEST_POLICY.maxResponseBytes)
-      .default(DEFAULT_SCRAPER_REQUEST_POLICY.maxResponseBytes),
+      .max(DEFAULT_SCRAPER_SETTINGS.maxResponseBytes)
+      .default(DEFAULT_SCRAPER_SETTINGS.maxResponseBytes),
     maxRetries: z
       .number()
       .int()
       .min(0)
-      .max(DEFAULT_SCRAPER_REQUEST_POLICY.maxRetries)
-      .default(DEFAULT_SCRAPER_REQUEST_POLICY.maxRetries),
+      .max(DEFAULT_SCRAPER_SETTINGS.maxRetries)
+      .default(DEFAULT_SCRAPER_SETTINGS.maxRetries),
     allowedRequestHeaders: z.array(HeaderNameSchema).default([]),
-    policyException: z
-      .object({ rationale: RationaleSchema })
-      .strict()
-      .optional(),
+    fasterRateReason: ReasonSchema.optional(),
     origins: z.tuple([OriginSchema], OriginSchema),
   })
   .strict()
   .superRefine((target, context) => {
-    const isLessRestrictive =
-      getRequestSpacingMs(target) <
-      getRequestSpacingMs(DEFAULT_SCRAPER_REQUEST_POLICY);
-    if (isLessRestrictive && !target.policyException) {
+    if (
+      target.requestsPerHour > DEFAULT_SCRAPER_SETTINGS.requestsPerHour &&
+      !target.fasterRateReason
+    ) {
       context.addIssue({
         code: "custom",
-        message: "A less restrictive target policy requires a rationale.",
-        path: ["policyException"],
+        message: "A higher hourly request limit requires a reason.",
+        path: ["fasterRateReason"],
       });
     }
   });
@@ -164,8 +159,8 @@ const SourceDefinitionSchema = z
       .number()
       .int()
       .positive()
-      .max(DEFAULT_SCRAPER_REQUEST_POLICY.requestLimit)
-      .default(DEFAULT_SCRAPER_REQUEST_POLICY.requestLimit),
+      .max(DEFAULT_SCRAPER_SETTINGS.requestLimit)
+      .default(DEFAULT_SCRAPER_SETTINGS.requestLimit),
     resumeFromLastRun: z.boolean().default(false),
     cursorSchema: ZodSchemaSchema,
     observationSchema: ZodSchemaSchema,
@@ -174,7 +169,7 @@ const SourceDefinitionSchema = z
   })
   .strict();
 
-export type CodeOwnedScraperSourceDefinition<
+export type BuiltInScraperSourceDefinition<
   TCursor = any,
   TObservation = any,
 > = Omit<ScraperSourceDefinition<TCursor, TObservation>, "externalSiteKey"> & {
@@ -182,47 +177,28 @@ export type CodeOwnedScraperSourceDefinition<
 };
 
 export function defineScrapeTarget(
-  input: Omit<
-    ScrapeTargetDefinition,
-    | "enabled"
-    | "minimumSpacingMs"
-    | "requestsPerWindow"
-    | "windowMs"
-    | "timeoutMs"
-    | "maxResponseBytes"
-    | "maxRetries"
-    | "allowedRequestHeaders"
-  > &
-    Partial<
-      Pick<
-        ScrapeTargetDefinition,
-        | "enabled"
-        | "minimumSpacingMs"
-        | "requestsPerWindow"
-        | "windowMs"
-        | "timeoutMs"
-        | "maxResponseBytes"
-        | "maxRetries"
-        | "allowedRequestHeaders"
-      >
-    >,
+  input: z.input<typeof TargetDefinitionSchema>,
 ): ScrapeTargetDefinition {
-  const target = TargetDefinitionSchema.parse(input);
+  const {
+    requestsPerHour,
+    fasterRateReason: _,
+    ...target
+  } = TargetDefinitionSchema.parse(input);
   return {
     ...target,
-    minimumSpacingMs: getRequestSpacingMs(target),
+    ...getHourlyRequestSettings(requestsPerHour),
   };
 }
 
 export function defineScraperSource<TCursor, TObservation>(
   input: Omit<
-    CodeOwnedScraperSourceDefinition<TCursor, TObservation>,
+    BuiltInScraperSourceDefinition<TCursor, TObservation>,
     "requestLimit" | "resumeFromLastRun"
   > & {
     requestLimit?: number;
     resumeFromLastRun?: boolean;
   },
-): CodeOwnedScraperSourceDefinition<TCursor, TObservation> {
+): BuiltInScraperSourceDefinition<TCursor, TObservation> {
   const parsed = SourceDefinitionSchema.parse(input);
   return {
     ...input,
@@ -233,12 +209,11 @@ export function defineScraperSource<TCursor, TObservation>(
 
 export function createScraperRegistry(input: {
   targets: readonly ScrapeTargetDefinition[];
-  sources: readonly CodeOwnedScraperSourceDefinition[];
+  sources: readonly BuiltInScraperSourceDefinition[];
 }): ScraperRegistry {
   const targets = new Map<string, ScrapeTargetDefinition>();
   const originOwners = new Map<string, string>();
-  for (const value of input.targets) {
-    const target = defineScrapeTarget(value);
+  for (const target of input.targets) {
     if (targets.has(target.key)) {
       throw new Error(`Duplicate scraper target: ${target.key}`);
     }
@@ -314,7 +289,7 @@ export function findScraperSourceBySiteKey(
   );
 }
 
-/** Disabled code-owned targets cannot create or execute durable scraper work. */
+/** A disabled built-in target cannot start or continue a scrape. */
 export function requireEnabledScraperTargets(
   registry: ScraperRegistry,
   source: ScraperSourceDefinition,

--- a/apps/server/src/scraper/definitions.ts
+++ b/apps/server/src/scraper/definitions.ts
@@ -26,6 +26,18 @@ export const DEFAULT_SCRAPER_REQUEST_POLICY = Object.freeze({
   maxRetries: 2,
 });
 
+export function getRequestSpacingMs(
+  target: Pick<
+    ScrapeTargetDefinition,
+    "minimumSpacingMs" | "requestsPerWindow" | "windowMs"
+  >,
+) {
+  return Math.max(
+    target.minimumSpacingMs,
+    Math.ceil(target.windowMs / target.requestsPerWindow),
+  );
+}
+
 const DefinitionKeySchema = z
   .string()
   .min(1)
@@ -125,11 +137,8 @@ const TargetDefinitionSchema = z
   .strict()
   .superRefine((target, context) => {
     const isLessRestrictive =
-      target.minimumSpacingMs <
-        DEFAULT_SCRAPER_REQUEST_POLICY.minimumSpacingMs ||
-      target.requestsPerWindow >
-        DEFAULT_SCRAPER_REQUEST_POLICY.requestsPerWindow ||
-      target.windowMs < DEFAULT_SCRAPER_REQUEST_POLICY.windowMs;
+      getRequestSpacingMs(target) <
+      getRequestSpacingMs(DEFAULT_SCRAPER_REQUEST_POLICY);
     if (isLessRestrictive && !target.policyException) {
       context.addIssue({
         code: "custom",
@@ -198,7 +207,11 @@ export function defineScrapeTarget(
       >
     >,
 ): ScrapeTargetDefinition {
-  return TargetDefinitionSchema.parse(input);
+  const target = TargetDefinitionSchema.parse(input);
+  return {
+    ...target,
+    minimumSpacingMs: getRequestSpacingMs(target),
+  };
 }
 
 export function defineScraperSource<TCursor, TObservation>(

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -117,7 +117,9 @@ async function setupRuntime({
 }
 
 test("waits for the target spacing before the next request", async () => {
-  const { registry, run } = await setupRuntime({ minimumSpacingMs: 5_000 });
+  const { registry, run } = await setupRuntime({
+    minimumSpacingMs: 120_000,
+  });
   const clock = clockAt();
   const fetchImpl = vi
     .fn<typeof fetch>()
@@ -137,7 +139,7 @@ test("waits for the target spacing before the next request", async () => {
   await requestScraperUrl(input);
   await requestScraperUrl(input);
 
-  expect(clock.sleepSpy).toHaveBeenCalledWith(5_000);
+  expect(clock.sleepSpy).toHaveBeenCalledWith(120_000);
   expect(fetchImpl).toHaveBeenCalledTimes(2);
 });
 

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -50,14 +50,14 @@ function clockAt(value = "2026-08-18T12:00:00Z") {
 async function setupRuntime({
   origins = ["https://example.com"],
   requestLimit = 20,
-  minimumSpacingMs,
+  requestsPerHour,
   maxRetries = 2,
   maxResponseBytes = 10 * 1024 * 1024,
   allowedRequestHeaders = [],
 }: {
   origins?: [string, ...string[]];
   requestLimit?: number;
-  minimumSpacingMs?: number;
+  requestsPerHour?: number;
   maxRetries?: number;
   maxResponseBytes?: number;
   allowedRequestHeaders?: string[];
@@ -75,7 +75,7 @@ async function setupRuntime({
     targets: [
       defineScrapeTarget({
         key: "operator",
-        minimumSpacingMs,
+        requestsPerHour,
         maxRetries,
         maxResponseBytes,
         allowedRequestHeaders,
@@ -116,9 +116,9 @@ async function setupRuntime({
   return { registry, run };
 }
 
-test("waits for the target spacing before the next request", async () => {
+test("spaces requests from the hourly limit", async () => {
   const { registry, run } = await setupRuntime({
-    minimumSpacingMs: 120_000,
+    requestsPerHour: 30,
   });
   const clock = clockAt();
   const fetchImpl = vi

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -63,6 +63,7 @@ test("registers each code-owned scraper source with explicit target ownership", 
   }
   expect(scraperRegistry.targets.get("astorwines")?.enabled).toBe(true);
   expect(EXTERNAL_SITE_DEFINITIONS.astorwines.runEvery).toBeNull();
+  expect(EXTERNAL_SITE_DEFINITIONS.berrybrosrudd.runEvery).toBeNull();
   expect(EXTERNAL_SITE_DEFINITIONS.dramfool.runEvery).toBe(10080);
   expect(scraperRegistry.targets.get("dramfool")?.enabled).toBe(true);
   expect(scraperRegistry.targets.get("totalwine")?.enabled).toBe(false);

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -66,6 +66,10 @@ test("registers each code-owned scraper source with explicit target ownership", 
   expect(EXTERNAL_SITE_DEFINITIONS.berrybrosrudd.runEvery).toBeNull();
   expect(EXTERNAL_SITE_DEFINITIONS.dramfool.runEvery).toBe(10080);
   expect(scraperRegistry.targets.get("dramfool")?.enabled).toBe(true);
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskyworld.runEvery).toBeNull();
+  expect(scraperRegistry.targets.get("whiskyworld")?.minimumSpacingMs).toBe(
+    60_000,
+  );
   expect(scraperRegistry.targets.get("totalwine")?.enabled).toBe(false);
   expect(
     scraperRegistry.targets.get("smws")?.origins.map(({ origin }) => origin),

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -76,12 +76,12 @@ test("registers each code-owned scraper source with explicit target ownership", 
   ).toEqual(["https://api.smws.com", "https://smws.com"]);
   expect(scraperRegistry.targets.get("smws")).toMatchObject({
     allowedRequestHeaders: ["authorization", "content-type"],
-    minimumSpacingMs: 2_000,
+    minimumSpacingMs: 45_000,
     requestsPerWindow: 80,
   });
   expect(EXTERNAL_SITE_DEFINITIONS.bourbonculture.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("bourbonculture")).toMatchObject({
-    minimumSpacingMs: 5_000,
+    minimumSpacingMs: 360_000,
     requestsPerWindow: 10,
     windowMs: 3_600_000,
   });
@@ -89,28 +89,28 @@ test("registers each code-owned scraper source with explicit target ownership", 
   expect(scraperRegistry.targets.get("compassbox")).toBeDefined();
   expect(EXTERNAL_SITE_DEFINITIONS.dramface.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("dramface")).toMatchObject({
-    minimumSpacingMs: 2_500,
+    minimumSpacingMs: 144_000,
     requestsPerWindow: 25,
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("dramface")?.requestLimit).toBe(30);
   expect(EXTERNAL_SITE_DEFINITIONS.fredminnick.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("fredminnick")).toMatchObject({
-    minimumSpacingMs: 30_000,
+    minimumSpacingMs: 360_000,
     requestsPerWindow: 10,
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("fredminnick")?.requestLimit).toBe(9);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskeyreviewer.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskeyreviewer")).toMatchObject({
-    minimumSpacingMs: 5_000,
+    minimumSpacingMs: 360_000,
     requestsPerWindow: 10,
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.targets.get("kilchoman")).toBeDefined();
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyadvocate.runEvery).toBeNull();
   expect(scraperRegistry.targets.get("whiskyadvocate")).toMatchObject({
-    minimumSpacingMs: 2_500,
+    minimumSpacingMs: 180_000,
     requestsPerWindow: 20,
     windowMs: 3_600_000,
   });
@@ -120,13 +120,13 @@ test("registers each code-owned scraper source with explicit target ownership", 
   );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskynotes.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskynotes")).toMatchObject({
-    minimumSpacingMs: 2_500,
+    minimumSpacingMs: 120_000,
     requestsPerWindow: 30,
     windowMs: 3_600_000,
   });
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyfun.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskyfun")).toMatchObject({
-    minimumSpacingMs: 2_500,
+    minimumSpacingMs: 144_000,
     requestsPerWindow: 25,
     windowMs: 3_600_000,
   });
@@ -136,19 +136,19 @@ test("registers each code-owned scraper source with explicit target ownership", 
   );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskysaga.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskysaga")).toMatchObject({
-    minimumSpacingMs: 2_500,
+    minimumSpacingMs: 144_000,
     requestsPerWindow: 25,
     windowMs: 3_600_000,
   });
   expect(EXTERNAL_SITE_DEFINITIONS.whiskystudy.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskystudy")).toMatchObject({
-    minimumSpacingMs: 2_500,
+    minimumSpacingMs: 144_000,
     requestsPerWindow: 25,
     windowMs: 3_600_000,
   });
   expect(EXTERNAL_SITE_DEFINITIONS.wordsofwhisky.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("wordsofwhisky")).toMatchObject({
-    minimumSpacingMs: 2_500,
+    minimumSpacingMs: 144_000,
     requestsPerWindow: 25,
     windowMs: 3_600_000,
   });

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -53,7 +53,14 @@ const configuredSources = [
   "wordsofwhisky",
 ];
 
-test("registers each code-owned scraper source with explicit target ownership", () => {
+function expectHourlyLimit(key: string, requests: number) {
+  expect(scraperRegistry.targets.get(key)).toMatchObject({
+    requestsPerWindow: requests,
+    windowMs: 60 * 60_000,
+  });
+}
+
+test("registers each built-in scraper source with its target", () => {
   expect([...scraperRegistry.sources.keys()].sort()).toEqual(
     registeredSources.sort(),
   );
@@ -67,91 +74,48 @@ test("registers each code-owned scraper source with explicit target ownership", 
   expect(EXTERNAL_SITE_DEFINITIONS.dramfool.runEvery).toBe(10080);
   expect(scraperRegistry.targets.get("dramfool")?.enabled).toBe(true);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyworld.runEvery).toBeNull();
-  expect(scraperRegistry.targets.get("whiskyworld")?.minimumSpacingMs).toBe(
-    60_000,
-  );
   expect(scraperRegistry.targets.get("totalwine")?.enabled).toBe(false);
   expect(
     scraperRegistry.targets.get("smws")?.origins.map(({ origin }) => origin),
   ).toEqual(["https://api.smws.com", "https://smws.com"]);
-  expect(scraperRegistry.targets.get("smws")).toMatchObject({
-    allowedRequestHeaders: ["authorization", "content-type"],
-    minimumSpacingMs: 45_000,
-    requestsPerWindow: 80,
-  });
+  expect(scraperRegistry.targets.get("smws")?.allowedRequestHeaders).toEqual([
+    "authorization",
+    "content-type",
+  ]);
+  expectHourlyLimit("smws", 80);
   expect(EXTERNAL_SITE_DEFINITIONS.bourbonculture.runEvery).toBe(1440);
-  expect(scraperRegistry.targets.get("bourbonculture")).toMatchObject({
-    minimumSpacingMs: 360_000,
-    requestsPerWindow: 10,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("bourbonculture", 10);
   expect(scraperRegistry.targets.get("bruichladdich")).toBeDefined();
   expect(scraperRegistry.targets.get("compassbox")).toBeDefined();
   expect(EXTERNAL_SITE_DEFINITIONS.dramface.runEvery).toBe(1440);
-  expect(scraperRegistry.targets.get("dramface")).toMatchObject({
-    minimumSpacingMs: 144_000,
-    requestsPerWindow: 25,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("dramface", 25);
   expect(scraperRegistry.sources.get("dramface")?.requestLimit).toBe(30);
   expect(EXTERNAL_SITE_DEFINITIONS.fredminnick.runEvery).toBe(1440);
-  expect(scraperRegistry.targets.get("fredminnick")).toMatchObject({
-    minimumSpacingMs: 360_000,
-    requestsPerWindow: 10,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("fredminnick", 10);
   expect(scraperRegistry.sources.get("fredminnick")?.requestLimit).toBe(9);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskeyreviewer.runEvery).toBe(1440);
-  expect(scraperRegistry.targets.get("whiskeyreviewer")).toMatchObject({
-    minimumSpacingMs: 360_000,
-    requestsPerWindow: 10,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("whiskeyreviewer", 10);
   expect(scraperRegistry.targets.get("kilchoman")).toBeDefined();
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyadvocate.runEvery).toBeNull();
-  expect(scraperRegistry.targets.get("whiskyadvocate")).toMatchObject({
-    minimumSpacingMs: 180_000,
-    requestsPerWindow: 20,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("whiskyadvocate", 20);
   expect(scraperRegistry.sources.get("whiskyadvocate")?.requestLimit).toBe(30);
   expect(scraperRegistry.sources.get("whiskyadvocate")?.resumeFromLastRun).toBe(
     true,
   );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskynotes.runEvery).toBe(1440);
-  expect(scraperRegistry.targets.get("whiskynotes")).toMatchObject({
-    minimumSpacingMs: 120_000,
-    requestsPerWindow: 30,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("whiskynotes", 30);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyfun.runEvery).toBe(1440);
-  expect(scraperRegistry.targets.get("whiskyfun")).toMatchObject({
-    minimumSpacingMs: 144_000,
-    requestsPerWindow: 25,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("whiskyfun", 25);
   expect(scraperRegistry.sources.get("whiskyfun")?.requestLimit).toBe(30);
   expect(scraperRegistry.sources.get("whiskyfun")?.resumeFromLastRun).toBe(
     true,
   );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskysaga.runEvery).toBe(1440);
-  expect(scraperRegistry.targets.get("whiskysaga")).toMatchObject({
-    minimumSpacingMs: 144_000,
-    requestsPerWindow: 25,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("whiskysaga", 25);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskystudy.runEvery).toBe(1440);
-  expect(scraperRegistry.targets.get("whiskystudy")).toMatchObject({
-    minimumSpacingMs: 144_000,
-    requestsPerWindow: 25,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("whiskystudy", 25);
   expect(EXTERNAL_SITE_DEFINITIONS.wordsofwhisky.runEvery).toBe(1440);
-  expect(scraperRegistry.targets.get("wordsofwhisky")).toMatchObject({
-    minimumSpacingMs: 144_000,
-    requestsPerWindow: 25,
-    windowMs: 3_600_000,
-  });
+  expectHourlyLimit("wordsofwhisky", 25);
   for (const type of registeredReviewSources) {
     const source = scraperRegistry.sources.get(type);
     expect(source, `${type} is not registered`).toBeDefined();
@@ -170,9 +134,7 @@ test("registers each code-owned scraper source with explicit target ownership", 
   }
 });
 
-test("dispatches code-owned sources to the isolated scraper job", async ({
-  fixtures,
-}) => {
+test("dispatches built-in sources to the scraper job", async ({ fixtures }) => {
   const requestedBy = await fixtures.User({ admin: true });
   const site = await fixtures.ExternalSite({ type: "edradour" });
   const enqueue = vi.fn(async () => undefined);

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -69,11 +69,11 @@ test("registers each built-in scraper source with its target", () => {
     expect(scraperRegistry.targets.get(source.targetKeys[0])).toBeDefined();
   }
   expect(scraperRegistry.targets.get("astorwines")?.enabled).toBe(true);
-  expect(EXTERNAL_SITE_DEFINITIONS.astorwines.runEvery).toBeNull();
-  expect(EXTERNAL_SITE_DEFINITIONS.berrybrosrudd.runEvery).toBeNull();
-  expect(EXTERNAL_SITE_DEFINITIONS.dramfool.runEvery).toBe(10080);
+  expect(EXTERNAL_SITE_DEFINITIONS.astorwines.initialRunEvery).toBeNull();
+  expect(EXTERNAL_SITE_DEFINITIONS.berrybrosrudd.initialRunEvery).toBeNull();
+  expect(EXTERNAL_SITE_DEFINITIONS.dramfool.initialRunEvery).toBe(10080);
   expect(scraperRegistry.targets.get("dramfool")?.enabled).toBe(true);
-  expect(EXTERNAL_SITE_DEFINITIONS.whiskyworld.runEvery).toBeNull();
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskyworld.initialRunEvery).toBeNull();
   expect(scraperRegistry.targets.get("totalwine")?.enabled).toBe(false);
   expect(
     scraperRegistry.targets.get("smws")?.origins.map(({ origin }) => origin),
@@ -83,38 +83,38 @@ test("registers each built-in scraper source with its target", () => {
     "content-type",
   ]);
   expectHourlyLimit("smws", 80);
-  expect(EXTERNAL_SITE_DEFINITIONS.bourbonculture.runEvery).toBe(1440);
+  expect(EXTERNAL_SITE_DEFINITIONS.bourbonculture.initialRunEvery).toBe(1440);
   expectHourlyLimit("bourbonculture", 10);
   expect(scraperRegistry.targets.get("bruichladdich")).toBeDefined();
   expect(scraperRegistry.targets.get("compassbox")).toBeDefined();
-  expect(EXTERNAL_SITE_DEFINITIONS.dramface.runEvery).toBe(1440);
+  expect(EXTERNAL_SITE_DEFINITIONS.dramface.initialRunEvery).toBe(1440);
   expectHourlyLimit("dramface", 25);
   expect(scraperRegistry.sources.get("dramface")?.requestLimit).toBe(30);
-  expect(EXTERNAL_SITE_DEFINITIONS.fredminnick.runEvery).toBe(1440);
+  expect(EXTERNAL_SITE_DEFINITIONS.fredminnick.initialRunEvery).toBe(1440);
   expectHourlyLimit("fredminnick", 10);
   expect(scraperRegistry.sources.get("fredminnick")?.requestLimit).toBe(9);
-  expect(EXTERNAL_SITE_DEFINITIONS.whiskeyreviewer.runEvery).toBe(1440);
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskeyreviewer.initialRunEvery).toBe(1440);
   expectHourlyLimit("whiskeyreviewer", 10);
   expect(scraperRegistry.targets.get("kilchoman")).toBeDefined();
-  expect(EXTERNAL_SITE_DEFINITIONS.whiskyadvocate.runEvery).toBeNull();
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskyadvocate.initialRunEvery).toBeNull();
   expectHourlyLimit("whiskyadvocate", 20);
   expect(scraperRegistry.sources.get("whiskyadvocate")?.requestLimit).toBe(30);
   expect(scraperRegistry.sources.get("whiskyadvocate")?.resumeFromLastRun).toBe(
     true,
   );
-  expect(EXTERNAL_SITE_DEFINITIONS.whiskynotes.runEvery).toBe(1440);
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskynotes.initialRunEvery).toBe(1440);
   expectHourlyLimit("whiskynotes", 30);
-  expect(EXTERNAL_SITE_DEFINITIONS.whiskyfun.runEvery).toBe(1440);
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskyfun.initialRunEvery).toBe(1440);
   expectHourlyLimit("whiskyfun", 25);
   expect(scraperRegistry.sources.get("whiskyfun")?.requestLimit).toBe(30);
   expect(scraperRegistry.sources.get("whiskyfun")?.resumeFromLastRun).toBe(
     true,
   );
-  expect(EXTERNAL_SITE_DEFINITIONS.whiskysaga.runEvery).toBe(1440);
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskysaga.initialRunEvery).toBe(1440);
   expectHourlyLimit("whiskysaga", 25);
-  expect(EXTERNAL_SITE_DEFINITIONS.whiskystudy.runEvery).toBe(1440);
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskystudy.initialRunEvery).toBe(1440);
   expectHourlyLimit("whiskystudy", 25);
-  expect(EXTERNAL_SITE_DEFINITIONS.wordsofwhisky.runEvery).toBe(1440);
+  expect(EXTERNAL_SITE_DEFINITIONS.wordsofwhisky.initialRunEvery).toBe(1440);
   expectHourlyLimit("wordsofwhisky", 25);
   for (const type of registeredReviewSources) {
     const source = scraperRegistry.sources.get(type);

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -57,9 +57,8 @@ import { bottleObservationSink } from "./sinks/bottles";
 import { externalReviewSink } from "./sinks/externalReviews";
 import { createStorePriceSink } from "./sinks/storePrices";
 
-// TODO(scraper-source-migration): Delete these ordinary HTML adapters after
-// every site has an active database-managed parsing revision. New HTML sources
-// must use configured rules instead of joining this compatibility group.
+// TODO(scraper-source-migration): Delete these HTML adapters after every site
+// uses saved parsing rules. New HTML sources must use those rules.
 const legacyPriceSources = [
   {
     type: "astorwines",
@@ -145,7 +144,6 @@ const legacyPriceSources = [
   {
     type: "whiskyworld",
     origin: "https://www.thewhiskyworld.com",
-    minimumSpacingMs: 60_000,
     scrape: scrapeWhiskyWorld,
   },
   {
@@ -155,9 +153,8 @@ const legacyPriceSources = [
   },
 ] as const;
 
-// Custom adapters remain available for sources that configured parsing cannot
-// express. SMWS emits bottle-catalog observations from an API, not HTML review
-// or price observations.
+// Some sources still need their own adapters. SMWS reads bottles from an API,
+// not reviews or prices from HTML.
 const legacyBottleSources = [
   {
     type: "smws",
@@ -187,10 +184,8 @@ export const scraperRegistry = createScraperRegistry({
         enabled: "enabled" in source ? source.enabled : true,
         allowedRequestHeaders:
           "allowedRequestHeaders" in source
-            ? source.allowedRequestHeaders
+            ? [...source.allowedRequestHeaders]
             : undefined,
-        minimumSpacingMs:
-          "minimumSpacingMs" in source ? source.minimumSpacingMs : undefined,
         origins: [{ origin: source.origin, robots: { mode: "enforce" } }],
       }),
     ),
@@ -199,21 +194,17 @@ export const scraperRegistry = createScraperRegistry({
         key: source.type,
         allowedRequestHeaders:
           source.type === "smws" ? ["authorization", "content-type"] : [],
-        requestsPerWindow: source.type === "smws" ? 80 : undefined,
-        policyException:
+        requestsPerHour: source.type === "smws" ? 80 : undefined,
+        fasterRateReason:
           source.type === "smws"
-            ? {
-                rationale:
-                  "The official weekly SMWS archive sync uses public batch APIs and needs about 74 requests, paced across one hour.",
-              }
+            ? "Copying the weekly SMWS bottle list needs about 74 requests."
             : undefined,
-        origins: source.origins,
+        origins: [...source.origins],
       }),
     ),
     defineScrapeTarget({
       key: "bourbonculture",
-      minimumSpacingMs: 5_000,
-      requestsPerWindow: 10,
+      requestsPerHour: 10,
       origins: [
         {
           origin: "https://thebourbonculture.com",
@@ -259,8 +250,7 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "dramface",
-      minimumSpacingMs: 2_500,
-      requestsPerWindow: 25,
+      requestsPerHour: 25,
       origins: [
         {
           origin: "https://www.dramface.com",
@@ -270,8 +260,7 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "fredminnick",
-      minimumSpacingMs: 30_000,
-      requestsPerWindow: 10,
+      requestsPerHour: 10,
       origins: [
         {
           origin: "https://www.fredminnick.com",
@@ -308,8 +297,7 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "whiskeyreviewer",
-      minimumSpacingMs: 5_000,
-      requestsPerWindow: 10,
+      requestsPerHour: 10,
       origins: [
         {
           origin: "https://whiskeyreviewer.com",
@@ -319,8 +307,7 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "whiskyadvocate",
-      minimumSpacingMs: 2_500,
-      requestsPerWindow: 20,
+      requestsPerHour: 20,
       origins: [
         {
           origin: "https://whiskyadvocate.com",
@@ -330,8 +317,7 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "whiskynotes",
-      minimumSpacingMs: 2_500,
-      requestsPerWindow: 30,
+      requestsPerHour: 30,
       origins: [
         {
           origin: "https://www.whiskynotes.be",
@@ -341,8 +327,7 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "whiskyfun",
-      minimumSpacingMs: 2_500,
-      requestsPerWindow: 25,
+      requestsPerHour: 25,
       origins: [
         {
           origin: "https://www.whiskyfun.com",
@@ -352,8 +337,7 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "whiskysaga",
-      minimumSpacingMs: 2_500,
-      requestsPerWindow: 25,
+      requestsPerHour: 25,
       origins: [
         {
           origin: "https://www.whiskysaga.com",
@@ -363,8 +347,7 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "whiskystudy",
-      minimumSpacingMs: 2_500,
-      requestsPerWindow: 25,
+      requestsPerHour: 25,
       origins: [
         {
           origin: "https://thewhiskystudy.com",
@@ -374,8 +357,7 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "wordsofwhisky",
-      minimumSpacingMs: 2_500,
-      requestsPerWindow: 25,
+      requestsPerHour: 25,
       origins: [
         {
           origin: "https://wordsofwhisky.com",
@@ -408,7 +390,7 @@ export const scraperRegistry = createScraperRegistry({
       }),
     ),
     // TODO(scraper-source-migration): Remove each remaining HTML review
-    // definition after its publisher activates database-managed rules.
+    // definition after its publisher turns on saved parsing rules.
     defineScraperSource({
       key: "dramface",
       externalSiteKey: "dramface",
@@ -433,8 +415,8 @@ export const scraperRegistry = createScraperRegistry({
       key: "whiskyadvocate",
       externalSiteKey: "whiskyadvocate",
       targetKeys: ["whiskyadvocate"],
-      // Keep the slice budget above the target quota so one hourly deferral
-      // consumes one execution attempt.
+      // Keep the run limit above the hourly limit so the run waits for the next
+      // hour instead of stopping.
       requestLimit: 30,
       resumeFromLastRun: true,
       cursorSchema: WhiskyAdvocateCursorSchema,

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -204,7 +204,7 @@ export const scraperRegistry = createScraperRegistry({
           source.type === "smws"
             ? {
                 rationale:
-                  "The official weekly SMWS archive sync uses public batch APIs and about 74 requests with two-second spacing.",
+                  "The official weekly SMWS archive sync uses public batch APIs and needs about 74 requests, paced across one hour.",
               }
             : undefined,
         origins: source.origins,

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -145,6 +145,7 @@ const legacyPriceSources = [
   {
     type: "whiskyworld",
     origin: "https://www.thewhiskyworld.com",
+    minimumSpacingMs: 60_000,
     scrape: scrapeWhiskyWorld,
   },
   {
@@ -188,6 +189,8 @@ export const scraperRegistry = createScraperRegistry({
           "allowedRequestHeaders" in source
             ? source.allowedRequestHeaders
             : undefined,
+        minimumSpacingMs:
+          "minimumSpacingMs" in source ? source.minimumSpacingMs : undefined,
         origins: [{ origin: source.origin, robots: { mode: "enforce" } }],
       }),
     ),

--- a/apps/server/src/scraper/syncDefinitions.test.ts
+++ b/apps/server/src/scraper/syncDefinitions.test.ts
@@ -150,6 +150,7 @@ test("preserves admin-owned targets, origins, and site mappings", async () => {
       key: "admin-source",
       managedBy: "admin",
       enabled: true,
+      minimumSpacingMs: 2_000,
     }),
   ]);
   expect(await db.select().from(scrapeOrigins)).toEqual([

--- a/apps/server/src/scraper/syncDefinitions.ts
+++ b/apps/server/src/scraper/syncDefinitions.ts
@@ -14,8 +14,7 @@ async function applyScraperDefinitions(
 ) {
   const now = new Date();
 
-  // Definitions are code-owned. Rows are retained but made inactive when a
-  // definition disappears so coordination history is never silently deleted.
+  // Keep rows for removed registry entries so their run history is not lost.
   await tx
     .update(externalSiteScrapeTargets)
     .set({ active: false, updatedAt: now })

--- a/apps/server/src/scraper/types.ts
+++ b/apps/server/src/scraper/types.ts
@@ -84,7 +84,6 @@ export type ScrapeTargetDefinition = {
   maxResponseBytes: number;
   maxRetries: number;
   allowedRequestHeaders: readonly string[];
-  policyException?: { rationale: string };
   origins: readonly [ScrapeOriginDefinition, ...ScrapeOriginDefinition[]];
 };
 


### PR DESCRIPTION
When we define a scraper in code, we now set one request value: `requestsPerHour`. Requests are spread evenly through the hour, so 60 per hour means one request each minute and 10 per hour means one every six minutes. A scraper must include a reason to exceed 60 requests per hour.

Saved sources use the same rule. Existing database fields remain in place, so this change does not need a data migration and older saved sources keep working.

Berry Bros. & Rudd and WhiskyWorld no longer run automatically. Berry Bros. & Rudd does not allow its search page in `robots.txt`, and WhiskyWorld blocks our `robots.txt` check. Their existing listings remain, and admins can still start either scraper manually.
