### PR TITLE
feat(tasting-wheel): carry category colors through exploration

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -244,9 +244,11 @@ Use one warm color for links, ratings, and main actions. Do not add another
 action color or use red and green to mean bad and good.
 
 Each tasting-note category has its own color. Use these colors only to connect
-the same category across saved tags and flavor charts. Use them on complete tag
-borders, the inner edge of the tasting wheel, and filled chart slices. Do not
-use them for links, buttons, ratings, feedback, page decoration, or tag
+the same category across the tasting wheel, tasting-note vocabulary, saved
+tags, and flavor charts. Use them on category edges, complete borders around
+tasting-note tags and selectors, and filled chart slices. Keep text and action
+states on the usual ink and accent colors. Do not use category colors for
+general links or buttons, ratings, feedback, unrelated decoration, or tag
 backgrounds. If a saved note has no known category, use the usual neutral tag
 border.
 

--- a/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
+++ b/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
@@ -2,10 +2,13 @@
 
 import { foundationStyles } from "@peated/web/styles/foundations.stylex";
 
-import { Button } from "@peated/web/components";
 import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import { textLinkStyles } from "@peated/web/components/textLinkStyles.stylex";
-import { tastingCategoryFillStyles } from "@peated/web/features/tastingWheel/tastingCategoryStyles.stylex";
+import {
+  tastingCategoryBorderStyles,
+  tastingCategoryFillStyles,
+} from "@peated/web/features/tastingWheel/tastingCategoryStyles.stylex";
+import { TastingNoteButton } from "@peated/web/features/tastingWheel/tastingNoteButton.stylex";
 import { WHEEL_CATEGORIES } from "@peated/web/features/tastingWheel/tastingWheelData";
 import { useTastingWheel } from "@peated/web/features/tastingWheel/tastingWheelDetails.stylex";
 import * as stylex from "@stylexjs/stylex";
@@ -143,7 +146,7 @@ function TastingWheelGraphic() {
                   <path
                     d={ringSegment(
                       HUB_RADIUS,
-                      HUB_RADIUS + 8,
+                      HUB_RADIUS + 12,
                       startAngle + 0.6,
                       endAngle - 0.6,
                     )}
@@ -227,7 +230,10 @@ export function TastingWheelCategories() {
         <article
           id={`tasting-note-${category.key}`}
           key={category.key}
-          {...stylex.props(styles.category)}
+          {...stylex.props(
+            styles.category,
+            tastingCategoryBorderStyles[category.key],
+          )}
         >
           <SectionHeading level={3}>{category.name}</SectionHeading>
           <button
@@ -253,15 +259,14 @@ export function TastingWheelCategories() {
           </p>
           <div {...stylex.props(styles.notes)}>
             {category.notes.map((note) => (
-              <Button
+              <TastingNoteButton
+                category={category.key}
                 key={note}
-                size="sm"
-                variant="tonal"
                 aria-haspopup="dialog"
                 onClick={() => select({ category: category.key, note })}
               >
                 {note}
-              </Button>
+              </TastingNoteButton>
             ))}
           </div>
         </article>
@@ -368,9 +373,8 @@ const styles = stylex.create({
   category: {
     minWidth: 0,
     paddingTop: space.x3,
-    borderTopWidth: "1px",
+    borderTopWidth: "2px",
     borderTopStyle: "solid",
-    borderTopColor: colors.hairline,
     scrollMarginTop: space.x8,
   },
   categoryDescription: {

--- a/apps/web/src/components/slideout.stylex.tsx
+++ b/apps/web/src/components/slideout.stylex.tsx
@@ -16,7 +16,7 @@ import { IconButton } from "./button.stylex";
 export type SlideoutProps = {
   open: boolean;
   onClose: () => void;
-  title: string;
+  title: ReactNode;
   navigation?: ReactNode;
   children: ReactNode;
   footer?: ReactNode;

--- a/apps/web/src/features/tastingWheel/tastingCategoryStyles.stylex.ts
+++ b/apps/web/src/features/tastingWheel/tastingCategoryStyles.stylex.ts
@@ -22,6 +22,51 @@ const styles = stylex.create({
   sweetOutline: { boxShadow: `inset 0 0 0 1px ${colors.categorySweet}` },
   spiceOutline: { boxShadow: `inset 0 0 0 1px ${colors.categorySpice}` },
   woodOutline: { boxShadow: `inset 0 0 0 1px ${colors.categoryWood}` },
+  cerealSelectedOutline: {
+    boxShadow: `inset 0 0 0 2px ${colors.categoryCereal}`,
+  },
+  fruitSelectedOutline: {
+    boxShadow: `inset 0 0 0 2px ${colors.categoryFruit}`,
+  },
+  floralSelectedOutline: {
+    boxShadow: `inset 0 0 0 2px ${colors.categoryFloral}`,
+  },
+  smokeSelectedOutline: {
+    boxShadow: `inset 0 0 0 2px ${colors.categorySmoke}`,
+  },
+  earthySelectedOutline: {
+    boxShadow: `inset 0 0 0 2px ${colors.categoryEarthy}`,
+  },
+  sulfurSelectedOutline: {
+    boxShadow: `inset 0 0 0 2px ${colors.categorySulfur}`,
+  },
+  sweetSelectedOutline: {
+    boxShadow: `inset 0 0 0 2px ${colors.categorySweet}`,
+  },
+  spiceSelectedOutline: {
+    boxShadow: `inset 0 0 0 2px ${colors.categorySpice}`,
+  },
+  woodSelectedOutline: {
+    boxShadow: `inset 0 0 0 2px ${colors.categoryWood}`,
+  },
+  cerealBorder: { borderColor: colors.categoryCereal },
+  fruitBorder: { borderColor: colors.categoryFruit },
+  floralBorder: { borderColor: colors.categoryFloral },
+  smokeBorder: { borderColor: colors.categorySmoke },
+  earthyBorder: { borderColor: colors.categoryEarthy },
+  sulfurBorder: { borderColor: colors.categorySulfur },
+  sweetBorder: { borderColor: colors.categorySweet },
+  spiceBorder: { borderColor: colors.categorySpice },
+  woodBorder: { borderColor: colors.categoryWood },
+  cerealBackground: { backgroundColor: colors.categoryCereal },
+  fruitBackground: { backgroundColor: colors.categoryFruit },
+  floralBackground: { backgroundColor: colors.categoryFloral },
+  smokeBackground: { backgroundColor: colors.categorySmoke },
+  earthyBackground: { backgroundColor: colors.categoryEarthy },
+  sulfurBackground: { backgroundColor: colors.categorySulfur },
+  sweetBackground: { backgroundColor: colors.categorySweet },
+  spiceBackground: { backgroundColor: colors.categorySpice },
+  woodBackground: { backgroundColor: colors.categoryWood },
 });
 
 export const tastingCategoryFillStyles = {
@@ -46,4 +91,40 @@ export const tastingCategoryOutlineStyles = {
   sweet: styles.sweetOutline,
   spice: styles.spiceOutline,
   wood: styles.woodOutline,
+} satisfies Record<TagCategory, stylex.StyleXStyles>;
+
+export const tastingCategorySelectedOutlineStyles = {
+  cereal: styles.cerealSelectedOutline,
+  fruit: styles.fruitSelectedOutline,
+  floral: styles.floralSelectedOutline,
+  smoke: styles.smokeSelectedOutline,
+  earthy: styles.earthySelectedOutline,
+  sulfur: styles.sulfurSelectedOutline,
+  sweet: styles.sweetSelectedOutline,
+  spice: styles.spiceSelectedOutline,
+  wood: styles.woodSelectedOutline,
+} satisfies Record<TagCategory, stylex.StyleXStyles>;
+
+export const tastingCategoryBorderStyles = {
+  cereal: styles.cerealBorder,
+  fruit: styles.fruitBorder,
+  floral: styles.floralBorder,
+  smoke: styles.smokeBorder,
+  earthy: styles.earthyBorder,
+  sulfur: styles.sulfurBorder,
+  sweet: styles.sweetBorder,
+  spice: styles.spiceBorder,
+  wood: styles.woodBorder,
+} satisfies Record<TagCategory, stylex.StyleXStyles>;
+
+export const tastingCategoryBackgroundStyles = {
+  cereal: styles.cerealBackground,
+  fruit: styles.fruitBackground,
+  floral: styles.floralBackground,
+  smoke: styles.smokeBackground,
+  earthy: styles.earthyBackground,
+  sulfur: styles.sulfurBackground,
+  sweet: styles.sweetBackground,
+  spice: styles.spiceBackground,
+  wood: styles.woodBackground,
 } satisfies Record<TagCategory, stylex.StyleXStyles>;

--- a/apps/web/src/features/tastingWheel/tastingNoteButton.stories.tsx
+++ b/apps/web/src/features/tastingWheel/tastingNoteButton.stories.tsx
@@ -1,0 +1,41 @@
+import { TAG_CATEGORIES } from "@peated/server/constants";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { StoryCanvas, StoryRow } from "../../components/storyFixtures.stylex";
+import { TastingNoteButton } from "./tastingNoteButton.stylex";
+import { WHEEL_CATEGORIES } from "./tastingWheelData";
+
+const meta = {
+  title: "Components/Reviews & Tastings/Tasting Note Button",
+  component: TastingNoteButton,
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="wide">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+  args: { category: "smoke", children: "peat" },
+} satisfies Meta<typeof TastingNoteButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Categories: Story = {
+  render: () => (
+    <StoryRow>
+      {TAG_CATEGORIES.map((category) => (
+        <TastingNoteButton category={category} key={category}>
+          {
+            WHEEL_CATEGORIES.find((item) => item.key === category)!
+              .wheelNotes[0]
+          }
+        </TastingNoteButton>
+      ))}
+    </StoryRow>
+  ),
+};
+
+export const Selected: Story = {
+  args: { selected: true },
+};

--- a/apps/web/src/features/tastingWheel/tastingNoteButton.stylex.tsx
+++ b/apps/web/src/features/tastingWheel/tastingNoteButton.stylex.tsx
@@ -1,0 +1,100 @@
+import type { TagCategory } from "@peated/server/types";
+import * as stylex from "@stylexjs/stylex";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, controlMetrics } from "../../styles/tokens.stylex";
+import {
+  tastingCategoryOutlineStyles,
+  tastingCategorySelectedOutlineStyles,
+} from "./tastingCategoryStyles.stylex";
+
+type TastingNoteButtonProps = Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "children" | "className" | "style"
+> & {
+  category: TagCategory;
+  children: ReactNode;
+  selected?: boolean;
+};
+
+/** Selects a tasting note while keeping its category visible as a colored border. */
+export function TastingNoteButton({
+  category,
+  children,
+  selected,
+  type = "button",
+  ...props
+}: TastingNoteButtonProps) {
+  return (
+    <button
+      {...props}
+      aria-pressed={selected}
+      type={type}
+      {...stylex.props(
+        foundationStyles.interactiveSmall,
+        styles.button,
+        tastingCategoryOutlineStyles[category],
+        selected && styles.selected,
+        selected && tastingCategorySelectedOutlineStyles[category],
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+const REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)";
+
+const styles = stylex.create({
+  button: {
+    boxSizing: "border-box",
+    position: "relative",
+    display: "inline-flex",
+    height: controlMetrics.controlHeightSmall,
+    flexShrink: 0,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 0,
+    borderRadius: controlMetrics.radiusSmall,
+    paddingRight: "12px",
+    paddingLeft: "12px",
+    backgroundColor: {
+      default: "transparent",
+      ":hover": colors.surface,
+      ":active": colors.inset,
+      ":focus-visible": colors.surface,
+    },
+    color: colors.ink,
+    cursor: {
+      default: "pointer",
+      ":disabled": "not-allowed",
+    },
+    opacity: {
+      default: 1,
+      ":hover": 0.86,
+      ":active": 0.75,
+      ":focus-visible": 0.86,
+      ":disabled": 0.45,
+    },
+    outline: "none",
+    transitionProperty: "background-color, color, opacity",
+    transitionDuration: { default: "120ms", [REDUCED_MOTION]: "0ms" },
+    whiteSpace: "nowrap",
+    "::after": {
+      position: "absolute",
+      inset: "-2px",
+      content: '""',
+    },
+  },
+  selected: {
+    backgroundColor: {
+      default: colors.surface,
+      ":hover": colors.inset,
+      ":active": colors.inset,
+      ":focus-visible": colors.surface,
+    },
+    color: colors.ink,
+    fontWeight: 700,
+  },
+});

--- a/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
+++ b/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
@@ -11,6 +11,8 @@ import { ArrowLeft } from "lucide-react";
 import { createContext, useContext, useState, type ReactNode } from "react";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
+import { tastingCategoryBackgroundStyles } from "./tastingCategoryStyles.stylex";
+import { TastingNoteButton } from "./tastingNoteButton.stylex";
 import { CATEGORY_DEFINITIONS, NOTE_DESCRIPTIONS } from "./tastingWheelData";
 
 type Selection = {
@@ -44,9 +46,22 @@ export function TastingWheelProvider({ children }: { children: ReactNode }) {
         open={open}
         onClose={() => setOpen(false)}
         title={
-          selection?.note
-            ? titleCase(selection.note)
-            : (category?.name ?? "Tasting notes")
+          selection ? (
+            <span {...stylex.props(styles.panelTitle)}>
+              <span
+                aria-hidden
+                {...stylex.props(
+                  styles.categoryMarker,
+                  tastingCategoryBackgroundStyles[selection.category],
+                )}
+              />
+              {selection.note
+                ? titleCase(selection.note)
+                : (category?.name ?? "Tasting notes")}
+            </span>
+          ) : (
+            "Tasting notes"
+          )
         }
         navigation={
           selection?.note ? (
@@ -106,15 +121,14 @@ function TastingWheelDetails({
         </SectionHeading>
         <div {...stylex.props(styles.notes)}>
           {notes.map((note) => (
-            <Button
+            <TastingNoteButton
+              category={selection.category}
               key={note}
-              size="sm"
-              variant={selection.note === note ? "accent" : "tonal"}
-              aria-pressed={selection.note === note}
+              selected={selection.note === note}
               onClick={() => select({ category: selection.category, note })}
             >
               {note}
-            </Button>
+            </TastingNoteButton>
           ))}
         </div>
       </section>
@@ -158,6 +172,18 @@ function titleCase(value: string) {
 }
 
 const styles = stylex.create({
+  panelTitle: {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: space.x3,
+  },
+  categoryMarker: {
+    display: "inline-block",
+    width: "20px",
+    height: "3px",
+    flexShrink: 0,
+    borderRadius: "1px",
+  },
   details: { display: "flex", flexDirection: "column", gap: space.x6 },
   description: {
     margin: 0,


### PR DESCRIPTION
The tasting-wheel reference page now carries each category color from the wheel into category dividers, tasting-note selectors, and the detail slideout. Selected notes use a stronger category outline with a neutral fill, so they remain visibly selected without competing with Peated's warm action color.

This adds a shared tasting-note button and lets slideout titles compose a category marker without making the generic slideout category-aware. The visual rule is captured in `DESIGN.md`, with Storybook states for every category and the selected treatment; the page and slideout were reviewed in light and dark modes at desktop and mobile widths.
