### PR TITLE
docs(catalog): record Heaven Hill production audit

### DIFF
--- a/docs/research/catalog-research-examples-2026-09.md
+++ b/docs/research/catalog-research-examples-2026-09.md
@@ -310,3 +310,79 @@ images. It did not merge or delete records.
   remain limited to exact records already in Peated or supported by a specific
   source. Generic Longrow Red, 18, and 21 records are possible merge candidates,
   but no merge was made without separate approval.
+
+## Heaven Hill — September 6, 2026
+
+The production review resolved Heaven Hill to company and Brand E1013, the
+historic Heaven Hill Springs distillery E366600, and the Bernheim distillery
+E366601. It started with 14 Brand-attached Bottles and finished the
+catalog pass with 48. The operation created 36 exact release records, corrected
+11 existing records, created five Series, updated the company description,
+added the verified company alias “Heaven Hill Brands,” and merged two proven
+duplicates. It did not delete any unique identity.
+
+- The producer's
+  [Bottled-in-Bond page](https://heavenhilldistillery.com/hh-bottled-in-bond.php)
+  and [2019 launch announcement](https://heavenhill.com/news-and-notes/heaven-hill-distillery-launches-historic-bottled-in-bond-namesake-bourbon/)
+  established the current 7-year product and its relationship to the original
+  1939 namesake and discontinued 6-year release. The
+  [Double Mash announcement](https://heavenhill.com/news-and-notes/heaven-hill-distillery-rewrites-bottled-in-bond-tradition-with-first-of-its-kind-double-mash-bourbon/)
+  established the separate 9-year 2026 release. Five Artist Series labels were
+  treated as packaging for the same flagship whiskey, not five new identities.
+- The producer's
+  [Heritage Collection archive](https://heavenhilldistillery.com/heavenhill-heritage-collection.php)
+  and exact announcements for
+  [2022](https://heavenhill.com/news-and-notes/heaven-hill-distillery-launches-new-ultra-premium-heaven-hill-heritage-collection/),
+  [2023](https://heavenhill.com/news-and-notes/heaven-hill-distillery-announces-2023-heaven-hill-heritage-collection-release/),
+  [2024](https://www.heavenhill.com/press-detail.php?postid=heaven-hill-distillery-announces-2024-heaven-hill-heritage-collection-release),
+  [2025](https://heavenhill.com/news-and-notes/heaven-hill-distillery-announces-2025-heaven-hill-heritage-collection-release/),
+  and [2026](https://heavenhill.com/news-and-notes/heaven-hill-distillery-announces-2026-heaven-hill-heritage-collection-release/)
+  established the five annual releases, including their category, age, strength,
+  vintage, and release facts. Four missing releases were created in Series
+  S0695. B44833 was merged into B34670 for the duplicate 2024 release, and the
+  survivor was corrected and assigned to the Series, which now has five
+  releases.
+- The producer's
+  [Grain to Glass archive](https://heavenhilldistillery.com/grain-to-glass/),
+  [2024 launch](https://heavenhill.com/news-and-notes/heaven-hill-distillery-announces-launch-of-heaven-hill-grain-to-glass/),
+  [2025 Specialty Barrel announcement](https://heavenhill.com/news-and-notes/heaven-hill-distillery-announces-first-release-of-heaven-hill-grain-to-glass-specialty-barrel-series/),
+  and [2026 Year of Wheat announcement](https://blog.heavenhilldistillery.com/detail.php?post_name=heaven-hill-distillery-announces-2026-year-of-wheat-grain-to-glass-releases)
+  established the 2024–2026 traditional, Specialty Barrel, and Extra Aged
+  releases. Ten missing Bottles were created and two existing 2024 Bottles were
+  corrected. Series S0697 holds Grain to Glass and S0693 holds the Specialty
+  Barrel Series. Conflicting producer months for the 2025 wheated bourbon and
+  rye were left unknown. Proofs announced as pending for two 2026 releases were
+  also left unknown.
+- The complete producer
+  [Select Stock archive](https://heavenhilldistillery.com/heaven-hill-select-stock.php/index.php)
+  established all 18 numbered editions from 2014 through 2024, including their
+  categories, ages, finishes, and strengths. They were created in Series S0694.
+  Existing B16612, “Select Stock Barrel #44823,” does not identify one of those
+  numbered editions and remains unresolved rather than being guessed.
+- The producer's
+  [Trybox launch announcement](https://heavenhill.com/news-and-notes/heaven-hill-launches-trybox-series-of-new-make-american-whiskeys/)
+  established the New Make and Rye releases. Exact specialist records confirmed
+  that Corn and Wheat were also marketed at 62.5% ABV. The two existing records
+  were corrected, two missing records were created, and all four now belong to
+  Series S0696.
+- Exact producer announcements established the
+  [27-year-old Barrel Proof release](https://heavenhill.com/news-and-notes/heaven-hill-distillery-announces-limited-edition-release-of-heaven-hill-27-year-old-barrel-proof-small-batch-kentucky-straight-bourbon-whiskey/),
+  [85th Anniversary release](https://heavenhill.com/news-and-notes/heaven-hill-distillery-announces-release-of-limited-edition-heaven-hill-85th-anniversary-single-barrel-kentucky-straight-bourbon-whiskey/),
+  [90th Anniversary release](https://heavenhill.com/news-and-notes/heaven-hill-distillery-celebrates-90-years-of-independent-family-ownership-with-limited-9-year-old-kentucky-straight-bourbon-release/),
+  [Master Distillers Unity](https://heavenhill.com/news-and-notes/heaven-hill-distillery-unveils-heaven-hill-master-distillers-unity-in-celebration-of-the-grand-opening-of-heaven-hill-springs-distillery/),
+  and [Deatsville](https://heavenhill.com/news-and-notes/heaven-hill-distillery-honors-a-storied-legacy-with-heaven-hill-deatsville-13-year-old-bourbon-whiskey/).
+  Existing records were corrected where present; the latter two were created.
+- Producer, retailer, auction, and specialist photos did not state reusable
+  rights, so no image was copied. Existing Peated-hosted store images were
+  preserved. Specialist historical indexes exposed old Old Style, Gold Label,
+  Private Cellar, Ultra Deluxe, Canadian whisky, and other label variants, but
+  did not consistently prove release boundaries. Those leads, and the
+  unannounced Phoenix listing, remain unresolved rather than being added as
+  facts.
+- After explicit approval, B44149 was merged into B13613 for the current 7-year
+  Bottled-in-Bond release, and B44833 was merged into B34670 for the 2024
+  Heritage Collection 18-year release. B13613 retained the only image and now
+  has all four exact source references. B34670 now has all three exact source
+  references. Both retired IDs resolve to the intended survivor; the survivors
+  remain singleton groups with zero tastings, aliases, and barcodes; and neither
+  retired ID appears in the 48-Bottle Brand inventory.


### PR DESCRIPTION
Records the September 2026 Heaven Hill production catalog audit, including the source coverage for each release family, completed Bottle and Series changes, duplicate merges, and image-license limits.

The record also preserves the unresolved historical leads and conflicting facts that were intentionally left unset, so future catalog work can continue without treating weak evidence as fact.
