### PR TITLE
fix(web): collapse long bottle distillery lists

### DIFF
--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -77,7 +77,7 @@ const meta = {
 | sidebar | Sidebar bottle lists | 15px title limited to two lines, 32 × 46px thumbnail, and trailing content below the identity. |
 | compact | Single or grouped library additions | One regular-weight name line, 24 × 32px thumbnail, and a 44px hit area. |
 
-Sidebar omits membership status icons and keeps full accessible names when its two-line titles truncate. Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Use layout="cell" inside an existing control so its bottle link stays within the identity. Use linkArea="title" when the surrounding card is also clickable. The end slot holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
+Sidebar omits membership status icons and keeps full accessible names when its two-line titles truncate. Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Bottles made by more than 3 distilleries show the count; hover it to see their names. Use layout="cell" inside an existing control so its bottle link stays within the identity. Use linkArea="title" when the surrounding card is also clickable. The end slot holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
 
 Use Row Layouts to compare these components at desktop and phone widths.`,
       },
@@ -192,6 +192,17 @@ export const RowLayouts: Story = {
         <section aria-label="Bottle list">
           <SectionHeading level={3}>Bottle list</SectionHeading>
           <BottleIdentityRow {...args} />
+          <BottleIdentityRow
+            {...args}
+            name="Compass Box The Peat Monster"
+            provenance={[
+              {
+                name: "4 distilleries",
+                title: "Caol Ila · Highland Park · Springbank · Talisker",
+              },
+              { name: "Blended Malt" },
+            ]}
+          />
         </section>
         <section aria-label="Library addition">
           <SectionHeading level={3}>Library addition</SectionHeading>

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -28,7 +28,7 @@ export type BottleIdentityRowProps = {
   name: string;
   onClick?: MouseEventHandler<HTMLAnchorElement>;
   query?: string;
-  provenance?: readonly { name: string; href?: string }[];
+  provenance?: readonly { name: string; href?: string; title?: string }[];
   relatedReleases?: {
     count: number;
     href: string;
@@ -144,11 +144,13 @@ export function BottleIdentityRow({
           <Join divider=" · ">
             {provenance.map((item, index) =>
               item.href ? (
-                <TextLink href={item.href} key={index}>
+                <TextLink href={item.href} key={index} title={item.title}>
                   {item.name}
                 </TextLink>
               ) : (
-                <span key={index}>{item.name}</span>
+                <span key={index} title={item.title}>
+                  {item.name}
+                </span>
               ),
             )}
           </Join>

--- a/apps/web/src/components/bottleIdentityRow.test.tsx
+++ b/apps/web/src/components/bottleIdentityRow.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { BottleIdentityRow } from "./bottleIdentityRow.stylex";
+
+describe("BottleIdentityRow", () => {
+  test("renders provenance details as a native tooltip", () => {
+    const html = renderToStaticMarkup(
+      <BottleIdentityRow
+        name="Blended whisky"
+        provenance={[
+          {
+            name: "4 distilleries",
+            title: "Caol Ila · Highland Park · Springbank · Talisker",
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain(
+      'title="Caol Ila · Highland Park · Springbank · Talisker"',
+    );
+    expect(html).toContain(">4 distilleries</span>");
+  });
+});

--- a/apps/web/src/lib/bottleListItem.test.ts
+++ b/apps/web/src/lib/bottleListItem.test.ts
@@ -1,4 +1,10 @@
-import { mockBottle } from "@peated/server/orpc/mock/fixtures";
+import {
+  mockBottle,
+  mockCaolIlaEntity,
+  mockHighlandParkEntity,
+  mockSpringbankEntity,
+  mockTaliskerEntity,
+} from "@peated/server/orpc/mock/fixtures";
 import { describe, expect, test } from "vitest";
 
 import { toBottleListItem, toBottlePickerOption } from "./bottleListItem";
@@ -38,6 +44,57 @@ describe("toBottleListItem", () => {
       toBottleListItem({ ...mockBottle, distillers: [mockBottle.brand] })
         .provenance,
     ).toEqual([{ name: "Single Malt" }]);
+  });
+
+  test("shows up to three distilleries by name", () => {
+    const distillers = [
+      mockCaolIlaEntity,
+      mockHighlandParkEntity,
+      mockTaliskerEntity,
+    ];
+
+    expect(toBottleListItem({ ...mockBottle, distillers }).provenance).toEqual([
+      ...distillers.map((distiller) => ({
+        name: distiller.name,
+        href: `/distillers/${distiller.id}-${distiller.name
+          .toLowerCase()
+          .replaceAll(" ", "-")}`,
+      })),
+      { name: "Single Malt" },
+    ]);
+  });
+
+  test("summarizes more than three distilleries with their names in a tooltip", () => {
+    const distillers = [
+      mockCaolIlaEntity,
+      mockHighlandParkEntity,
+      mockSpringbankEntity,
+      mockTaliskerEntity,
+    ];
+
+    expect(toBottleListItem({ ...mockBottle, distillers }).provenance).toEqual([
+      {
+        name: "4 distilleries",
+        title: distillers.map((distiller) => distiller.name).join(" · "),
+      },
+      { name: "Single Malt" },
+    ]);
+  });
+
+  test("keeps the distillery tooltip inside a picker option", () => {
+    const distillers = [
+      mockCaolIlaEntity,
+      mockHighlandParkEntity,
+      mockSpringbankEntity,
+      mockTaliskerEntity,
+    ];
+
+    expect(
+      toBottlePickerOption({ ...mockBottle, distillers }).bottle.provenance,
+    ).toContainEqual({
+      name: "4 distilleries",
+      title: distillers.map((distiller) => distiller.name).join(" · "),
+    });
   });
 
   test("keeps the database ID for selection and removes links inside the option control", () => {

--- a/apps/web/src/lib/bottleListItem.ts
+++ b/apps/web/src/lib/bottleListItem.ts
@@ -43,7 +43,9 @@ export function toBottlePickerOption(
     bottle: {
       ...identity,
       imageUrl: bottle.imageUrl,
-      provenance: identity.provenance?.map(({ name }) => ({ name })),
+      provenance: identity.provenance?.map(({ name, title }) =>
+        title ? { name, title } : { name },
+      ),
     },
   };
 }
@@ -63,18 +65,29 @@ export function getBottleIdentityProps(
   const releaseFact = getBottleReleaseMetadata(bottle);
   const releaseYear =
     bottle.releaseYear == null ? null : `${bottle.releaseYear} release`;
+  const distillers = bottle.distillers ?? [];
+  const distillerProvenance =
+    distillers.length > 3
+      ? [
+          {
+            name: `${distillers.length.toLocaleString("en-US")} distilleries`,
+            title: distillers.map((distiller) => distiller.name).join(" · "),
+          },
+        ]
+      : distillers
+          .filter((distiller) => distiller.id !== bottle.brand.id)
+          .map((distiller) => ({
+            name: distiller.name,
+            href: getEntityUrl(distiller),
+          }));
+
   return {
     name: formatBottleDisplayName(bottle, {
       includeBrand: includeBrandInName,
       includeSeries: includeSeriesInName,
     }),
     provenance: [
-      ...(bottle.distillers ?? [])
-        .filter((distiller) => distiller.id !== bottle.brand.id)
-        .map((distiller) => ({
-          name: distiller.name,
-          href: getEntityUrl(distiller),
-        })),
+      ...distillerProvenance,
       ...(includeBottler &&
       bottle.bottler &&
       bottle.bottler.id !== bottle.brand.id


### PR DESCRIPTION
Bottle rows now collapse provenance with more than 3 distilleries into a compact “N distilleries” label whose tooltip preserves every distillery name. Rows with up to 3 distilleries keep their individual links, and picker rows carry the same tooltip behavior; Storybook and focused tests cover the boundary and rendered tooltip.
