### PR TITLE
fix(prices): finish retry run cancellation

### DIFF
--- a/apps/server/src/lib/storePriceMatchRetryRuns.test.ts
+++ b/apps/server/src/lib/storePriceMatchRetryRuns.test.ts
@@ -4,7 +4,10 @@ import {
   storePriceMatchRetryRunItems,
   storePriceMatchRetryRuns,
 } from "@peated/server/db/schema";
-import { processStorePriceMatchRetryRun } from "@peated/server/lib/storePriceMatchRetryRuns";
+import {
+  cancelStorePriceMatchRetryRun,
+  processStorePriceMatchRetryRun,
+} from "@peated/server/lib/storePriceMatchRetryRuns";
 import { eq } from "drizzle-orm";
 import { describe, expect, test, vi } from "vitest";
 
@@ -153,5 +156,75 @@ describe("store price match retry runs", () => {
       skippedCount: 1,
       status: "canceled",
     });
+  });
+
+  test("does not let in-flight work revive a canceled retry run", async ({
+    fixtures,
+  }) => {
+    const price = await fixtures.StorePrice({
+      name: "Retry Run In Flight Cancel",
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "match_existing",
+      })
+      .returning();
+    const [run] = await db
+      .insert(storePriceMatchRetryRuns)
+      .values({
+        matchedCount: 1,
+        status: "running",
+      })
+      .returning();
+    const [item] = await db
+      .insert(storePriceMatchRetryRunItems)
+      .values({
+        priceId: price.id,
+        proposalId: proposal!.id,
+        runId: run!.id,
+      })
+      .returning();
+
+    let finishResolution!: (value: NonNullable<typeof proposal>) => void;
+    const resolveProposal = vi.fn(
+      () =>
+        new Promise<NonNullable<typeof proposal>>((resolve) => {
+          finishResolution = resolve;
+        }),
+    );
+    const enqueueNext = vi.fn(async () => undefined);
+    const processing = processStorePriceMatchRetryRun({
+      enqueueNext,
+      resolveProposal,
+      runId: run!.id,
+    });
+
+    await vi.waitFor(() => expect(resolveProposal).toHaveBeenCalledOnce());
+    await cancelStorePriceMatchRetryRun(run!.id);
+    finishResolution(proposal!);
+    await processing;
+
+    const [updatedRun, updatedItem] = await Promise.all([
+      db.query.storePriceMatchRetryRuns.findFirst({
+        where: eq(storePriceMatchRetryRuns.id, run!.id),
+      }),
+      db.query.storePriceMatchRetryRunItems.findFirst({
+        where: eq(storePriceMatchRetryRunItems.id, item!.id),
+      }),
+    ]);
+    expect(updatedRun).toMatchObject({
+      processedCount: 1,
+      reviewableCount: 0,
+      skippedCount: 1,
+      status: "canceled",
+    });
+    expect(updatedItem).toMatchObject({
+      resultStatus: null,
+      status: "skipped",
+    });
+    expect(enqueueNext).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/lib/storePriceMatchRetryRuns.ts
+++ b/apps/server/src/lib/storePriceMatchRetryRuns.ts
@@ -14,7 +14,7 @@ import {
   releaseStorePriceMatchProposalProcessingLease,
 } from "@peated/server/lib/priceMatchingProcessingLease";
 import { resolveStorePriceMatchProposal } from "@peated/server/lib/priceMatchingProposals";
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, exists, inArray, sql } from "drizzle-orm";
 
 export const STORE_PRICE_MATCH_RETRY_RUN_TERMINAL_STATUSES = [
   "completed",
@@ -204,7 +204,7 @@ async function markRetryRunItemCompleted({
   const counter = getFinishedCounter(resultStatus);
 
   await db.transaction(async (tx) => {
-    await tx
+    const [updatedItem] = await tx
       .update(storePriceMatchRetryRunItems)
       .set({
         completedAt: sql`NOW()`,
@@ -212,7 +212,15 @@ async function markRetryRunItemCompleted({
         status: "completed",
         updatedAt: sql`NOW()`,
       })
-      .where(eq(storePriceMatchRetryRunItems.id, item.id));
+      .where(
+        and(
+          eq(storePriceMatchRetryRunItems.id, item.id),
+          eq(storePriceMatchRetryRunItems.status, "processing"),
+        ),
+      )
+      .returning({ id: storePriceMatchRetryRunItems.id });
+
+    if (!updatedItem) return;
 
     await tx
       .update(storePriceMatchRetryRuns)
@@ -221,7 +229,12 @@ async function markRetryRunItemCompleted({
         processedCount: sql`${storePriceMatchRetryRuns.processedCount} + 1`,
         updatedAt: sql`NOW()`,
       })
-      .where(eq(storePriceMatchRetryRuns.id, item.runId));
+      .where(
+        and(
+          eq(storePriceMatchRetryRuns.id, item.runId),
+          inArray(storePriceMatchRetryRuns.status, ["pending", "running"]),
+        ),
+      );
   });
 }
 
@@ -233,7 +246,7 @@ async function markRetryRunItemSkipped({
   item: StorePriceMatchRetryRunItem;
 }) {
   await db.transaction(async (tx) => {
-    await tx
+    const [updatedItem] = await tx
       .update(storePriceMatchRetryRunItems)
       .set({
         completedAt: sql`NOW()`,
@@ -241,7 +254,15 @@ async function markRetryRunItemSkipped({
         status: "skipped",
         updatedAt: sql`NOW()`,
       })
-      .where(eq(storePriceMatchRetryRunItems.id, item.id));
+      .where(
+        and(
+          eq(storePriceMatchRetryRunItems.id, item.id),
+          eq(storePriceMatchRetryRunItems.status, "processing"),
+        ),
+      )
+      .returning({ id: storePriceMatchRetryRunItems.id });
+
+    if (!updatedItem) return;
 
     await tx
       .update(storePriceMatchRetryRuns)
@@ -250,7 +271,12 @@ async function markRetryRunItemSkipped({
         skippedCount: sql`${storePriceMatchRetryRuns.skippedCount} + 1`,
         updatedAt: sql`NOW()`,
       })
-      .where(eq(storePriceMatchRetryRuns.id, item.runId));
+      .where(
+        and(
+          eq(storePriceMatchRetryRuns.id, item.runId),
+          inArray(storePriceMatchRetryRuns.status, ["pending", "running"]),
+        ),
+      );
   });
 }
 
@@ -262,7 +288,7 @@ async function markRetryRunItemFailed({
   item: StorePriceMatchRetryRunItem;
 }) {
   await db.transaction(async (tx) => {
-    await tx
+    const [updatedItem] = await tx
       .update(storePriceMatchRetryRunItems)
       .set({
         completedAt: sql`NOW()`,
@@ -270,7 +296,15 @@ async function markRetryRunItemFailed({
         status: "failed",
         updatedAt: sql`NOW()`,
       })
-      .where(eq(storePriceMatchRetryRunItems.id, item.id));
+      .where(
+        and(
+          eq(storePriceMatchRetryRunItems.id, item.id),
+          eq(storePriceMatchRetryRunItems.status, "processing"),
+        ),
+      )
+      .returning({ id: storePriceMatchRetryRunItems.id });
+
+    if (!updatedItem) return;
 
     await tx
       .update(storePriceMatchRetryRuns)
@@ -279,42 +313,78 @@ async function markRetryRunItemFailed({
         processedCount: sql`${storePriceMatchRetryRuns.processedCount} + 1`,
         updatedAt: sql`NOW()`,
       })
-      .where(eq(storePriceMatchRetryRuns.id, item.runId));
+      .where(
+        and(
+          eq(storePriceMatchRetryRuns.id, item.runId),
+          inArray(storePriceMatchRetryRuns.status, ["pending", "running"]),
+        ),
+      );
   });
 }
 
-async function cancelRetryRun(runId: number) {
-  const skippedItems = await db
-    .update(storePriceMatchRetryRunItems)
-    .set({
-      completedAt: sql`NOW()`,
-      error: "Retry run canceled.",
-      status: "skipped",
-      updatedAt: sql`NOW()`,
-    })
-    .where(
-      and(
-        eq(storePriceMatchRetryRunItems.runId, runId),
-        inArray(storePriceMatchRetryRunItems.status, ["pending", "processing"]),
-      ),
-    )
-    .returning({
-      id: storePriceMatchRetryRunItems.id,
-    });
+export async function cancelStorePriceMatchRetryRun(runId: number) {
+  return await db.transaction(async (tx) => {
+    const skippedItems = await tx
+      .update(storePriceMatchRetryRunItems)
+      .set({
+        completedAt: sql`NOW()`,
+        error: "Retry run canceled.",
+        status: "skipped",
+        updatedAt: sql`NOW()`,
+      })
+      .where(
+        and(
+          eq(storePriceMatchRetryRunItems.runId, runId),
+          inArray(storePriceMatchRetryRunItems.status, [
+            "pending",
+            "processing",
+          ]),
+          exists(
+            tx
+              .select({ id: storePriceMatchRetryRuns.id })
+              .from(storePriceMatchRetryRuns)
+              .where(
+                and(
+                  eq(storePriceMatchRetryRuns.id, runId),
+                  inArray(storePriceMatchRetryRuns.status, [
+                    "pending",
+                    "running",
+                  ]),
+                ),
+              ),
+          ),
+        ),
+      )
+      .returning({
+        id: storePriceMatchRetryRunItems.id,
+      });
 
-  const [run] = await db
-    .update(storePriceMatchRetryRuns)
-    .set({
-      completedAt: sql`NOW()`,
-      processedCount: sql`${storePriceMatchRetryRuns.processedCount} + ${skippedItems.length}`,
-      skippedCount: sql`${storePriceMatchRetryRuns.skippedCount} + ${skippedItems.length}`,
-      status: "canceled",
-      updatedAt: sql`NOW()`,
-    })
-    .where(eq(storePriceMatchRetryRuns.id, runId))
-    .returning();
+    const [run] = await tx
+      .update(storePriceMatchRetryRuns)
+      .set({
+        cancelRequestedAt: sql`COALESCE(${storePriceMatchRetryRuns.cancelRequestedAt}, NOW())`,
+        completedAt: sql`NOW()`,
+        processedCount: sql`${storePriceMatchRetryRuns.processedCount} + ${skippedItems.length}`,
+        skippedCount: sql`${storePriceMatchRetryRuns.skippedCount} + ${skippedItems.length}`,
+        status: "canceled",
+        updatedAt: sql`NOW()`,
+      })
+      .where(
+        and(
+          eq(storePriceMatchRetryRuns.id, runId),
+          inArray(storePriceMatchRetryRuns.status, ["pending", "running"]),
+        ),
+      )
+      .returning();
 
-  return run ?? null;
+    if (run) return run;
+
+    return (
+      (await tx.query.storePriceMatchRetryRuns.findFirst({
+        where: eq(storePriceMatchRetryRuns.id, runId),
+      })) ?? null
+    );
+  });
 }
 
 async function completeRetryRunIfDone(runId: number) {
@@ -341,10 +411,21 @@ async function completeRetryRunIfDone(runId: number) {
       status: "completed",
       updatedAt: sql`NOW()`,
     })
-    .where(eq(storePriceMatchRetryRuns.id, runId))
+    .where(
+      and(
+        eq(storePriceMatchRetryRuns.id, runId),
+        inArray(storePriceMatchRetryRuns.status, ["pending", "running"]),
+      ),
+    )
     .returning();
 
-  return run ?? null;
+  if (run) return run;
+
+  return (
+    (await db.query.storePriceMatchRetryRuns.findFirst({
+      where: eq(storePriceMatchRetryRuns.id, runId),
+    })) ?? null
+  );
 }
 
 async function processRetryRunItem({
@@ -413,7 +494,7 @@ export async function processStorePriceMatchRetryRun({
   }
 
   if (existingRun.cancelRequestedAt) {
-    return await cancelRetryRun(runId);
+    return await cancelStorePriceMatchRetryRun(runId);
   }
 
   await db
@@ -436,7 +517,7 @@ export async function processStorePriceMatchRetryRun({
     });
 
     if (!currentRun || currentRun.cancelRequestedAt) {
-      return await cancelRetryRun(runId);
+      return await cancelStorePriceMatchRetryRun(runId);
     }
 
     await processRetryRunItem({

--- a/apps/server/src/orpc/routes/prices/matchQueue/cancel-retry-run.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/cancel-retry-run.ts
@@ -1,9 +1,9 @@
-import { db } from "@peated/server/db";
-import { storePriceMatchRetryRuns } from "@peated/server/db/schema";
-import { serializeStorePriceMatchRetryRun } from "@peated/server/lib/storePriceMatchRetryRuns";
+import {
+  cancelStorePriceMatchRetryRun,
+  serializeStorePriceMatchRetryRun,
+} from "@peated/server/lib/storePriceMatchRetryRuns";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
-import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { PriceMatchRetryRunSchema } from "./retry-run-schema";
 
@@ -14,7 +14,7 @@ export default procedure
     path: "/prices/match-queue/retry-runs/{run}/cancel",
     summary: "Cancel price match retry run",
     description:
-      "Request cancellation for a background price match retry run. Requires moderator privileges",
+      "Cancel a background price match retry run. Requires moderator privileges",
     operationId: "cancelPriceMatchRetryRun",
   })
   .input(
@@ -24,32 +24,12 @@ export default procedure
   )
   .output(PriceMatchRetryRunSchema)
   .handler(async function ({ input, errors }) {
-    const [run] = await db
-      .update(storePriceMatchRetryRuns)
-      .set({
-        cancelRequestedAt: sql`COALESCE(${storePriceMatchRetryRuns.cancelRequestedAt}, NOW())`,
-        updatedAt: sql`NOW()`,
-      })
-      .where(
-        and(
-          eq(storePriceMatchRetryRuns.id, input.run),
-          inArray(storePriceMatchRetryRuns.status, ["pending", "running"]),
-        ),
-      )
-      .returning();
+    const run = await cancelStorePriceMatchRetryRun(input.run);
 
     if (!run) {
-      const existingRun = await db.query.storePriceMatchRetryRuns.findFirst({
-        where: eq(storePriceMatchRetryRuns.id, input.run),
+      throw errors.NOT_FOUND({
+        message: "Retry run not found.",
       });
-
-      if (!existingRun) {
-        throw errors.NOT_FOUND({
-          message: "Retry run not found.",
-        });
-      }
-
-      return serializeStorePriceMatchRetryRun(existingRun);
     }
 
     return serializeStorePriceMatchRetryRun(run);

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -3856,15 +3856,30 @@ describe("price match queue", () => {
     fixtures,
   }) => {
     const user = await fixtures.User({ mod: true });
+    const price = await fixtures.StorePrice({
+      name: "Cancel Retry Run",
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "errored",
+        proposalType: "no_match",
+      })
+      .returning();
     const [run] = await db
       .insert(storePriceMatchRetryRuns)
       .values({
         createdById: user.id,
-        matchedCount: 3,
-        processedCount: 1,
+        matchedCount: 1,
         status: "running",
       })
       .returning();
+    await db.insert(storePriceMatchRetryRunItems).values({
+      priceId: price.id,
+      proposalId: proposal!.id,
+      runId: run!.id,
+    });
 
     const details = await routerClient.prices.matchQueue.retryRunDetails(
       { run: run!.id },
@@ -3878,12 +3893,20 @@ describe("price match queue", () => {
       { run: run!.id },
       { context: { user } },
     );
+    const activeAfterCancel =
+      await routerClient.prices.matchQueue.activeRetryRun(undefined, {
+        context: { user },
+      });
+    const replacement = await routerClient.prices.matchQueue.retryAll(
+      { kind: "errored", query: "Cancel Retry Run" },
+      { context: { user } },
+    );
 
     expect(details).toMatchObject({
       id: run!.id,
-      matchedCount: 3,
-      pendingCount: 2,
-      progress: 33,
+      matchedCount: 1,
+      pendingCount: 1,
+      progress: 0,
       status: "running",
     });
     expect(active.run).toMatchObject({
@@ -3892,9 +3915,21 @@ describe("price match queue", () => {
     });
     expect(canceled).toMatchObject({
       cancelRequestedAt: expect.any(String),
+      completedAt: expect.any(String),
       id: run!.id,
-      status: "running",
+      pendingCount: 0,
+      processedCount: 1,
+      skippedCount: 1,
+      status: "canceled",
     });
+    expect(activeAfterCancel).toEqual({ run: null });
+    expect(replacement).toMatchObject({
+      id: expect.any(Number),
+      matchedCount: 1,
+      pendingCount: 1,
+      status: "pending",
+    });
+    expect(replacement.id).not.toBe(run!.id);
   });
 
   test("clears the processing lease if retry enqueue fails", async ({

--- a/docs/research/catalog-research-examples-2026-09.md
+++ b/docs/research/catalog-research-examples-2026-09.md
@@ -467,3 +467,36 @@ including the exact evidence page and stored facts for every new Bottle, is in
   retailer, and auction images were useful identity evidence but did not state
   reusable rights, so no image was copied. Entity `E1079` also has no image; no
   unlicensed logo or product art was added.
+
+## Store-price queue repairs — September 6, 2026
+
+This production pass resolved the eight remaining SMWS `match_existing`
+proposals and the four `correction` proposals. It repaired five Bottle categories
+from blended Scotch to blended malt, retried the four affected listings, and
+approved all twelve exact matches. The final queue counts for both
+`match_existing` and `correction` were zero. No Bottle was merged or deleted.
+
+- The saved images on the eight SMWS candidate Bottles were inspected directly.
+  Each label showed the exact cask code and marketed name from its listing,
+  including 149.27, 168.4, 95.117, 78.102, 79.17, 64.173, 36.237, and 8.58.
+  The classifier's recorded image-conflict rationales were false positives, so
+  the images were retained and the listings were matched to those exact Bottles.
+- Douglas Laing's exact producer pages for
+  [The Epicurean](https://www.douglaslaing.com/products/the-epicurean),
+  [The Founding Fathers Reserve](https://www.douglaslaing.com/products/rangers-the-founding-fathers-reserve),
+  [Timorous Beastie 10 Years Old](https://www.douglaslaing.com/en-us/products/timorous-beastie-10-years-old),
+  and
+  [Timorous Beastie x West Brewery](https://www.douglaslaing.com/products/timorous-beastie-x-west-brewery)
+  established regional-malt compositions and the stored strengths. The Founding
+  Fathers page explicitly identifies a blended malt, while The Epicurean and
+  Timorous Beastie pages describe marriages of regional malts. B45374, B45356,
+  B45381, B14154, and B47221 were therefore corrected to `blended_malt`.
+- Timorous Beastie 10-year-old has separate Small Batch #1 and #2 releases.
+  The exact [Batch 1 retailer record](https://www.thewhiskyexchange.com/p/39858/timorous-beastie-10-year-old-batch-1)
+  and [Small Batch #1 auction record](https://whiskyauctioneer.com/learn/explore-whisky/bottles/timorous-beastie-10-year-old-small-batch-1)
+  support the first identity. B47221's stored label visibly says “10” and
+  “Small Batch #2”; the queue listing used that same image, so it was assigned
+  to B47221 rather than B14154. B14154 remains the supported Small Batch #1
+  identity. Its stored image showed the standard no-age Timorous Beastie and was
+  removed after explicit deletion approval. No replacement was uploaded because
+  the exact Batch #1 sources did not state reusable image rights.


### PR DESCRIPTION
Moderator cancellation now finalizes an active store-price retry run immediately: pending or processing items are skipped, the run totals and terminal status are updated together, and the single-active-run slot is freed without waiting for another worker job.

Late worker results can no longer overwrite canceled items, increment a terminal run, or revive it as completed. This fixes stale runs whose worker chain disappeared after cancellation was requested. The branch also records the evidence and approved image removal from the related production moderation pass.
