### PR TITLE
feat(web): show tasting notes in review and tasting rows

### DIFF
--- a/apps/web/src/components/chip.stories.tsx
+++ b/apps/web/src/components/chip.stories.tsx
@@ -9,8 +9,12 @@ import { StoryRow } from "./storyFixtures.stylex";
 const meta = {
   title: "Components/Labels/Chip",
   component: Chip,
-  args: { children: "Smoke", variant: "neutral" },
+  args: { children: "Smoke", size: "md", variant: "neutral" },
   argTypes: {
+    size: {
+      control: "inline-radio",
+      options: ["sm", "md"],
+    },
     variant: {
       control: "inline-radio",
       options: ["neutral", "tinted", "solid"],
@@ -36,6 +40,17 @@ export const Overview: Story = {
 
 export const InteractiveNotes: Story = {
   render: () => <InteractiveChipSet />,
+};
+
+export const CompactNotes: Story = {
+  render: () => (
+    <StoryRow>
+      <Chip size="sm">Smoke</Chip>
+      <Chip size="sm">Dried fruit</Chip>
+      <Chip size="sm">Sea salt</Chip>
+      <Chip size="sm">+2 more</Chip>
+    </StoryRow>
+  ),
 };
 
 function InteractiveChipSet() {

--- a/apps/web/src/components/chip.stylex.tsx
+++ b/apps/web/src/components/chip.stylex.tsx
@@ -5,18 +5,22 @@ import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, controlMetrics, effects } from "../styles/tokens.stylex";
 
 export type ChipVariant = "neutral" | "tinted" | "solid";
+export type ChipSize = "sm" | "md";
 
 export type ChipProps = Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
   "className" | "style" | "type"
 > & {
   children: ReactNode;
+  size?: ChipSize;
   variant?: ChipVariant;
 };
 
+/** A static label or interactive filter; small chips suit dense read-only previews. */
 export function Chip({
   children,
   onClick,
+  size = "md",
   variant = "neutral",
   ...props
 }: ChipProps) {
@@ -30,7 +34,9 @@ export function Chip({
         {...stylex.props(
           foundationStyles.interactiveSmall,
           styles.chip,
+          size === "sm" && styles.small,
           styles.interactive,
+          size === "sm" && styles.smallInteractive,
           variants[variant],
         )}
       >
@@ -45,6 +51,7 @@ export function Chip({
       {...stylex.props(
         foundationStyles.interactiveSmall,
         styles.chip,
+        size === "sm" && styles.small,
         variants[variant],
       )}
     >
@@ -105,6 +112,16 @@ const styles = stylex.create({
       default: "none",
       ":focus-visible": effects.focusRing,
     },
+  },
+  small: {
+    minHeight: "24px",
+    paddingTop: "2px",
+    paddingRight: "8px",
+    paddingBottom: "2px",
+    paddingLeft: "8px",
+  },
+  smallInteractive: {
+    minHeight: controlMetrics.controlHeightSmall,
   },
   neutral: {
     backgroundColor: "transparent",

--- a/apps/web/src/components/communityFeed.stories.tsx
+++ b/apps/web/src/components/communityFeed.stories.tsx
@@ -88,6 +88,27 @@ export const TastingList: Story = {
     },
   },
 };
+export const ManyTastingNotes: Story = {
+  args: {
+    ariaLabel: "Tastings",
+    items: withStoryImages(
+      getTastingFeedItems([
+        {
+          ...mockTastings[0]!,
+          tags: ["smoke", "brine", "lemon", "vanilla", "pepper", "oak"],
+        },
+      ]),
+    ),
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Compact rows show the first four tasting notes and summarize the remaining count. The detail page keeps the full list.",
+      },
+    },
+  },
+};
 export const NarrowColumn: Story = {
   decorators: [
     (Story) => (

--- a/apps/web/src/components/communityFeed.stylex.tsx
+++ b/apps/web/src/components/communityFeed.stylex.tsx
@@ -7,6 +7,7 @@ import {
   type BottleIdentityRowProps,
 } from "./bottleIdentityRow.stylex";
 import { Card, CardPrimaryLink } from "./card.stylex";
+import { Chip } from "./chip.stylex";
 import { ItemList, ItemListItem } from "./itemList.stylex";
 import { ReviewScore, TastingRating, type RatingBand } from "./scoring.stylex";
 import { TextLink } from "./textLink.stylex";
@@ -19,6 +20,7 @@ export type CommunityFeedBottle = Pick<
   id: string;
   description?: string;
   byline?: string;
+  tags?: readonly string[];
   ratingBand?: RatingBand | null;
   score?: { value: number; scale: number };
 };
@@ -140,18 +142,20 @@ function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
                 metadata={bottle.metadata}
                 verticalPadding="sm"
                 activityDetails={
-                  bottle.description || bottle.byline ? (
-                    <>
+                  bottle.description || bottle.byline || bottle.tags?.length ? (
+                    <div {...stylex.props(styles.details)}>
                       {bottle.description ? (
                         <p
                           {...stylex.props(
                             foundationStyles.body,
                             styles.excerpt,
-                            Boolean(bottle.byline) && styles.excerptWithFooter,
                           )}
                         >
                           {bottle.description}
                         </p>
+                      ) : null}
+                      {bottle.tags?.length ? (
+                        <TastingNotePreview tags={bottle.tags} />
                       ) : null}
                       {bottle.byline ? (
                         <div
@@ -163,7 +167,7 @@ function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
                           By {bottle.byline}
                         </div>
                       ) : null}
-                    </>
+                    </div>
                   ) : undefined
                 }
                 end={
@@ -192,6 +196,28 @@ function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
         </div>
       </Card>
     </article>
+  );
+}
+
+const MAX_VISIBLE_NOTES = 4;
+
+function TastingNotePreview({ tags }: { tags: readonly string[] }) {
+  const visibleTags = tags.slice(0, MAX_VISIBLE_NOTES);
+  const hiddenCount = tags.length - visibleTags.length;
+
+  return (
+    <ul aria-label="Tasting notes" {...stylex.props(styles.notes)}>
+      {visibleTags.map((tag, index) => (
+        <li key={`${tag}-${index}`} {...stylex.props(styles.note)}>
+          <Chip size="sm">{tag}</Chip>
+        </li>
+      ))}
+      {hiddenCount ? (
+        <li {...stylex.props(styles.note)}>
+          <Chip size="sm">+{hiddenCount} more</Chip>
+        </li>
+      ) : null}
+    </ul>
   );
 }
 
@@ -255,11 +281,24 @@ const styles = stylex.create({
     flexDirection: "column",
     gap: space.x2,
   },
+  details: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space.x2,
+  },
   excerpt: {
     marginTop: 0,
     marginBottom: 0,
     color: colors.ink,
   },
-  excerptWithFooter: { marginBottom: space.x2 },
+  notes: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: space.x1,
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+  },
+  note: { display: "flex" },
   footer: { color: colors.inkMuted },
 });

--- a/apps/web/src/components/communityFeed.test.tsx
+++ b/apps/web/src/components/communityFeed.test.tsx
@@ -96,4 +96,28 @@ describe("CommunityFeed", () => {
       "Second Bottle",
     ]);
   });
+
+  it("shows a compact tasting-note preview and preserves the full count", () => {
+    const item: CommunityFeedItem = {
+      id: "review-1",
+      kind: "member_review",
+      actor: "alice",
+      action: "reviewed",
+      date: "2026-09-04T12:00:00.000Z",
+      bottles: [
+        {
+          id: "1",
+          name: "Example Bottle",
+          tags: ["smoke", "brine", "lemon", "vanilla", "pepper", "oak"],
+        },
+      ],
+    };
+
+    act(() => root.render(<CommunityFeed items={[item]} />));
+
+    const notes = container.querySelector('[aria-label="Tasting notes"]');
+    expect(notes?.textContent).toBe("smokebrinelemonvanilla+2 more");
+    expect(notes?.textContent).not.toContain("pepper");
+    expect(notes?.textContent).not.toContain("oak");
+  });
 });

--- a/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
@@ -178,12 +178,7 @@ export function TastingReviewDetail({
       {tags.length ? (
         <div {...stylex.props(styles.tags)}>
           {tags.map((tag, index) => (
-            <Chip
-              key={`${tag}-${index}`}
-              variant={index < 2 ? "tinted" : "neutral"}
-            >
-              {tag}
-            </Chip>
+            <Chip key={`${tag}-${index}`}>{tag}</Chip>
           ))}
         </div>
       ) : null}

--- a/apps/web/src/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/tastingEntry.stylex.tsx
@@ -136,12 +136,7 @@ export function TastingEntry({
               {member.tags?.length ? (
                 <div {...stylex.props(styles.tags)}>
                   {member.tags.map((tag, index) => (
-                    <Chip
-                      key={`${tag}-${index}`}
-                      variant={index < 2 ? "tinted" : "neutral"}
-                    >
-                      {tag}
-                    </Chip>
+                    <Chip key={`${tag}-${index}`}>{tag}</Chip>
                   ))}
                 </div>
               ) : null}

--- a/apps/web/src/lib/communityFeed.test.ts
+++ b/apps/web/src/lib/communityFeed.test.ts
@@ -23,6 +23,7 @@ describe("getCommunityFeedItems", () => {
     });
 
     expect(item?.bottles[0]?.description).toBe(mockExternalReview.clip);
+    expect(item?.bottles[0]?.tags).toEqual(mockExternalReview.extractedTags);
     expect(item?.actorHref).toBe(mockExternalReview.url);
     expect(item?.href).toBe(mockExternalReview.url);
   });
@@ -49,6 +50,7 @@ describe("getCommunityFeedItems", () => {
       bottles: [
         {
           description: mockExternalReview.clip,
+          tags: mockExternalReview.extractedTags,
         },
       ],
     });
@@ -137,6 +139,7 @@ describe("getTastingFeedItems", () => {
           id: String(mockTasting.id),
           description: mockTasting.notes,
           ratingBand: mockTasting.ratingBand,
+          tags: mockTasting.tags,
         },
       ],
     });
@@ -178,6 +181,7 @@ describe("getMemberReviewFeedItems", () => {
         {
           description: expect.stringContaining("Freshly poured"),
           score: { value: mockMemberReview.score, scale: 100 },
+          tags: mockMemberReview.tags,
         },
       ],
     });

--- a/apps/web/src/lib/communityFeed.ts
+++ b/apps/web/src/lib/communityFeed.ts
@@ -44,6 +44,7 @@ function tastingFeedItem(tasting: Tasting, id = String(tasting.id)) {
         description: getPreview(tasting.notes),
         imageUrl: tasting.imageUrl ?? tasting.bottle.imageUrl,
         ratingBand: tasting.ratingBand,
+        tags: tasting.tags,
       },
     ],
   } satisfies CommunityFeedItem;
@@ -76,6 +77,7 @@ export function getMemberReviewFeedItems(
         id: String(review.id),
         score: { value: review.score, scale: 100 },
         description: getPreview(review.notes),
+        tags: review.tags,
       },
     ],
   }));
@@ -105,6 +107,7 @@ export function getCommunityFeedItems({
           {
             ...feedBottle(review.bottle),
             description: getPreview(review.clip ?? review.article.title),
+            tags: review.extractedTags,
             byline:
               review.reviewerName && review.reviewerName !== source
                 ? review.reviewerName
@@ -134,6 +137,7 @@ export function getCommunityFeedItems({
             {
               ...feedBottle(review.bottle),
               description: getPreview(review.clip ?? review.article.title),
+              tags: review.extractedTags,
               byline:
                 review.reviewerName && review.reviewerName !== source
                   ? review.reviewerName
@@ -168,6 +172,7 @@ export function getCommunityFeedItems({
               ...feedBottle(entry.review.bottle),
               score: { value: entry.review.score, scale: 100 },
               description: getPreview(entry.review.notes),
+              tags: entry.review.tags,
             },
           ],
         },


### PR DESCRIPTION
Tasting and review rows now show up to four structured tasting notes as compact neutral chips beneath the free-text comment, with a “+N more” summary when needed. This covers member tastings, member reviews, and extracted critic-review notes while keeping activity rows compact.

Displayed tasting notes now use the same neutral treatment in activity rows, tasting sessions, and detail views, so their order no longer implies that some notes are more important than others.
