### PR TITLE
fix(classifier): leave room for reference decisions

### DIFF
--- a/packages/bottle-classifier/src/classifierOutputBoundary.test.ts
+++ b/packages/bottle-classifier/src/classifierOutputBoundary.test.ts
@@ -78,14 +78,42 @@ async function runWithFakeModel(
   agent: Agent<unknown, JsonSchemaDefinition>,
   input: string,
   finalOutput: JsonValue,
-): Promise<{ outputType: JsonSchemaDefinition; result: unknown }> {
+  {
+    researchTurns = 0,
+    runOptions,
+  }: {
+    researchTurns?: number;
+    runOptions?: Awaited<
+      ReturnType<typeof prepareBottleClassifierAgentRun>
+    >["runOptions"];
+  } = {},
+): Promise<{
+  outputType: JsonSchemaDefinition;
+  result: unknown;
+  turn: number;
+}> {
   let outputType: JsonSchemaDefinition | undefined;
+  let turn = 0;
   const model: Model = {
     async getResponse(request) {
+      turn += 1;
       if (request.outputType === "text") {
         throw new Error("Expected a JSON schema output type.");
       }
       outputType = request.outputType;
+      if (turn <= researchTurns) {
+        return {
+          usage: new Usage(),
+          output: [
+            {
+              type: "function_call",
+              callId: `call-${turn}`,
+              name: "search_bottles",
+              arguments: JSON.stringify({ query: `Example query ${turn}` }),
+            },
+          ],
+        };
+      }
       return {
         usage: new Usage(),
         output: [
@@ -109,12 +137,13 @@ async function runWithFakeModel(
   const result = await new Runner({ tracingDisabled: true }).run(
     agent.clone({ model }),
     input,
+    runOptions,
   );
 
   if (!outputType) {
     throw new Error("Fake model did not receive an output type");
   }
-  return { outputType, result };
+  return { outputType, result, turn };
 }
 
 describe("classifier output boundary", () => {
@@ -290,6 +319,37 @@ describe("classifier output boundary", () => {
         matchedBottleId: null,
         proposedBottle: null,
       },
+    });
+  });
+
+  test("returns a decision after eight research turns", async () => {
+    const prepared = await prepareBottleClassifierAgentRun(classifierOptions, {
+      reference: { name: "Example Single Malt" },
+      extractedIdentity: null,
+      initialCandidates: [],
+    });
+
+    const { result, turn } = await runWithFakeModel(
+      prepared.agent,
+      prepared.input,
+      {
+        action: "no_match",
+        rationale: "No safe local match.",
+        candidateBottleIds: [],
+        identityScope: "product",
+        referenceScope: "none",
+        observation: null,
+        confidenceBasis: null,
+        matchedBottleId: null,
+        proposedBottle: null,
+      },
+      { researchTurns: 8, runOptions: prepared.runOptions },
+    );
+
+    expect(turn).toBe(9);
+    expect(prepared.runOptions.maxTurns).toBe(turn);
+    expect(prepared.getAgentResult(result).decision).toMatchObject({
+      action: "no_match",
     });
   });
 

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -111,9 +111,11 @@ export type {
   BottleClassifierToolEvent,
 } from "./runtime/bottleCheckRuntime";
 
-const CLASSIFIER_MAX_TURNS = 8;
-// Parallel tool calls are disabled, and the agent needs one final-output turn.
-const CLASSIFIER_MAX_PROPOSED_OPERATIONS = CLASSIFIER_MAX_TURNS - 1;
+// A reference run can use eight turns for research and one to return its decision.
+const REFERENCE_CLASSIFIER_MAX_TURNS = 9;
+const AUDIT_CLASSIFIER_MAX_TURNS = 8;
+// Tool calls run one at a time, so an audit keeps its last turn for the result.
+const CLASSIFIER_MAX_PROPOSED_OPERATIONS = AUDIT_CLASSIFIER_MAX_TURNS - 1;
 const MAX_CANDIDATE_ENTITY_SEARCH_REQUESTS = 12;
 
 function buildReferencePageFocus(referenceName: string): string {
@@ -724,7 +726,7 @@ export async function prepareBottleClassifierAgentRun(
           : `${reference.currentBottleId}`,
     },
     runOptions: {
-      maxTurns: CLASSIFIER_MAX_TURNS,
+      maxTurns: REFERENCE_CLASSIFIER_MAX_TURNS,
       stream: false,
     },
     webSearchBudget,
@@ -880,7 +882,7 @@ export function prepareBottleAuditAgentRun(
     }),
     conversationId,
     runOptions: {
-      maxTurns: CLASSIFIER_MAX_TURNS,
+      maxTurns: AUDIT_CLASSIFIER_MAX_TURNS,
       stream: false,
     },
     getArtifacts,


### PR DESCRIPTION
Reference matching can now use eight sequential research turns and a ninth turn to return its decision, preventing successful research from ending with a max-turn error. Bottle audits keep their existing eight-turn limit.

The regression test runs the real agent loop through eight synthetic searches and confirms that the ninth turn returns a valid decision.

Fixes PEATED-4BK
