### PR TITLE
fix(web): remove redundant distillery labels

### DIFF
--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -238,7 +238,7 @@ export function HomeDistilleries({
       <ItemList ariaLabel="Distilleries">
         {distilleries.map((distillery) => (
           <ItemListItem key={distillery.href}>
-            <EntityIdentityRow {...distillery} />
+            <EntityIdentityRow {...distillery} kind={undefined} />
           </ItemListItem>
         ))}
       </ItemList>

--- a/apps/web/src/components/pages/homeBrowse.test.tsx
+++ b/apps/web/src/components/pages/homeBrowse.test.tsx
@@ -1,0 +1,25 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { HomeDistilleries } from "./homeBrowse.stylex";
+
+describe("HomeDistilleries", () => {
+  it("shows locations without repeating the distillery kind", () => {
+    const html = renderToStaticMarkup(
+      <HomeDistilleries
+        distilleries={[
+          {
+            href: "/distillers/42",
+            kind: "distillery",
+            location: "Islay, Scotland",
+            name: "Example Distillery",
+          },
+        ]}
+        totalDistilleries={1267}
+      />,
+    );
+
+    expect(html).toContain("Islay, Scotland");
+    expect(html).not.toContain("Distillery ·");
+  });
+});


### PR DESCRIPTION
The homepage Distilleries sidebar now omits the redundant “Distillery” kind from each row while retaining its recorded location and following state. Other entity lists continue to use the shared kind-and-location metadata.
