### PR TITLE
docs(catalog): record Laphroaig audit

### DIFF
--- a/docs/research/catalog-research-examples-2026-09.md
+++ b/docs/research/catalog-research-examples-2026-09.md
@@ -554,3 +554,109 @@ approved all twelve exact matches. The final queue counts for both
   identity. Its stored image showed the standard no-age Timorous Beastie and was
   removed after explicit deletion approval. No replacement was uploaded because
   the exact Batch #1 sources did not state reusable image rights.
+
+## Laphroaig — September 6, 2026
+
+This review expanded from the current range and annual families into the named
+official back catalog, private selections, and documented distillery handfills.
+The completed September 6 production snapshot contains 360 Laphroaig Brand
+records. Of those, 342 have the official relationship (`brand:1129`,
+`distillers:[1129]`, and no separate bottler); 192 are exact single-cask
+releases, including 49 Highgrove releases, and 86 are verified official
+handfills. Production has an exact image on 40 official records, including four
+with verified reusable terms. Twelve proven duplicate records were merged after
+separate approval. Four sparse legacy records remain unresolved because they do
+not identify one exact marketed release.
+
+- The producer's [current sitemap](https://www.laphroaig.com/html-sitemap) and
+  exact product pages established the current core, travel-retail, prestige,
+  Elements, Strong Characters, Archive Collection, Wall Collection, and Friends
+  releases. Peated now holds Elements 1.0–3.0, both Strong Characters chapters,
+  both Archive and Wall releases, and all five Ian Hunter Story books.
+- The official [Càirdeas history](https://www.laphroaig.com/en-gb/whisky-stories/cairdeas-expressions),
+  [2026 release page](https://www.laphroaig.com/whiskies/cairdeas-2026), and
+  [Whisky Auctioneer guide](https://whiskyauctioneer.com/learn/explore-whisky/series/laphroaig-cairdeas)
+  established the complete 2008–2026 annual sequence. The separate 2017
+  Càirdeas 15-year-old is also present. Numbered 10-year-old Cask Strength
+  Batches 001–017 are present; Batch 18 had not been released on the review date.
+- Exact producer, collector, and auction records established the supported
+  25-year-old releases from 2007 through 2023, including US and Asia editions,
+  and the 27-, 28-, 30-, 31-, 33-, 34-, 35-, 36-, 38-, 39-, and 40-year-old
+  prestige releases. Unsupported year assignments were left unknown.
+- The [Laphroaig Collector archive](https://www.laphroaigcollector.com/) was
+  checked across its 10-year-old, 15-year-old, and other official-release
+  indexes. Historic official strengths now represented include 10-year-old at
+  40%, 43%, 45%, and 45.7%; 14-year-old at 45.7%; and 15-year-old at 40%, 43%,
+  and 45%. The rare Non Peaty Old Liqueur Scotch Whisky is present without an
+  invented year because reputable sources disagree between the 1930s and 1940s.
+- Exact records were added for the 1976 and 1977 vintages; Royal Warrant and ISO
+  14001 10-year-old labels; Iain Henderson retirement releases; Friends and
+  Fèis Ìle releases before Càirdeas; the 190th anniversary; World Duty Free,
+  Nordic, Viking Line, Heathrow, US travel-retail, and Buy Paris releases; and
+  the Bessie Williamson, Erskine, Macmillan, and Diamond Jubilee bottlings.
+- The Highgrove archive was inventoried as its own Series (S0683). Peated now
+  holds 49 exact releases, using stored cask numbers, vintages, ages, strengths,
+  bottling years, and outturns only where the source supplied them.
+- Existing official Single Cask Selection records were repaired with exact
+  evidence: Cask Collectors Editions 1 and 2, PX I Love You, the 2014 privately
+  selected PX cask 807519, Sip Whiskey x Wooden Cork cask 770, Fortunato's
+  Folly, and Islay Ember. The backfill also added the publicly documented
+  commissioned casks, Warehouse #1 variants, Dunnage Warehouse releases, and
+  full-size visitor handfills whose exact cask, vintage, strength, and bottling
+  facts could be established. One-hundred-millilitre tour samples and records
+  explicitly labelled as cask or duty-paid samples were excluded.
+- Exact back-catalog releases added late in the audit include the 59.2% UK
+  version of Cask Strength Batch 008, the 15-year-old bottled for the Allied
+  Domecq board visit in 2000, the 7-year-old Dr Jekyll's PX single cask, and all
+  six Diego Sandrin private wine-cask finishes. The existing 59.9% Batch 008 is
+  now identified as the separate US release.
+- The [Wikimedia Commons bottle category](https://commons.wikimedia.org/wiki/Category:Laphroaig_bottles)
+  supplied four exact reusable images, stored with their canonical source page
+  and `CC BY-SA 3.0` license: Triple Wood (B0961), Quarter Cask (B0997), the
+  original 15-year-old (B38540), and the 40% 10-year-old (B54469). Production
+  currently has exact-release images on 40 of the 342 official records; only
+  those four have verified reusable terms. Copyrighted producer, retailer, and
+  auction photos were used as evidence but were not copied. Targeted Openverse
+  searches for Càirdeas, 18-year-old, 25-year-old, PX Cask, Lore, Triple Wood,
+  Cask Strength, and 15-year-old found no additional exact, commercially
+  reusable image beyond the already stored Wikimedia files.
+- Exclusions were deliberate: the Unforgettable Edition and 200th-anniversary
+  gift packages did not change the whisky; the 5-year-old Whisky-Botschafter
+  relabel and the HMS Vanguard and 22nd SAS labels did not establish distinct
+  whisky; a supposed 1903 “Hollow of Proig” release was a fabricated lead; the
+  reported cask 7307 release was independently bottled by Malts of Scotland;
+  and Friendship Cask #1 was still an upcoming ballot, not a marketed release,
+  on the review date.
+- Four legacy reference names for Cask Collectors Editions 1 and 2 were moved
+  from the generic Single Cask Selection record to B45034 and B45033. The
+  generic 25-year-old Cask Strength record B1493 was also repaired to use
+  Laphroaig as distiller with no independent bottler. A wrong Elements 2.0
+  reference was moved from B44286 to B43018. The generic “Laphroaig Elements”
+  reference is ambiguous and was left unresolved. Two non-canonical generic
+  10-year-old Cask Strength references were moved to the retained general
+  expression B44005.
+- Approved exact merges retired B45144 into B44286 (Elements 1.0); B45172 into
+  B45034 and B45198 into B45033 (Cask Collectors Editions); B3832 into B54460
+  (QA Cask); B3833 into B0997 (Quarter Cask); B3834 into B0960 (Select); B54710
+  into B45035 (Fortunato's Folly); B54711 into B45199 (cask 770); B54712 into
+  B11860 (cask 807519); B54713 into B54059 (Islay Ember); B3822 into B0001
+  (10-year-old anniversary package); and B54368 into B54370 (the US and UK
+  allocations of the same nine-cask 21-year-old vatting). Exact label and
+  auction evidence confirmed the [Quarter Cask anniversary package](https://whiskyauction.com/item/3164105),
+  [10-year-old anniversary package](https://whisky.auction/auctions/lot/216577/laphroaig-10-year-old),
+  [cask 770](https://woodencork.com/products/laphroaig-single-cask-selection-by-sip-whiskey-x-wooden-cork-1),
+  [cask 0896](https://www.whiskybase.com/whiskies/whisky/229460/laphroaig-2013),
+  [cask 802279](https://www.whiskybase.com/whiskies/whisky/286167/laphroaig-2014),
+  and the 21-year-old release's [1,427 US and 750 UK allocation](https://lovescotch.com/products/laphroaig-21-year-old-cask-strength-islay-single-malt-whisky).
+  B54370 now records the complete 2,177-bottle outturn. Every retired ID was
+  fetched after the merge and resolved to its intended survivor; survivor
+  facts, images, tasting totals, aliases, and references were also rechecked.
+- Four sparse legacy records were preserved as unresolved rather than guessed.
+  B18782 is a generic 10-year-old Cask Strength record whose canonical reference
+  and exact-price consumer prevent a safe independent reference correction;
+  B19113 lacks the strength, year, stripe, barcode, activity, or listing evidence
+  needed to assign it to one Original Cask Strength release. B3569 and B1492
+  name only 1998 and 2005 handfills, respectively, but each vintage has several
+  exact casks in Peated. None of those four records was merged or given invented
+  facts. Ambiguous generic 25-year-old and Single Cask Selection records were
+  likewise preserved.

--- a/docs/research/catalog-research-sources-2026-09.md
+++ b/docs/research/catalog-research-sources-2026-09.md
@@ -84,6 +84,9 @@ automatically. See the
 - Specialist-catalog bottler abbreviations such as Whiskybase's `Gs` are source
   notation, not marketed Bottle names. Keep them only as import references, and
   check for collisions before treating the complete reference as exact.
+- Collector indexes can contain fabricated or misidentified lead entries. Verify
+  the exact label against an independent auction, producer, or retailer source
+  before creating a Bottle; a plausible old date and name are not evidence.
 - An exact image may still lack permission for Peated to store it.
 - A direct image URL does not record its source or license.
 


### PR DESCRIPTION
Documents the completed Laphroaig production catalog audit, including scope and counts, exact evidence sources, approved duplicate merges, reference repairs, reusable-image coverage, deliberate exclusions, and four unresolved legacy records. This gives future catalog work a durable record of what was verified and what was deliberately left unknown.

Also records a reusable caution that collector indexes are leads until exact labels are corroborated by an independent producer, auction, or retailer source.
