### PR TITLE
feat(scraper): prepare Edradour saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -107,6 +107,15 @@ function prepareDramface(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareEdradour(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "edradour", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareCompassBox(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "compassbox", ...input },
@@ -180,6 +189,7 @@ function codeOwnedSource(
     | "cadenheads"
     | "compassbox"
     | "dramface"
+    | "edradour"
     | "gordonmacphail"
     | "kilchoman"
     | "ncnean"
@@ -246,6 +256,11 @@ const dramfaceCanonicalUrl =
 const dramfaceRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("dramface")!],
   sources: [codeOwnedSource("dramface")],
+});
+
+const edradourRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("edradour")!],
+  sources: [codeOwnedSource("edradour")],
 });
 
 const compassBoxRegistry = createScraperRegistry({
@@ -737,6 +752,25 @@ async function setupCompassBoxMigration() {
     })
     .returning();
   await syncScraperDefinitions(compassBoxRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
+}
+
+async function setupEdradourMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "edradour",
+      name: "Edradour",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(edradourRegistry);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "succeeded",
@@ -1488,6 +1522,102 @@ describe("POST /admin/scrape-sources/prepare", () => {
         "Check the URL and review records for WhiskyNotes article",
       ),
     });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares Edradour without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupEdradourMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Ballechin 10-year-old",
+      price: 4876,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.edradour.com/ballechin-10-year-old",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Edradour Cask Strength 21-year-old Oloroso Sherry",
+      price: 37500,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.edradour.com/Cask-Strength-21-y.o.-Oloroso-Sherry",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareEdradour()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareEdradour({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(edradourRegistry);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl: "https://www.edradour.com/shop/",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+    await expect(prepareEdradour({ apply: true })).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Edradour is already prepared for saved scraping rules.",
+    });
+  });
+
+  test("refuses an unexpected Edradour price without changing records", async ({
+    fixtures,
+  }) => {
+    const site = await setupEdradourMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Edradour Cask Strength 21-year-old Oloroso Sherry",
+      currency: "gbp",
+      volume: 700,
+      url: "https://example.com/Cask-Strength-21-y.o.-Oloroso-Sherry",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareEdradour({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check Edradour price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
     expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -6,6 +6,7 @@ import { prepareBruichladdichSource } from "@peated/server/scraper/configured/pr
 import { prepareCadenheadsSource } from "@peated/server/scraper/configured/prepareCadenheads";
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
 import { prepareDramfaceSource } from "@peated/server/scraper/configured/prepareDramface";
+import { prepareEdradourSource } from "@peated/server/scraper/configured/prepareEdradour";
 import { prepareGordonMacphailSource } from "@peated/server/scraper/configured/prepareGordonMacphail";
 import { prepareKilchomanSource } from "@peated/server/scraper/configured/prepareKilchoman";
 import { prepareNcneanSource } from "@peated/server/scraper/configured/prepareNcnean";
@@ -39,7 +40,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, dramface, gordonmacphail, kilchoman, ncnean, northstarspirits, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
+          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, dramface, edradour, gordonmacphail, kilchoman, ncnean, northstarspirits, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -75,6 +76,7 @@ export default procedure
       cadenheads: prepareCadenheadsSource,
       compassbox: prepareCompassBoxSource,
       dramface: prepareDramfaceSource,
+      edradour: prepareEdradourSource,
       gordonmacphail: prepareGordonMacphailSource,
       kilchoman: prepareKilchomanSource,
       ncnean: prepareNcneanSource,

--- a/apps/server/src/scraper/configured/prepareEdradour.ts
+++ b/apps/server/src/scraper/configured/prepareEdradour.ts
@@ -1,0 +1,24 @@
+import { ALLOWED_VOLUMES } from "@peated/server/constants";
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks Edradour by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareEdradourSource(input: PreparePriceSourceInput) {
+  return preparePriceSource(input, {
+    siteKey: "edradour",
+    siteName: "Edradour",
+    targetKey: "edradour",
+    origin: "https://www.edradour.com",
+    listUrl: "https://www.edradour.com/shop/",
+    isExpectedPrice: (price) =>
+      /^https:\/\/www\.edradour\.com\/[A-Za-z0-9][A-Za-z0-9._-]*$/.test(
+        price.url,
+      ) &&
+      price.externalProductId === null &&
+      /^(?:Edradour|Ballechin)\b/.test(price.name) &&
+      price.currency === "gbp" &&
+      ALLOWED_VOLUMES.includes(price.volume),
+  });
+}

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -268,6 +268,28 @@ Activate only exact output, trigger one manual collection, and confirm that it
 updates the same price IDs and Bottle matches before restoring the schedule.
 Check the run and Sentry.
 
+## Edradour
+
+Use the preparation endpoint with `{"site": "edradour"}`. The check-only
+request examines every saved price without changing it. It stops if a price
+has a product ID or does not use an Edradour product URL, an `Edradour` or
+`Ballechin` name, GBP, or a supported bottle size. Applying moves the request
+limits to a paused price source for `https://www.edradour.com/shop/`. It does
+not change price rows or history.
+
+Before applying, stop the `edradour` schedule and wait for active collection to
+finish. Save the existing price IDs, URLs, Bottle links, hidden states,
+histories, request limits, and run history. Run the version 8 rules through the
+full local preview. The shop-page rules must keep only whisky that can be
+bought. The product-page rules must read the displayed name, GBP price, bottle
+size, product URL, and image. Add the `Edradour` prefix when an Edradour whisky
+name does not already start with `Edradour` or `Ballechin`.
+
+After applying, save and preview the reviewed rules. Activate only exact
+output, trigger one manual collection, and confirm that it updates the same
+price IDs and Bottle links. Check the run and Sentry before restoring the
+weekly schedule.
+
 ## Kilchoman
 
 Use the preparation endpoint with `{"site": "kilchoman"}`. The check-only
@@ -352,10 +374,11 @@ handles reviews added after the switch. Do not delete source or run history.
 ## Other sources
 
 The preparation API is shared. It currently supports Bourbon Culture,
-Bruichladdich, Cadenhead's, Compass Box, Gordon & MacPhail, Kilchoman, Nc'nean,
-North Star, The Whiskey Reviewer, WhiskyNotes, Whisky Saga, The Whisky Study,
-and Words of Whisky. Other sites are rejected without changing records. Add
-each site's conversion behind this route as its existing records are reviewed.
+Bruichladdich, Cadenhead's, Compass Box, Dramface, Edradour, Gordon & MacPhail,
+Kilchoman, Nc'nean, North Star, The Whiskey Reviewer, WhiskyNotes, Whisky Saga,
+The Whisky Study, and Words of Whisky. Other sites are rejected without
+changing records. Add each site's conversion behind this route as its existing
+records are reviewed.
 
 Prepare each source using its own rules for recognizing existing records.
 Articles with several reviews need a verified match for each review. Store


### PR DESCRIPTION
Edradour can now move from its code scraper to saved rules without replacing price rows, price history, or Bottle matches. The preparation endpoint verifies the existing Edradour URLs, names, currency, sizes, and empty product IDs, transfers the request settings, and creates the saved-rule source with collection paused.

The migration guide records the production handoff and rollback checks. A full no-write preview against the current shop parsed all eight products supported by the code scraper with no request errors; it explicitly leaves out the ninth product because Edradour does not publish a bottle size for it.
