### PR TITLE
feat(activity): show active critics

### DIFF
--- a/apps/server/src/orpc/contracts/externalReviews/active-critics.ts
+++ b/apps/server/src/orpc/contracts/externalReviews/active-critics.ts
@@ -1,0 +1,48 @@
+import { ExternalSiteKeySchema } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export const ActiveCriticSchema = z
+  .object({
+    site: z
+      .object({
+        type: ExternalSiteKeySchema.describe("Stable key for the review site"),
+        name: z.string().trim().min(1).describe("Name of the review site"),
+        imageUrl: z.string().url().nullable().describe("Site icon URL"),
+      })
+      .strict(),
+    latestReview: z
+      .object({
+        bottleName: z
+          .string()
+          .trim()
+          .min(1)
+          .describe("Full name of the Bottle reviewed"),
+        publishedAt: z
+          .string()
+          .datetime()
+          .describe("Publication time of the review"),
+        url: z.string().trim().min(1).describe("URL to the original review"),
+      })
+      .strict(),
+  })
+  .strict();
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/external-reviews/active-critics",
+    summary: "List active critics",
+    description:
+      "List review sites in Peated's activity order. Each site includes the public review used to place it.",
+    operationId: "listActiveCritics",
+  })
+  .input(
+    z
+      .object({
+        limit: z.coerce.number().int().gte(1).lte(10).default(5),
+      })
+      .strict()
+      .default({ limit: 5 }),
+  )
+  .output(z.array(ActiveCriticSchema));

--- a/apps/server/src/orpc/mock/contract.ts
+++ b/apps/server/src/orpc/mock/contract.ts
@@ -33,6 +33,7 @@ import entityList from "@peated/server/orpc/contracts/entities/list";
 import entityPortfolio from "@peated/server/orpc/contracts/entities/portfolio";
 import entityResolve from "@peated/server/orpc/contracts/entities/resolve";
 import eventList from "@peated/server/orpc/contracts/events/list";
+import externalReviewActiveCritics from "@peated/server/orpc/contracts/externalReviews/active-critics";
 import externalReviewList from "@peated/server/orpc/contracts/externalReviews/list";
 import flightDetails from "@peated/server/orpc/contracts/flights/details";
 import flightList from "@peated/server/orpc/contracts/flights/list";
@@ -158,6 +159,7 @@ export const mockContract = {
     list: regionList,
   },
   externalReviews: {
+    activeCritics: externalReviewActiveCritics,
     list: externalReviewList,
   },
   smws: {

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -79,6 +79,25 @@ describe("mock oRPC router", () => {
         },
       ],
     });
+    const activeCritics = await anonymousClient.externalReviews.activeCritics({
+      limit: 3,
+    });
+    expect(activeCritics).toHaveLength(3);
+    expect(new Set(activeCritics.map((critic) => critic.site.type)).size).toBe(
+      3,
+    );
+    expect(activeCritics[0]).toEqual({
+      site: {
+        type: mockExternalReview.site!.type,
+        name: mockExternalReview.site!.name,
+        imageUrl: mockExternalReview.site!.imageUrl,
+      },
+      latestReview: {
+        bottleName: mockExternalReview.bottle!.fullName,
+        publishedAt: mockExternalReview.article.publishedAt!,
+        url: mockExternalReview.url,
+      },
+    });
 
     const bottles = await anonymousClient.bottles.list({ query: "Lagavulin" });
     expect(bottles.results).toHaveLength(3);

--- a/apps/server/src/orpc/mock/router.ts
+++ b/apps/server/src/orpc/mock/router.ts
@@ -33,6 +33,7 @@ import entityList from "./routes/entities/list";
 import entityPortfolio from "./routes/entities/portfolio";
 import entityResolve from "./routes/entities/resolve";
 import eventList from "./routes/events/list";
+import externalReviewActiveCritics from "./routes/externalReviews/active-critics";
 import externalReviewList from "./routes/externalReviews/list";
 import flightDetails from "./routes/flights/details";
 import flightList from "./routes/flights/list";
@@ -158,6 +159,7 @@ export const mockRouter = mockOS.router({
     list: regionList,
   },
   externalReviews: {
+    activeCritics: externalReviewActiveCritics,
     list: externalReviewList,
   },
   smws: {

--- a/apps/server/src/orpc/mock/routes/externalReviews/active-critics.ts
+++ b/apps/server/src/orpc/mock/routes/externalReviews/active-critics.ts
@@ -1,0 +1,33 @@
+import { mockExternalReviews } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.externalReviews.activeCritics.handler(
+  async ({ input }) => {
+    const sites = new Set<string>();
+    return mockExternalReviews
+      .filter(
+        (review) => review.site && review.bottle && review.article.publishedAt,
+      )
+      .toSorted((first, second) =>
+        second.article.publishedAt!.localeCompare(first.article.publishedAt!),
+      )
+      .filter((review) => {
+        if (sites.has(review.site!.type)) return false;
+        sites.add(review.site!.type);
+        return true;
+      })
+      .slice(0, input.limit)
+      .map((review) => ({
+        site: {
+          type: review.site!.type,
+          name: review.site!.name,
+          imageUrl: review.site!.imageUrl,
+        },
+        latestReview: {
+          bottleName: review.bottle!.fullName,
+          publishedAt: review.article.publishedAt!,
+          url: review.url,
+        },
+      }));
+  },
+);

--- a/apps/server/src/orpc/routes/externalReviews/active-critics.test.ts
+++ b/apps/server/src/orpc/routes/externalReviews/active-critics.test.ts
@@ -1,0 +1,145 @@
+import { db } from "@peated/server/db";
+import {
+  bottleTombstones,
+  externalReviewArticles,
+} from "@peated/server/db/schema";
+import { routerClient } from "@peated/server/orpc/router";
+import { eq } from "drizzle-orm";
+
+describe("GET /external-reviews/active-critics", () => {
+  test("returns one latest public review per active site", async ({
+    fixtures,
+  }) => {
+    const firstSite = await fixtures.ExternalSite({
+      name: "First critic",
+      type: "first-critic",
+    });
+    const secondSite = await fixtures.ExternalSite({
+      name: "Second critic",
+      type: "second-critic",
+    });
+    const hiddenSite = await fixtures.ExternalSite({
+      name: "Hidden critic",
+      type: "hidden-critic",
+    });
+    const unapprovedSite = await fixtures.ExternalSite({
+      name: "Unapproved critic",
+      type: "unapproved-critic",
+    });
+    const unresolvedSite = await fixtures.ExternalSite({
+      name: "Unresolved critic",
+      type: "unresolved-critic",
+    });
+    const missingDateSite = await fixtures.ExternalSite({
+      name: "Undated critic",
+      type: "undated-critic",
+    });
+    const deletedBottleSite = await fixtures.ExternalSite({
+      name: "Retired Bottle critic",
+      type: "retired-bottle-critic",
+    });
+    await Promise.all(
+      [
+        firstSite,
+        secondSite,
+        hiddenSite,
+        unresolvedSite,
+        missingDateSite,
+        deletedBottleSite,
+      ].map((site) =>
+        fixtures.ApprovedExternalReviewPublication({ externalSiteId: site.id }),
+      ),
+    );
+
+    const olderFirst = await fixtures.ExternalReview({
+      externalSiteId: firstSite.id,
+      url: "https://example.com/first-older",
+    });
+    const latestFirst = await fixtures.ExternalReview({
+      externalSiteId: firstSite.id,
+      url: "https://example.com/first-latest",
+    });
+    const second = await fixtures.ExternalReview({
+      externalSiteId: secondSite.id,
+      url: "https://example.com/second",
+    });
+    const hidden = await fixtures.ExternalReview({
+      externalSiteId: hiddenSite.id,
+      hidden: true,
+    });
+    const unapproved = await fixtures.ExternalReview({
+      externalSiteId: unapprovedSite.id,
+    });
+    const unresolved = await fixtures.ExternalReview({
+      bottleId: null,
+      externalSiteId: unresolvedSite.id,
+    });
+    const missingDate = await fixtures.ExternalReview({
+      externalSiteId: missingDateSite.id,
+    });
+    const retiredBottle = await fixtures.Bottle();
+    const deletedBottle = await fixtures.ExternalReview({
+      bottleId: retiredBottle.id,
+      externalSiteId: deletedBottleSite.id,
+    });
+    await db.insert(bottleTombstones).values({ bottleId: retiredBottle.id });
+    const dates = new Map([
+      [olderFirst.articleId!, "2026-08-10T00:00:00.000Z"],
+      [latestFirst.articleId!, "2026-08-30T00:00:00.000Z"],
+      [second.articleId!, "2026-08-20T00:00:00.000Z"],
+      [hidden.articleId!, "2026-09-01T00:00:00.000Z"],
+      [unapproved.articleId!, "2026-09-02T00:00:00.000Z"],
+      [unresolved.articleId!, "2026-09-03T00:00:00.000Z"],
+      [deletedBottle.articleId!, "2026-09-04T00:00:00.000Z"],
+      [missingDate.articleId!, null],
+    ]);
+    await Promise.all(
+      [...dates].map(([articleId, publishedAt]) =>
+        db
+          .update(externalReviewArticles)
+          .set({
+            contentHash: `content-${articleId}`,
+            publishedAt: publishedAt ? new Date(publishedAt) : null,
+          })
+          .where(eq(externalReviewArticles.id, articleId)),
+      ),
+    );
+
+    const results = await routerClient.externalReviews.activeCritics({
+      limit: 2,
+    });
+
+    expect(results).toEqual([
+      {
+        site: {
+          type: firstSite.type,
+          name: firstSite.name,
+          imageUrl: null,
+        },
+        latestReview: {
+          bottleName: latestFirst.name,
+          publishedAt: "2026-08-30T00:00:00.000Z",
+          url: "https://example.com/first-latest",
+        },
+      },
+      {
+        site: {
+          type: secondSite.type,
+          name: secondSite.name,
+          imageUrl: null,
+        },
+        latestReview: {
+          bottleName: second.name,
+          publishedAt: "2026-08-20T00:00:00.000Z",
+          url: "https://example.com/second",
+        },
+      },
+    ]);
+  });
+
+  test("rejects a limit outside the public range", async () => {
+    await expect(
+      routerClient.externalReviews.activeCritics({ limit: 0 }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/server/src/orpc/routes/externalReviews/active-critics.ts
+++ b/apps/server/src/orpc/routes/externalReviews/active-critics.ts
@@ -1,0 +1,102 @@
+import { db } from "@peated/server/db";
+import {
+  bottles,
+  bottleTombstones,
+  externalReviewArticles,
+  externalReviewPublications,
+  externalReviews,
+  externalSites,
+} from "@peated/server/db/schema";
+import { visibleExternalReviewWhere } from "@peated/server/externalReviews/visibility";
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
+import { implement } from "@peated/server/orpc";
+import activeCriticsContract from "@peated/server/orpc/contracts/externalReviews/active-critics";
+import { serializeExternalSite } from "@peated/server/serializers/externalSite";
+import { and, asc, desc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+
+export default implement(activeCriticsContract).handler(async function ({
+  input,
+}) {
+  const latestBySite = await db
+    .selectDistinctOn([externalReviewArticles.externalSiteId], {
+      bottleId: bottles.id,
+      publishedAt: externalReviewArticles.publishedAt,
+      reviewId: externalReviews.id,
+      reviewUrl: externalReviewArticles.canonicalUrl,
+      site: externalSites,
+    })
+    .from(externalReviews)
+    .innerJoin(
+      externalReviewArticles,
+      eq(externalReviews.articleId, externalReviewArticles.id),
+    )
+    .leftJoin(
+      externalReviewPublications,
+      eq(
+        externalReviewArticles.externalSiteId,
+        externalReviewPublications.externalSiteId,
+      ),
+    )
+    .innerJoin(
+      externalSites,
+      eq(externalReviewArticles.externalSiteId, externalSites.id),
+    )
+    .innerJoin(bottles, eq(externalReviews.bottleId, bottles.id))
+    .where(
+      and(
+        visibleExternalReviewWhere(),
+        isNotNull(externalReviews.bottleId),
+        isNotNull(externalReviewArticles.publishedAt),
+        isNotNull(bottles.groupId),
+        sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
+      ),
+    )
+    .orderBy(
+      asc(externalReviewArticles.externalSiteId),
+      desc(externalReviewArticles.publishedAt),
+      desc(externalReviews.id),
+    );
+
+  // The API owns the activity ranking so the product can tune it without
+  // changing every surface that presents critics.
+  const rankedCritics = latestBySite
+    .sort(
+      (first, second) =>
+        (second.publishedAt?.getTime() ?? 0) -
+          (first.publishedAt?.getTime() ?? 0) ||
+        second.reviewId - first.reviewId,
+    )
+    .slice(0, input.limit);
+  const rankedBottles = rankedCritics.length
+    ? await db.query.bottles.findMany({
+        where: inArray(
+          bottles.id,
+          rankedCritics.map(({ bottleId }) => bottleId),
+        ),
+        with: { brand: true, group: true, series: true },
+      })
+    : [];
+  const bottlesById = new Map(
+    rankedBottles.map((bottle) => [bottle.id, bottle]),
+  );
+
+  return rankedCritics.map(({ bottleId, publishedAt, reviewUrl, site }) => {
+    const bottle = bottlesById.get(bottleId);
+    if (!bottle) {
+      throw new Error(`Active critic references missing Bottle ${bottleId}.`);
+    }
+    const serializedSite = serializeExternalSite(site);
+    return {
+      site: {
+        type: serializedSite.type,
+        name: serializedSite.name,
+        imageUrl: serializedSite.imageUrl,
+      },
+      latestReview: {
+        bottleName: formatBottleDisplayName(bottle),
+        publishedAt: publishedAt!.toISOString(),
+        url: reviewUrl,
+      },
+    };
+  });
+});

--- a/apps/server/src/orpc/routes/externalReviews/index.ts
+++ b/apps/server/src/orpc/routes/externalReviews/index.ts
@@ -1,9 +1,11 @@
 import { base } from "@peated/server/orpc";
+import activeCritics from "./active-critics";
 import create from "./create";
 import list from "./list";
 import update from "./update";
 
 export default base.tag("external reviews").router({
+  activeCritics,
   list,
   create,
   update,

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
@@ -1,10 +1,12 @@
 import {
   mockActivity,
   mockExternalReview,
+  mockExternalReviews,
   mockFriendships,
 } from "@peated/server/orpc/mock/fixtures";
 import { beforeEach, expect, test, vi } from "vitest";
 import {
+  getActiveCriticRailItems,
   getActivityFeedHref,
   getActivityFeedSelection,
   loadActivityFeed,
@@ -31,6 +33,31 @@ const criticActivity = {
   createdAt: mockExternalReview.article.publishedAt!,
   review: mockExternalReview,
 };
+
+test("maps active critics without adding the review byline", () => {
+  const review = mockExternalReviews[0]!;
+  const critics = getActiveCriticRailItems([
+    {
+      site: {
+        type: review.site!.type,
+        name: review.site!.name,
+        imageUrl: review.site!.imageUrl,
+      },
+      latestReview: {
+        bottleName: review.bottle!.fullName,
+        publishedAt: review.article.publishedAt!,
+        url: review.url,
+      },
+    },
+  ]);
+
+  expect(critics[0]).toMatchObject({
+    bottleName: "Lagavulin 16-year-old",
+    href: mockExternalReviews[0]!.url,
+    name: "Whisky Advocate",
+  });
+  expect(critics[0]).not.toHaveProperty("reviewerName");
+});
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.ts
@@ -1,10 +1,22 @@
 import type { RouterClient } from "@orpc/server";
-import type { Router } from "@peated/server/orpc/router";
+import type { Outputs, Router } from "@peated/server/orpc/router";
 import { getAuthRedirect } from "@peated/web/lib/auth";
 import { getCommunityFeedItems } from "@peated/web/lib/communityFeed";
 
 type Client = RouterClient<Router>;
 type ActivityClient = { activity: Pick<Client["activity"], "list"> };
+type ActiveCritic = Outputs["externalReviews"]["activeCritics"][number];
+
+export function getActiveCriticRailItems(critics: readonly ActiveCritic[]) {
+  return critics.map(({ latestReview, site }) => ({
+    bottleName: latestReview.bottleName,
+    href: latestReview.url,
+    imageUrl: site.imageUrl,
+    name: site.name,
+    publishedAt: latestReview.publishedAt,
+    type: site.type,
+  }));
+}
 
 export function getActivityFeedSelection(feed?: string) {
   return feed === "following" ? "following" : "everyone";

--- a/apps/web/src/app/(app)/activity/page.tsx
+++ b/apps/web/src/app/(app)/activity/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@peated/web/lib/orpc/client.server";
 import type { Metadata } from "next";
 import {
+  getActiveCriticRailItems,
   getActivityFeedHref,
   getActivityFeedSelection,
   loadActivityFeed,
@@ -50,13 +51,14 @@ export default async function Activity({
 
   const { client: publicClient } = await getAnonymousServerClient();
   const memberClient = user ? (await getServerClient()).client : undefined;
-  const [{ items, note, rel }, library] = await Promise.all([
+  const [{ items, note, rel }, library, activeCritics] = await Promise.all([
     loadActivityFeed({ cursor, following, memberClient, publicClient }),
     memberClient?.collections.bottles.list({
       user: "me",
       collection: "library",
       limit: 25,
     }),
+    publicClient.externalReviews.activeCritics({ limit: 5 }),
   ]);
   const libraryBottles = (library?.results ?? [])
     .filter((item) => !item.hasTasted)
@@ -68,6 +70,7 @@ export default async function Activity({
 
   return (
     <ActivityPage
+      activeCritics={getActiveCriticRailItems(activeCritics)}
       items={items}
       libraryBottles={libraryBottles}
       libraryHref={user ? `/users/${user.username}/library` : undefined}

--- a/apps/web/src/components/pages/activeCriticRailSection.stylex.tsx
+++ b/apps/web/src/components/pages/activeCriticRailSection.stylex.tsx
@@ -1,0 +1,65 @@
+import { Avatar, RailList, RailListItem } from "@peated/web/components";
+
+import { RailListSection } from "./railListSection.stylex";
+
+export type ActiveCriticRailItem = {
+  bottleName: string;
+  href: string;
+  imageUrl?: string | null;
+  name: string;
+  publishedAt: string;
+  type: string;
+};
+
+/** Lists up to five review sites in the order chosen by the caller. */
+export function ActiveCriticRailSection({
+  items,
+}: {
+  items: readonly ActiveCriticRailItem[];
+}) {
+  if (!items.length) return null;
+
+  return (
+    <RailListSection
+      heading="Active critics"
+      intro="Sites behind the latest whisky reviews."
+    >
+      <RailList ariaLabel="Active critics">
+        {items.slice(0, 5).map((item) => (
+          <RailListItem
+            end={formatPublishedAt(item.publishedAt)}
+            href={item.href}
+            key={item.type}
+            leading={
+              <Avatar
+                imageUrl={item.imageUrl}
+                initials={getInitials(item.name)}
+                size="sm"
+              />
+            }
+            metadata={item.bottleName}
+            title={item.name}
+          />
+        ))}
+      </RailList>
+    </RailListSection>
+  );
+}
+
+function getInitials(name: string) {
+  const parts = name.split(/\s+/u).filter(Boolean);
+  return parts.length > 1
+    ? parts
+        .slice(0, 2)
+        .map((part) => part[0]?.toUpperCase())
+        .join("")
+    : name.slice(0, 2).toUpperCase();
+}
+
+function formatPublishedAt(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+  }).format(new Date(value));
+}

--- a/apps/web/src/components/pages/activityPage.stories.tsx
+++ b/apps/web/src/components/pages/activityPage.stories.tsx
@@ -2,6 +2,7 @@ import {
   mockActivity,
   mockCollectionBottles,
   mockExternalReview,
+  mockExternalReviews,
 } from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { toBottleListItem } from "../../lib/bottleListItem";
@@ -11,6 +12,33 @@ import { CursorPager } from "../lists.stylex";
 import { PageTabs } from "../pageTabs.stylex";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import { ActivityPage } from "./activityPage.stylex";
+
+const activeCritics = mockExternalReviews
+  .flatMap((review) => {
+    if (!review.site || !review.bottle || !review.article.publishedAt)
+      return [];
+    return [
+      {
+        bottleName: toBottleListItem(review.bottle).name,
+        href: review.url,
+        imageUrl: review.site.imageUrl,
+        name: review.site.name,
+        publishedAt: review.article.publishedAt,
+        type: review.site.type,
+      },
+    ];
+  })
+  .toSorted(
+    (first, second) =>
+      new Date(second.publishedAt).getTime() -
+      new Date(first.publishedAt).getTime(),
+  )
+  .filter(
+    (critic, index, critics) =>
+      critics.findIndex((candidate) => candidate.type === critic.type) ===
+      index,
+  )
+  .slice(0, 5);
 
 const meta = {
   title: "Pages/Activity",
@@ -26,11 +54,12 @@ const meta = {
     docs: {
       description: {
         component:
-          "Activity uses the catalog columns, with Following/Everyone beside the page title and aligned with the feed column. The cursor pager keeps the selected feed while moving through activity. The sidebar has the tasting action and bottles from the member’s library, and is hidden on mobile. A short notice explains when Following shows everyone's activity because there are no accepted follows.",
+          "Activity uses the catalog columns, with Following/Everyone beside the page title and aligned with the feed column. The cursor pager keeps the selected feed while moving through activity. The sidebar has the tasting action, active critic sites, and bottles from the member’s library, and is hidden on mobile. A short notice explains when Following shows everyone's activity because there are no accepted follows.",
       },
     },
   },
   args: {
+    activeCritics,
     items: getCommunityFeedItems({
       criticReviews: [],
       activity: [

--- a/apps/web/src/components/pages/activityPage.stylex.tsx
+++ b/apps/web/src/components/pages/activityPage.stylex.tsx
@@ -11,6 +11,10 @@ import {
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 import { CommunityFeed, type CommunityFeedItem } from "../communityFeed.stylex";
+import {
+  ActiveCriticRailSection,
+  type ActiveCriticRailItem,
+} from "./activeCriticRailSection.stylex";
 import { BottleRailSection } from "./bottleRailSection.stylex";
 import { PageColumns, PageHeader } from "./pageLayout.stylex";
 import { RailListSection } from "./railListSection.stylex";
@@ -22,6 +26,7 @@ export function ActivityPage({
   pagination,
   selector,
   loading = false,
+  activeCritics = [],
   libraryBottles = [],
   libraryHref,
 }: {
@@ -29,6 +34,7 @@ export function ActivityPage({
   loading?: boolean;
   note?: string;
   pagination?: ReactNode;
+  activeCritics?: readonly ActiveCriticRailItem[];
   libraryBottles?: readonly BottleListItem[];
   libraryHref?: string;
   selector: ReactNode;
@@ -59,6 +65,7 @@ export function ActivityPage({
                 </ButtonLink>
               </div>
             </RailListSection>
+            <ActiveCriticRailSection items={activeCritics} />
             {libraryBottles.length ? (
               <BottleRailSection
                 heading="From your library"

--- a/apps/web/src/components/pages/activityPage.test.tsx
+++ b/apps/web/src/components/pages/activityPage.test.tsx
@@ -14,3 +14,35 @@ test("keeps known activity content visible while the feed loads", () => {
   expect(html).toContain("Loading activity");
   expect(html).not.toContain("Nothing here yet");
 });
+
+test("shows review sites in the supplied critic order", () => {
+  const html = renderToStaticMarkup(
+    <ActivityPage
+      activeCritics={[
+        {
+          bottleName: "Lagavulin 8-year-old",
+          href: "https://example.com/reviews/lagavulin-8",
+          name: "Whiskyfun",
+          publishedAt: "2026-08-20T09:00:00.000Z",
+          type: "whiskyfun",
+        },
+        {
+          bottleName: "Lagavulin 16-year-old",
+          href: "https://example.com/reviews/lagavulin-16",
+          name: "Whisky Advocate",
+          publishedAt: "2026-08-26T09:00:00.000Z",
+          type: "whisky-advocate",
+        },
+      ]}
+      items={[]}
+      selector={<span>Feed selection</span>}
+    />,
+  );
+
+  expect(html).toContain("Active critics");
+  expect(html).toContain("Whiskyfun");
+  expect(html).toContain("Lagavulin 8-year-old");
+  expect(html.indexOf("Whiskyfun")).toBeLessThan(
+    html.indexOf("Whisky Advocate"),
+  );
+});

--- a/docs/features/external-reviews.md
+++ b/docs/features/external-reviews.md
@@ -4,6 +4,17 @@ Peated stores facts about external whisky reviews and links readers to the
 publisher's article. It can generate a short review clip, but does not republish
 the article body, complete tasting notes, conclusion, or images.
 
+## Active Critics
+
+Peated presents the review site as the critic. A writer's name remains an
+optional byline on that site's review; it is not a separate critic identity.
+
+The Activity sidebar shows up to 5 active critics. Peated chooses the order.
+It currently takes each site's newest public review linked to a Bottle that has
+not been deleted, then orders the sites by publication date. Reviews do not
+qualify when they are hidden, unpublished, missing a date, or missing a Bottle
+match. Each site links to the original review used to place it.
+
 ## Publication
 
 Every source starts unpublished. Collection and Bottle matching can run while


### PR DESCRIPTION
Activity now shows up to 5 active critics in the existing sidebar. Each review site is the primary identity, with its latest Bottle review and publication date underneath; the row links to the original review. The page width and responsive column behavior are unchanged.

A new public endpoint owns the ranking and returns only the site identity and review facts this rail needs. It currently selects each site's newest visible, dated review with a current Bottle match, excluding hidden, unpublished, unresolved, and deleted-Bottle records. Writer names remain review bylines and do not become critic identities.

This does not add critic profile pages; the sidebar links directly to publishers for now.
