### PR TITLE
feat(admin): clarify bottle resolution overview

### DIFF
--- a/apps/server/src/orpc/routes/admin/scraper-activity.test.ts
+++ b/apps/server/src/orpc/routes/admin/scraper-activity.test.ts
@@ -5,7 +5,7 @@ import {
   scrapeSourceRuns,
   scrapeSources,
 } from "@peated/server/db/schema";
-import { getPeatedSystemActor, getUserActor } from "@peated/server/lib/actors";
+import { getPeatedSystemActor } from "@peated/server/lib/actors";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 
@@ -16,7 +16,7 @@ function utcStartOfToday() {
 }
 
 describe("GET /admin/scrapers/activity", () => {
-  test("reports collection activity and leaves older counts untracked", async ({
+  test("reports source activity and Bottle resolution for the last 30 days", async ({
     fixtures,
   }) => {
     const admin = await fixtures.User({ admin: true });
@@ -30,10 +30,11 @@ describe("GET /admin/scrapers/activity", () => {
     });
     const bottle = await fixtures.Bottle();
     const systemActor = await getPeatedSystemActor();
-    const userActor = await getUserActor(admin);
     const today = utcStartOfToday();
     const startedAt = new Date(today.getTime() + 60 * 60_000);
     const completedAt = new Date(today.getTime() + 2 * 60 * 60_000);
+    const olderThanWindow = new Date(today);
+    olderThanWindow.setUTCDate(olderThanWindow.getUTCDate() - 30);
 
     await db.insert(externalSiteRuns).values([
       {
@@ -141,12 +142,45 @@ describe("GET /admin/scrapers/activity", () => {
       revisionId: null,
       purpose: "suggest",
     });
+
+    const createdReview = await fixtures.ExternalReview({
+      externalSiteId: reviewSite.id,
+      bottleId: bottle.id,
+      createdAt: startedAt,
+    });
+    const matchedPrice = await fixtures.StorePrice({
+      externalSiteId: priceSite.id,
+      bottleId: bottle.id,
+      createdAt: startedAt,
+    });
+    await fixtures.ExternalReview({
+      externalSiteId: reviewSite.id,
+      bottleId: bottle.id,
+      createdAt: startedAt,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: priceSite.id,
+      bottleId: null,
+      createdAt: startedAt,
+    });
+    await fixtures.ExternalReview({
+      externalSiteId: reviewSite.id,
+      bottleId: null,
+      hidden: true,
+      createdAt: startedAt,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: priceSite.id,
+      bottleId: null,
+      createdAt: olderThanWindow,
+    });
+
     await db.insert(incomingBottleDecisionLogs).values([
       {
         sourceKind: "review",
-        sourceId: 900_001,
+        sourceId: createdReview.id,
         externalSiteId: reviewSite.id,
-        name: "New bottle from a review",
+        name: createdReview.name,
         decision: "create_bottle",
         actorId: systemActor.id,
         bottleId: bottle.id,
@@ -155,33 +189,12 @@ describe("GET /admin/scrapers/activity", () => {
       },
       {
         sourceKind: "store_price",
-        sourceId: 900_002,
+        sourceId: matchedPrice.id,
         externalSiteId: priceSite.id,
-        name: "Existing bottle from a price",
+        name: matchedPrice.name,
         decision: "match_existing",
         actorId: systemActor.id,
         bottleId: bottle.id,
-        createdAt: startedAt,
-      },
-      {
-        sourceKind: "review",
-        sourceId: 900_003,
-        externalSiteId: reviewSite.id,
-        name: "Bottle matched by an administrator",
-        decision: "match_existing",
-        actorId: userActor.id,
-        bottleId: bottle.id,
-        createdAt: startedAt,
-      },
-      {
-        sourceKind: "store_price",
-        sourceId: 900_004,
-        externalSiteId: priceSite.id,
-        name: "Bottle match approved by an administrator",
-        decision: "match_existing",
-        actorId: systemActor.id,
-        bottleId: bottle.id,
-        metadata: { initiatedByUserId: admin.id },
         createdAt: startedAt,
       },
     ]);
@@ -202,12 +215,17 @@ describe("GET /admin/scrapers/activity", () => {
       ...result.totals,
       reviews: 8,
       prices: 5,
-      bottles: 4,
+      catalogListings: 2,
     });
     expect(result.saved).toEqual({
       reviews: { total: 8, new: 3, existing: 5 },
       prices: { total: 5, new: 2, existing: 3 },
-      bottles: { total: 4, new: 2, existing: 2 },
+      catalogListings: { total: 2, new: 1, existing: 1 },
+    });
+    expect(result.bottleResolution).toEqual({
+      unknown: 1,
+      created: 1,
+      matched: 2,
     });
     expect(result.recentFailures).toEqual([
       {

--- a/apps/server/src/orpc/routes/admin/scraper-activity.ts
+++ b/apps/server/src/orpc/routes/admin/scraper-activity.ts
@@ -1,12 +1,12 @@
 import { db } from "@peated/server/db";
 import {
-  actors,
+  externalReviews,
   externalSiteRuns,
   externalSites,
   incomingBottleDecisionLogs,
   scrapeSourceRuns,
+  storePrices,
 } from "@peated/server/db/schema";
-import { PEATED_SYSTEM_ACTOR_KEY } from "@peated/server/lib/actors";
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import type {
@@ -21,8 +21,14 @@ const DAYS = 30;
 
 type HealthCounts = z.infer<typeof AdminScraperHealthCountsSchema>;
 type SavedCounts = z.infer<typeof AdminScraperSavedCountsSchema>;
-type SavedKind = "reviews" | "prices" | "bottles";
+type SavedKind = "reviews" | "prices" | "catalogListings";
 type DayCounts = HealthCounts & Record<SavedKind, number>;
+
+type BottleResolutionCounts = {
+  unknown: number;
+  created: number;
+  matched: number;
+};
 
 function emptyHealthCounts(): HealthCounts {
   return {
@@ -73,7 +79,7 @@ function savedKindForRun(
     case "price":
       return "prices";
     case "bottle":
-      return "bottles";
+      return "catalogListings";
     case "catalog":
     case null:
       return null;
@@ -87,7 +93,7 @@ export default procedure
     path: "/admin/scrapers/activity",
     summary: "Get scraper activity",
     description:
-      "Get daily scraper requests, runs, reviews, prices, bottles, and recent failures for the admin homepage.",
+      "Get daily scraper requests, saved source records, Bottle resolution, and recent failures for the admin homepage.",
     operationId: "getScraperActivity",
   })
   .output(AdminScraperActivitySchema)
@@ -97,40 +103,67 @@ export default procedure
     const firstDay = new Date(today);
     firstDay.setUTCDate(firstDay.getUTCDate() - (DAYS - 1));
 
-    const [rows, bottleDecisions] = await Promise.all([
-      db
-        .select({
-          run: externalSiteRuns,
-          site: externalSites,
-          sourcePurpose: scrapeSourceRuns.purpose,
-        })
-        .from(externalSiteRuns)
-        .innerJoin(
-          externalSites,
-          eq(externalSites.id, externalSiteRuns.externalSiteId),
-        )
-        .leftJoin(
-          scrapeSourceRuns,
-          eq(scrapeSourceRuns.externalSiteRunId, externalSiteRuns.id),
-        )
-        .where(gte(externalSiteRuns.createdAt, firstDay))
-        .orderBy(desc(externalSiteRuns.createdAt)),
-      db
-        .select({
-          createdAt: incomingBottleDecisionLogs.createdAt,
-          createdBottle: incomingBottleDecisionLogs.createdBottle,
-        })
-        .from(incomingBottleDecisionLogs)
-        .innerJoin(actors, eq(actors.id, incomingBottleDecisionLogs.actorId))
-        .where(
-          and(
-            gte(incomingBottleDecisionLogs.createdAt, firstDay),
-            eq(actors.type, "system"),
-            eq(actors.key, PEATED_SYSTEM_ACTOR_KEY),
-            sql`NOT (${incomingBottleDecisionLogs.metadata} ? 'initiatedByUserId')`,
+    const [rows, reviewResolutionRows, priceResolutionRows] = await Promise.all(
+      [
+        db
+          .select({
+            run: externalSiteRuns,
+            site: externalSites,
+            sourcePurpose: scrapeSourceRuns.purpose,
+          })
+          .from(externalSiteRuns)
+          .innerJoin(
+            externalSites,
+            eq(externalSites.id, externalSiteRuns.externalSiteId),
+          )
+          .leftJoin(
+            scrapeSourceRuns,
+            eq(scrapeSourceRuns.externalSiteRunId, externalSiteRuns.id),
+          )
+          .where(gte(externalSiteRuns.createdAt, firstDay))
+          .orderBy(desc(externalSiteRuns.createdAt)),
+        db
+          .select({
+            unknown: sql<number>`count(*) filter (where ${externalReviews.bottleId} is null)::int`,
+            created: sql<number>`count(*) filter (where ${externalReviews.bottleId} is not null and coalesce(${incomingBottleDecisionLogs.createdBottle}, false))::int`,
+            matched: sql<number>`count(*) filter (where ${externalReviews.bottleId} is not null and not coalesce(${incomingBottleDecisionLogs.createdBottle}, false))::int`,
+          })
+          .from(externalReviews)
+          .leftJoin(
+            incomingBottleDecisionLogs,
+            and(
+              eq(incomingBottleDecisionLogs.sourceKind, "review"),
+              eq(incomingBottleDecisionLogs.sourceId, externalReviews.id),
+            ),
+          )
+          .where(
+            and(
+              gte(externalReviews.createdAt, firstDay),
+              eq(externalReviews.hidden, false),
+            ),
           ),
-        ),
-    ]);
+        db
+          .select({
+            unknown: sql<number>`count(*) filter (where ${storePrices.bottleId} is null)::int`,
+            created: sql<number>`count(*) filter (where ${storePrices.bottleId} is not null and coalesce(${incomingBottleDecisionLogs.createdBottle}, false))::int`,
+            matched: sql<number>`count(*) filter (where ${storePrices.bottleId} is not null and not coalesce(${incomingBottleDecisionLogs.createdBottle}, false))::int`,
+          })
+          .from(storePrices)
+          .leftJoin(
+            incomingBottleDecisionLogs,
+            and(
+              eq(incomingBottleDecisionLogs.sourceKind, "store_price"),
+              eq(incomingBottleDecisionLogs.sourceId, storePrices.id),
+            ),
+          )
+          .where(
+            and(
+              gte(storePrices.createdAt, firstDay),
+              eq(storePrices.hidden, false),
+            ),
+          ),
+      ],
+    );
     const collectionRows = rows.filter(
       ({ run, sourcePurpose }) => (sourcePurpose ?? run.purpose) === "collect",
     );
@@ -139,8 +172,19 @@ export default procedure
     const saved = {
       reviews: emptySavedCounts(),
       prices: emptySavedCounts(),
-      bottles: emptySavedCounts(),
+      catalogListings: emptySavedCounts(),
     };
+    const bottleResolution = [
+      reviewResolutionRows[0],
+      priceResolutionRows[0],
+    ].reduce<BottleResolutionCounts>(
+      (totals, counts) => ({
+        unknown: totals.unknown + (counts?.unknown ?? 0),
+        created: totals.created + (counts?.created ?? 0),
+        matched: totals.matched + (counts?.matched ?? 0),
+      }),
+      { unknown: 0, created: 0, matched: 0 },
+    );
     const days = new Map<string, DayCounts>();
     for (let offset = 0; offset < DAYS; offset += 1) {
       const date = new Date(firstDay);
@@ -149,7 +193,7 @@ export default procedure
         ...emptyHealthCounts(),
         reviews: 0,
         prices: 0,
-        bottles: 0,
+        catalogListings: 0,
       });
     }
 
@@ -166,17 +210,10 @@ export default procedure
       }
     }
 
-    for (const decision of bottleDecisions) {
-      const day = days.get(dayKey(decision.createdAt));
-      if (!day) continue;
-      saved.bottles.total += 1;
-      saved.bottles[decision.createdBottle ? "new" : "existing"] += 1;
-      day.bottles += 1;
-    }
-
     return {
       totals,
       saved,
+      bottleResolution,
       days: [...days.entries()]
         .reverse()
         .map(([date, counts]) => ({ date, ...counts })),

--- a/apps/server/src/schemas/adminScraperActivity.ts
+++ b/apps/server/src/schemas/adminScraperActivity.ts
@@ -20,14 +20,19 @@ export const AdminScraperActivitySchema = z.object({
   saved: z.object({
     reviews: AdminScraperSavedCountsSchema,
     prices: AdminScraperSavedCountsSchema,
-    bottles: AdminScraperSavedCountsSchema,
+    catalogListings: AdminScraperSavedCountsSchema,
+  }),
+  bottleResolution: z.object({
+    unknown: z.number().int().min(0),
+    created: z.number().int().min(0),
+    matched: z.number().int().min(0),
   }),
   days: z.array(
     AdminScraperHealthCountsSchema.extend({
       date: z.string().date(),
       reviews: z.number().int().min(0),
       prices: z.number().int().min(0),
-      bottles: z.number().int().min(0),
+      catalogListings: z.number().int().min(0),
     }),
   ),
   recentFailures: z.array(

--- a/apps/web/src/app/(admin)/admin/(default)/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/page.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import {
-  AdminActions,
   AdminBreadcrumbs,
   AdminPage,
   AdminPageHeader,
-  AdminTextLink,
 } from "@peated/web/components/admin/adminContent.stylex";
 import OperationsOverview from "@peated/web/components/admin/operationsOverview.stylex";
 import ScraperActivity from "@peated/web/components/admin/scraperActivity.stylex";
@@ -39,16 +37,11 @@ export default function Page() {
             Updated <TimeSince date={operations.generatedAt} />
           </>
         }
-        actions={
-          <AdminActions>
-            <AdminTextLink href="/admin/moderation/automation">
-              View background work
-            </AdminTextLink>
-            <AdminTextLink href="/admin/sites">Manage scrapers</AdminTextLink>
-          </AdminActions>
-        }
       />
-      <OperationsOverview data={operations} />
+      <OperationsOverview
+        bottleResolution={scraperActivity.bottleResolution}
+        data={operations}
+      />
       <ScraperActivity data={scraperActivity} />
     </AdminPage>
   );

--- a/apps/web/src/components/admin/operationsOverview.stories.tsx
+++ b/apps/web/src/components/admin/operationsOverview.stories.tsx
@@ -23,6 +23,11 @@ const meta = {
     },
   },
   args: {
+    bottleResolution: {
+      unknown: 8,
+      created: 6,
+      matched: 75,
+    },
     data: {
       generatedAt: "2026-09-06T18:00:00.000Z",
       counts: {
@@ -51,6 +56,11 @@ export const Overview: Story = {};
 
 export const Quiet: Story = {
   args: {
+    bottleResolution: {
+      unknown: 0,
+      created: 0,
+      matched: 0,
+    },
     data: {
       generatedAt: "2026-09-06T18:00:00.000Z",
       counts: {

--- a/apps/web/src/components/admin/operationsOverview.stylex.tsx
+++ b/apps/web/src/components/admin/operationsOverview.stylex.tsx
@@ -2,233 +2,407 @@
 
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
-import type { ReactNode } from "react";
 
 import { foundationStyles } from "../../styles/foundations.stylex";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import {
+  colors,
+  controlMetrics,
+  fonts,
+  space,
+} from "../../styles/tokens.stylex";
 import { SectionHeading } from "../sectionHeading.stylex";
+import { AdminTextLink } from "./adminContent.stylex";
 
 type OperationsData = Outputs["admin"]["moderation"]["automation"];
-type OperationsOverviewProps = { data: OperationsData };
+type BottleResolution = Outputs["admin"]["scraperActivity"]["bottleResolution"];
+type OperationsOverviewProps = {
+  bottleResolution: BottleResolution;
+  data: OperationsData;
+};
 
 function formatCount(value: number) {
   return value.toLocaleString("en-US");
 }
 
-function Metric({
+function formatPercent(value: number, total: number) {
+  return total ? Math.round((value / total) * 100) : 0;
+}
+
+function ResolutionItem({
   detail,
-  first = false,
   label,
-  mobileLeft = false,
-  mobileTop = false,
+  tone,
+  total,
+  value,
+}: {
+  detail: string;
+  label: string;
+  tone: "unknown" | "created" | "matched";
+  total: number;
+  value: number;
+}) {
+  return (
+    <div {...stylex.props(styles.resolutionItem)}>
+      <dt {...stylex.props(styles.resolutionLabel)}>
+        <span
+          aria-hidden="true"
+          {...stylex.props(
+            styles.resolutionMark,
+            tone === "unknown" && styles.unknown,
+            tone === "created" && styles.created,
+            tone === "matched" && styles.matched,
+          )}
+        />
+        <span {...stylex.props(foundationStyles.compactRowTitle)}>{label}</span>
+      </dt>
+      <dd {...stylex.props(styles.resolutionValue)}>{formatCount(value)}</dd>
+      <dd {...stylex.props(foundationStyles.metadata, styles.resolutionDetail)}>
+        {formatPercent(value, total)}% · {detail}
+      </dd>
+    </div>
+  );
+}
+
+function StatusRow({
+  label,
   tone = "default",
   value,
 }: {
-  detail?: ReactNode;
-  first?: boolean;
   label: string;
-  mobileLeft?: boolean;
-  mobileTop?: boolean;
   tone?: "default" | "danger";
   value: number;
 }) {
   return (
-    <div
-      {...stylex.props(
-        styles.metric,
-        !first && styles.metricDivider,
-        mobileLeft && styles.mobileLeft,
-        mobileTop && styles.mobileTop,
-      )}
-    >
-      <dt {...stylex.props(foundationStyles.rowTitle, styles.metricLabel)}>
+    <div {...stylex.props(styles.statusRow)}>
+      <dt {...stylex.props(foundationStyles.body, styles.statusLabel)}>
         {label}
       </dt>
       <dd
         {...stylex.props(
-          styles.metricValue,
+          styles.statusValue,
           tone === "danger" && styles.danger,
         )}
       >
         {formatCount(value)}
       </dd>
-      {detail ? (
-        <dd {...stylex.props(foundationStyles.metadata, styles.metricDetail)}>
-          {detail}
-        </dd>
-      ) : null}
     </div>
   );
 }
 
-/** Summarizes live background work and recent price matching for administrators. */
-export default function OperationsOverview({ data }: OperationsOverviewProps) {
+/** Prioritizes Bottle outcomes, live work, and recent price matching. */
+export default function OperationsOverview({
+  bottleResolution,
+  data,
+}: OperationsOverviewProps) {
+  const resolutionTotal =
+    bottleResolution.unknown +
+    bottleResolution.created +
+    bottleResolution.matched;
+
   return (
-    <div {...stylex.props(styles.root)}>
-      <section aria-labelledby="current-operations-heading">
-        <div {...stylex.props(styles.sectionHeading)}>
-          <SectionHeading id="current-operations-heading">
-            Right now
+    <div {...stylex.props(styles.overviewGrid)}>
+      <section
+        aria-labelledby="bottle-resolution-heading"
+        {...stylex.props(styles.resolutionPanel)}
+      >
+        <div {...stylex.props(styles.panelHeading)}>
+          <SectionHeading id="bottle-resolution-heading">
+            Bottle resolution
           </SectionHeading>
+          <p {...stylex.props(foundationStyles.body, styles.panelDescription)}>
+            New reviews and prices from the last 30 days, grouped by their
+            current Bottle match.
+          </p>
         </div>
-        <dl {...stylex.props(styles.currentGrid)}>
-          <Metric
-            first
+
+        {resolutionTotal ? (
+          <>
+            <div aria-hidden="true" {...stylex.props(styles.resolutionTrack)}>
+              {bottleResolution.unknown ? (
+                <span
+                  style={{ flexGrow: bottleResolution.unknown }}
+                  {...stylex.props(styles.resolutionSegment, styles.unknown)}
+                />
+              ) : null}
+              {bottleResolution.created ? (
+                <span
+                  style={{ flexGrow: bottleResolution.created }}
+                  {...stylex.props(styles.resolutionSegment, styles.created)}
+                />
+              ) : null}
+              {bottleResolution.matched ? (
+                <span
+                  style={{ flexGrow: bottleResolution.matched }}
+                  {...stylex.props(styles.resolutionSegment, styles.matched)}
+                />
+              ) : null}
+            </div>
+            <dl {...stylex.props(styles.resolutionList)}>
+              <ResolutionItem
+                label="Unknown"
+                value={bottleResolution.unknown}
+                total={resolutionTotal}
+                detail="no Bottle match yet"
+                tone="unknown"
+              />
+              <ResolutionItem
+                label="New bottles"
+                value={bottleResolution.created}
+                total={resolutionTotal}
+                detail="added to Peated"
+                tone="created"
+              />
+              <ResolutionItem
+                label="Existing matches"
+                value={bottleResolution.matched}
+                total={resolutionTotal}
+                detail="matched to Bottles in Peated"
+                tone="matched"
+              />
+            </dl>
+          </>
+        ) : (
+          <p {...stylex.props(foundationStyles.body, styles.empty)}>
+            No new reviews or prices in the last 30 days.
+          </p>
+        )}
+      </section>
+
+      <section
+        aria-labelledby="system-status-heading"
+        {...stylex.props(styles.statusPanel)}
+      >
+        <div {...stylex.props(styles.statusHeader)}>
+          <SectionHeading id="system-status-heading">
+            System status
+          </SectionHeading>
+          <AdminTextLink href="/admin/moderation/automation">
+            View work
+          </AdminTextLink>
+        </div>
+
+        <dl {...stylex.props(styles.statusList)}>
+          <StatusRow
             label="Needs attention"
             value={data.counts.failed}
             tone={data.counts.failed > 0 ? "danger" : "default"}
           />
-          <Metric
-            label="In progress"
-            mobileLeft
-            value={data.counts.processing}
-          />
-          <Metric label="Waiting" mobileTop value={data.counts.waiting} />
-          <Metric
-            label="Finished today"
-            mobileLeft
-            mobileTop
-            value={data.counts.clearedToday}
-          />
+          <StatusRow label="In progress" value={data.counts.processing} />
+          <StatusRow label="Waiting" value={data.counts.waiting} />
+          <StatusRow label="Finished today" value={data.counts.clearedToday} />
         </dl>
-      </section>
 
-      <section aria-labelledby="price-matching-heading">
-        <div {...stylex.props(styles.sectionHeading)}>
-          <SectionHeading id="price-matching-heading">
-            Price matching
-          </SectionHeading>
-          <p
-            {...stylex.props(foundationStyles.body, styles.sectionDescription)}
-          >
-            {data.listingAutomation.sampleSize
-              ? `Last ${formatCount(data.listingAutomation.sampleSize)} prices checked`
-              : "No completed price checks yet."}
-          </p>
+        <div {...stylex.props(styles.matching)}>
+          <div {...stylex.props(styles.matchingHeader)}>
+            <h3 {...stylex.props(foundationStyles.compactRowTitle)}>
+              Price matching
+            </h3>
+            {data.listingAutomation.sampleSize ? (
+              <strong {...stylex.props(styles.matchingRate)}>
+                {data.listingAutomation.rate ?? 0}% automatic
+              </strong>
+            ) : null}
+          </div>
+          {data.listingAutomation.sampleSize ? (
+            <p
+              {...stylex.props(
+                foundationStyles.metadata,
+                styles.matchingDetail,
+              )}
+            >
+              {formatCount(data.listingAutomation.automatic)} automatic ·{" "}
+              {formatCount(data.listingAutomation.manual)} manual ·{" "}
+              <span
+                {...stylex.props(
+                  data.listingAutomation.failed > 0 && styles.danger,
+                )}
+              >
+                {formatCount(data.listingAutomation.failed)} failed
+              </span>
+              <br />
+              Last {formatCount(data.listingAutomation.sampleSize)} prices
+              checked
+            </p>
+          ) : (
+            <p
+              {...stylex.props(
+                foundationStyles.metadata,
+                styles.matchingDetail,
+              )}
+            >
+              No completed price checks yet.
+            </p>
+          )}
         </div>
-        {data.listingAutomation.sampleSize ? (
-          <dl {...stylex.props(styles.matchingGrid)}>
-            <Metric
-              first
-              label="Matched automatically"
-              value={data.listingAutomation.automatic}
-              detail={`${data.listingAutomation.rate ?? 0}% of checks`}
-            />
-            <Metric
-              label="Handled by a person"
-              mobileTop
-              value={data.listingAutomation.manual}
-            />
-            <Metric
-              label="Failed"
-              mobileTop
-              value={data.listingAutomation.failed}
-              tone={data.listingAutomation.failed > 0 ? "danger" : "default"}
-            />
-          </dl>
-        ) : null}
       </section>
     </div>
   );
 }
 
 const styles = stylex.create({
-  root: {
-    display: "flex",
+  overviewGrid: {
+    display: "grid",
     minWidth: 0,
-    flexDirection: "column",
-    rowGap: space.x8,
+    gridTemplateColumns: {
+      default: "minmax(0, 1.7fr) minmax(280px, 1fr)",
+      "@media (max-width: 839px)": "1fr",
+    },
+    gap: space.x4,
   },
-  sectionHeading: {
+  resolutionPanel: {
+    minWidth: 0,
+    padding: { default: space.x6, "@media (max-width: 639px)": space.x4 },
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.surface,
+  },
+  statusPanel: {
+    minWidth: 0,
+    padding: { default: space.x6, "@media (max-width: 639px)": space.x4 },
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: colors.hairline,
+    borderRadius: controlMetrics.radius,
+  },
+  panelHeading: {
     display: "flex",
     minWidth: 0,
     flexDirection: "column",
     rowGap: space.x2,
-    marginBottom: space.x4,
   },
-  sectionDescription: {
-    maxWidth: "68ch",
-    color: colors.inkMuted,
+  panelDescription: { maxWidth: "62ch", color: colors.inkMuted },
+  resolutionTrack: {
+    display: "flex",
+    height: "10px",
+    marginTop: space.x6,
+    overflow: "hidden",
+    borderRadius: controlMetrics.radiusSmall,
+    backgroundColor: colors.inset,
   },
-  currentGrid: {
-    display: "grid",
-    minWidth: 0,
-    gridTemplateColumns: {
-      default: "repeat(4, minmax(0, 1fr))",
-      "@media (max-width: 639px)": "repeat(2, minmax(0, 1fr))",
-    },
-    margin: 0,
-    padding: 0,
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.sectionRule,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.sectionRule,
-  },
-  matchingGrid: {
+  resolutionSegment: { minWidth: "3px", flexBasis: 0 },
+  unknown: { backgroundColor: colors.dataRange },
+  created: { backgroundColor: colors.accent },
+  matched: { backgroundColor: colors.dataAccent },
+  resolutionList: {
     display: "grid",
     minWidth: 0,
     gridTemplateColumns: {
       default: "repeat(3, minmax(0, 1fr))",
-      "@media (max-width: 639px)": "1fr",
+      "@media (max-width: 559px)": "1fr",
     },
+    gap: { default: space.x4, "@media (max-width: 559px)": space.x3 },
     margin: 0,
+    marginTop: space.x6,
     padding: 0,
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.sectionRule,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.sectionRule,
   },
-  metric: {
+  resolutionItem: {
+    display: "grid",
     minWidth: 0,
-    paddingTop: space.x6,
-    paddingRight: space.x6,
-    paddingBottom: space.x6,
-    paddingLeft: space.x6,
-    "@media (max-width: 639px)": {
-      paddingRight: 0,
-      paddingLeft: 0,
+    gridTemplateColumns: "1fr auto",
+    columnGap: space.x2,
+    alignItems: "baseline",
+    "@media (max-width: 559px)": {
+      paddingBottom: space.x3,
+      borderBottomWidth: "1px",
+      borderBottomStyle: "solid",
+      borderBottomColor: colors.hairline,
     },
   },
-  metricDivider: {
-    borderLeftWidth: { default: "1px", "@media (max-width: 639px)": 0 },
-    borderLeftStyle: "solid",
-    borderLeftColor: colors.hairline,
+  resolutionLabel: {
+    display: "inline-flex",
+    minWidth: 0,
+    alignItems: "center",
+    gap: space.x2,
   },
-  mobileLeft: {
-    "@media (max-width: 639px)": {
-      paddingLeft: space.x4,
-      borderLeftWidth: "1px",
-      borderLeftStyle: "solid",
-      borderLeftColor: colors.hairline,
-    },
+  resolutionMark: {
+    width: "9px",
+    height: "9px",
+    flexShrink: 0,
+    borderRadius: "50%",
   },
-  mobileTop: {
-    "@media (max-width: 639px)": {
-      borderTopWidth: "1px",
-      borderTopStyle: "solid",
-      borderTopColor: colors.hairline,
-    },
-  },
-  metricLabel: { color: colors.ink },
-  metricValue: {
+  resolutionValue: {
     margin: 0,
-    marginTop: space.x3,
     color: colors.ink,
     fontFamily: fonts.display,
-    fontSize: "40px",
+    fontSize: "28px",
     fontWeight: 700,
-    letterSpacing: "-0.04em",
+    letterSpacing: "-0.035em",
     lineHeight: 1,
     fontVariantNumeric: "tabular-nums",
   },
-  metricDetail: {
+  resolutionDetail: {
+    gridColumn: "1 / -1",
     margin: 0,
-    marginTop: space.x3,
+    marginTop: space.x1,
     color: colors.inkMuted,
   },
+  empty: {
+    marginTop: space.x6,
+    paddingTop: space.x6,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+    color: colors.inkMuted,
+  },
+  statusHeader: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space.x3,
+  },
+  statusList: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    margin: 0,
+    marginTop: space.x4,
+    padding: 0,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+  },
+  statusRow: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space.x4,
+    paddingTop: space.x2,
+    paddingBottom: space.x2,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+  },
+  statusLabel: { color: colors.inkMuted },
+  statusValue: {
+    margin: 0,
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "20px",
+    fontWeight: 700,
+    lineHeight: 1,
+    fontVariantNumeric: "tabular-nums",
+  },
   danger: { color: colors.critical },
+  matching: {
+    marginTop: space.x4,
+    padding: space.x3,
+    borderRadius: controlMetrics.radiusSmall,
+    backgroundColor: colors.surface,
+  },
+  matchingHeader: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space.x3,
+  },
+  matchingRate: {
+    color: colors.accentDeep,
+    fontFamily: fonts.display,
+    fontSize: "15px",
+    fontWeight: 700,
+    lineHeight: 1.2,
+  },
+  matchingDetail: { marginTop: space.x2, color: colors.inkMuted },
 });

--- a/apps/web/src/components/admin/operationsOverview.test.tsx
+++ b/apps/web/src/components/admin/operationsOverview.test.tsx
@@ -1,0 +1,53 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import OperationsOverview from "./operationsOverview.stylex";
+
+const operations = {
+  generatedAt: "2026-09-06T18:00:00.000Z",
+  counts: {
+    processing: 4,
+    waiting: 12,
+    failed: 2,
+    clearedToday: 86,
+  },
+  listingAutomation: {
+    sampleSize: 100,
+    automatic: 73,
+    manual: 24,
+    failed: 3,
+    rate: 73,
+  },
+  needsAttention: [],
+  recentRuns: [],
+};
+
+describe("OperationsOverview", () => {
+  it("distinguishes unknown, new, and matched Bottles", () => {
+    const html = renderToStaticMarkup(
+      <OperationsOverview
+        bottleResolution={{ unknown: 8, created: 6, matched: 75 }}
+        data={operations}
+      />,
+    );
+
+    expect(html).toContain("Bottle resolution");
+    expect(html).toContain("Unknown");
+    expect(html).toContain("New bottles");
+    expect(html).toContain("Existing matches");
+    expect(html).toContain("73% automatic");
+    expect(html).toContain("View work");
+  });
+
+  it("uses a compact empty state when there are no new source items", () => {
+    const html = renderToStaticMarkup(
+      <OperationsOverview
+        bottleResolution={{ unknown: 0, created: 0, matched: 0 }}
+        data={operations}
+      />,
+    );
+
+    expect(html).toContain("No new reviews or prices in the last 30 days.");
+    expect(html).not.toContain("0% ·");
+  });
+});

--- a/apps/web/src/components/admin/scraperActivity.stories.tsx
+++ b/apps/web/src/components/admin/scraperActivity.stories.tsx
@@ -26,7 +26,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Shows scraper totals, 30-day charts for saved items and requests, exact daily details, and recent problems.",
+          "Shows 30-day scraper output, request health, daily details, and recent problems.",
       },
     },
   },
@@ -42,7 +42,12 @@ const meta = {
       saved: {
         reviews: { total: 47, new: 18, existing: 29 },
         prices: { total: 42, new: 13, existing: 26 },
-        bottles: { total: 21, new: 6, existing: 15 },
+        catalogListings: { total: 21, new: 6, existing: 15 },
+      },
+      bottleResolution: {
+        unknown: 8,
+        created: 6,
+        matched: 75,
       },
       days: [
         {
@@ -54,7 +59,7 @@ const meta = {
           failedRuns: 1,
           reviews: 12,
           prices: 9,
-          bottles: 4,
+          catalogListings: 4,
         },
         {
           date: "2026-09-04",
@@ -65,7 +70,7 @@ const meta = {
           failedRuns: 0,
           reviews: 8,
           prices: 11,
-          bottles: 3,
+          catalogListings: 3,
         },
         {
           date: "2026-09-03",
@@ -76,7 +81,7 @@ const meta = {
           failedRuns: 0,
           reviews: 6,
           prices: 7,
-          bottles: 2,
+          catalogListings: 2,
         },
       ],
       recentFailures: [
@@ -103,15 +108,16 @@ export const NoActivity: Story = {
       saved: {
         reviews: emptySaved,
         prices: emptySaved,
-        bottles: emptySaved,
+        catalogListings: emptySaved,
       },
+      bottleResolution: { unknown: 0, created: 0, matched: 0 },
       days: [
         {
           date: "2026-09-05",
           ...emptyHealth,
           reviews: 0,
           prices: 0,
-          bottles: 0,
+          catalogListings: 0,
         },
       ],
       recentFailures: [],

--- a/apps/web/src/components/admin/scraperActivity.stylex.tsx
+++ b/apps/web/src/components/admin/scraperActivity.stylex.tsx
@@ -78,11 +78,11 @@ function hasFailures(day: ActivityDay) {
 }
 
 function savedTotal(day: ActivityDay) {
-  return day.reviews + day.prices + day.bottles;
+  return day.reviews + day.prices + day.catalogListings;
 }
 
 function savedDayLabel(day: ActivityDay) {
-  return `${formatFullDay(day.date)}: ${formatNamedCount(day.reviews, "review")}, ${formatNamedCount(day.prices, "price")}, ${formatNamedCount(day.bottles, "bottle")}`;
+  return `${formatFullDay(day.date)}: ${formatNamedCount(day.reviews, "review")}, ${formatNamedCount(day.prices, "price")}, ${formatNamedCount(day.catalogListings, "catalog listing")}`;
 }
 
 function requestDayLabel(day: ActivityDay) {
@@ -106,7 +106,7 @@ function ChartLegend({
 }: {
   items: readonly {
     label: string;
-    tone: "reviews" | "prices" | "bottles" | "requests" | "failures";
+    tone: "reviews" | "prices" | "catalogListings" | "requests" | "failures";
   }[];
 }) {
   return (
@@ -122,7 +122,7 @@ function ChartLegend({
               styles.legendMark,
               item.tone === "reviews" && styles.reviews,
               item.tone === "prices" && styles.prices,
-              item.tone === "bottles" && styles.bottles,
+              item.tone === "catalogListings" && styles.catalogListings,
               item.tone === "requests" && styles.requests,
               item.tone === "failures" && styles.failures,
             )}
@@ -153,7 +153,7 @@ function SavedActivityChart({ days }: { days: readonly ActivityDay[] }) {
         <span aria-hidden="true" {...stylex.props(styles.chartGuide)} />
         {!largestTotal ? (
           <span {...stylex.props(foundationStyles.metadata, styles.chartEmpty)}>
-            No reviews, prices or bottles were saved.
+            No reviews, prices or catalog listings were saved.
           </span>
         ) : null}
         <ol aria-label="Saved items by day" {...stylex.props(styles.chartBars)}>
@@ -187,10 +187,13 @@ function SavedActivityChart({ days }: { days: readonly ActivityDay[] }) {
                         {...stylex.props(styles.savedBarPart, styles.prices)}
                       />
                     ) : null}
-                    {day.bottles > 0 ? (
+                    {day.catalogListings > 0 ? (
                       <span
-                        style={{ flexGrow: day.bottles }}
-                        {...stylex.props(styles.savedBarPart, styles.bottles)}
+                        style={{ flexGrow: day.catalogListings }}
+                        {...stylex.props(
+                          styles.savedBarPart,
+                          styles.catalogListings,
+                        )}
                       />
                     ) : null}
                   </span>
@@ -205,18 +208,24 @@ function SavedActivityChart({ days }: { days: readonly ActivityDay[] }) {
         items={[
           { label: "Reviews", tone: "reviews" },
           { label: "Prices", tone: "prices" },
-          { label: "Bottles", tone: "bottles" },
+          { label: "Catalog listings", tone: "catalogListings" },
         ]}
       />
     </figure>
   );
 }
 
-function RequestActivityChart({ days }: { days: readonly ActivityDay[] }) {
+function RequestActivityChart({
+  days,
+  divided = true,
+}: {
+  days: readonly ActivityDay[];
+  divided?: boolean;
+}) {
   const largestTotal = Math.max(...days.map((day) => day.requests), 0);
 
   return (
-    <figure {...stylex.props(styles.chart, styles.chartDivider)}>
+    <figure {...stylex.props(styles.chart, divided && styles.chartDivider)}>
       <figcaption {...stylex.props(styles.chartHeader)}>
         <span {...stylex.props(foundationStyles.compactRowTitle)}>
           Requests each day
@@ -318,151 +327,41 @@ function SavedTotal({
   );
 }
 
-/** Shows scraper totals, daily charts, exact daily details, and recent problems. */
+/** Shows scraper output, request health, daily details, and recent problems. */
 export default function ScraperActivity({ data }: ScraperActivityProps) {
   const activeDays = data.days.filter(
     (day) =>
-      day.runs > 0 || day.reviews > 0 || day.prices > 0 || day.bottles > 0,
+      day.runs > 0 ||
+      day.requests > 0 ||
+      hasFailures(day) ||
+      day.reviews > 0 ||
+      day.prices > 0 ||
+      day.catalogListings > 0,
   );
   const chartDays = [...data.days].reverse();
+  const savedRecordTotal =
+    data.saved.reviews.total +
+    data.saved.prices.total +
+    data.saved.catalogListings.total;
+  const hasSavedActivity = data.days.some((day) => savedTotal(day) > 0);
+  const hasRequestActivity = data.days.some(
+    (day) => day.requests > 0 || hasFailures(day),
+  );
 
   return (
     <div {...stylex.props(styles.root)}>
-      <section aria-labelledby="scraper-results-heading">
-        <div {...stylex.props(styles.sectionHeading)}>
-          <SectionHeading id="scraper-results-heading">
-            Reviews, prices and bottles
-          </SectionHeading>
-          <p
-            {...stylex.props(foundationStyles.body, styles.sectionDescription)}
-          >
-            Last 30 days. New means Peated did not already have that review,
-            price or bottle.
-          </p>
-        </div>
-
-        <dl {...stylex.props(styles.savedGrid)}>
-          <SavedTotal first label="Reviews" counts={data.saved.reviews} />
-          <SavedTotal label="Prices" counts={data.saved.prices} />
-          <SavedTotal label="Bottles" counts={data.saved.bottles} />
-        </dl>
-
-        <dl {...stylex.props(styles.healthGrid)}>
-          <div {...stylex.props(styles.healthItem)}>
-            <dt
-              {...stylex.props(foundationStyles.metadata, styles.healthLabel)}
-            >
-              Runs
-            </dt>
-            <dd {...stylex.props(styles.healthValue)}>
-              {formatCount(data.totals.runs)}
-            </dd>
-            <dd
-              {...stylex.props(
-                foundationStyles.metadata,
-                styles.healthDetail,
-                data.totals.failedRuns > 0 && styles.failure,
-              )}
-            >
-              {formatNamedCount(data.totals.failedRuns, "failed run")}
-            </dd>
-          </div>
-          <div {...stylex.props(styles.healthItem, styles.healthDivider)}>
-            <dt
-              {...stylex.props(foundationStyles.metadata, styles.healthLabel)}
-            >
-              Requests
-            </dt>
-            <dd {...stylex.props(styles.healthValue)}>
-              {formatCount(data.totals.requests)}
-            </dd>
-            <dd
-              {...stylex.props(
-                foundationStyles.metadata,
-                styles.healthDetail,
-                (data.totals.requestErrors > 0 ||
-                  !data.totals.requestErrorsComplete) &&
-                  styles.failure,
-              )}
-            >
-              {requestFailureText(data.totals)}
-            </dd>
-          </div>
-        </dl>
-      </section>
-
-      <section aria-labelledby="daily-activity-heading">
-        <div {...stylex.props(styles.sectionHeading)}>
-          <SectionHeading id="daily-activity-heading">
-            Daily activity
-          </SectionHeading>
-        </div>
-        {activeDays.length ? (
-          <>
-            <div {...stylex.props(styles.chartGrid)}>
-              <SavedActivityChart days={chartDays} />
-              <RequestActivityChart days={chartDays} />
-            </div>
-            <details {...stylex.props(styles.dailyDetails)}>
-              <summary
-                {...stylex.props(
-                  foundationStyles.interactiveSmall,
-                  styles.dailySummary,
-                )}
-              >
-                Daily details
-              </summary>
-              <ol {...stylex.props(styles.dailyList)}>
-                {activeDays.map((day) => (
-                  <li key={day.date} {...stylex.props(styles.dailyRow)}>
-                    <time
-                      dateTime={day.date}
-                      {...stylex.props(
-                        foundationStyles.compactRowTitle,
-                        styles.day,
-                      )}
-                    >
-                      {formatDay(day.date)}
-                    </time>
-                    <div {...stylex.props(styles.dailyResults)}>
-                      <span>{formatNamedCount(day.reviews, "review")}</span>
-                      <span>{formatNamedCount(day.prices, "price")}</span>
-                      <span>{formatNamedCount(day.bottles, "bottle")}</span>
-                    </div>
-                    <div
-                      {...stylex.props(
-                        foundationStyles.metadata,
-                        styles.dailyHealth,
-                      )}
-                    >
-                      <span>
-                        {formatNamedCount(day.runs, "run")} ·{" "}
-                        {formatNamedCount(day.requests, "request")}
-                      </span>
-                      <span
-                        {...stylex.props(hasFailures(day) && styles.failure)}
-                      >
-                        {failureText(day)}
-                      </span>
-                    </div>
-                  </li>
-                ))}
-              </ol>
-            </details>
-          </>
-        ) : (
-          <p {...stylex.props(foundationStyles.body, styles.empty)}>
-            No scraper activity in the last 30 days.
-          </p>
-        )}
-      </section>
-
       {data.recentFailures.length ? (
-        <section aria-labelledby="recent-problems-heading">
-          <div {...stylex.props(styles.sectionHeading)}>
+        <section
+          aria-labelledby="recent-problems-heading"
+          {...stylex.props(styles.problemSection)}
+        >
+          <div {...stylex.props(styles.problemSectionHeader)}>
             <SectionHeading id="recent-problems-heading">
-              Recent problems
+              Recent scraper problems
             </SectionHeading>
+            <span {...stylex.props(styles.problemCount)}>
+              {formatCount(data.recentFailures.length)}
+            </span>
           </div>
           <ul {...stylex.props(styles.problemList)}>
             {data.recentFailures.map((failure) => (
@@ -493,6 +392,162 @@ export default function ScraperActivity({ data }: ScraperActivityProps) {
           </ul>
         </section>
       ) : null}
+
+      <section aria-labelledby="source-activity-heading">
+        <div {...stylex.props(styles.sourceHeader)}>
+          <div {...stylex.props(styles.sectionHeading)}>
+            <SectionHeading id="source-activity-heading">
+              Source activity
+            </SectionHeading>
+            <p
+              {...stylex.props(
+                foundationStyles.body,
+                styles.sectionDescription,
+              )}
+            >
+              Last 30 days. New means Peated did not already have that review,
+              price or catalog listing.
+            </p>
+          </div>
+          <AdminTextLink href="/admin/sites">Manage scrapers</AdminTextLink>
+        </div>
+
+        <dl {...stylex.props(styles.healthSummary)}>
+          <div {...stylex.props(styles.healthSummaryItem)}>
+            <dt
+              {...stylex.props(foundationStyles.metadata, styles.healthLabel)}
+            >
+              Runs
+            </dt>
+            <dd {...stylex.props(styles.healthSummaryValue)}>
+              {formatCount(data.totals.runs)}
+            </dd>
+            <dd
+              {...stylex.props(
+                foundationStyles.metadata,
+                styles.healthDetail,
+                data.totals.failedRuns > 0 && styles.failure,
+              )}
+            >
+              {formatNamedCount(data.totals.failedRuns, "failed run")}
+            </dd>
+          </div>
+          <div {...stylex.props(styles.healthSummaryItem)}>
+            <dt
+              {...stylex.props(foundationStyles.metadata, styles.healthLabel)}
+            >
+              Requests
+            </dt>
+            <dd {...stylex.props(styles.healthSummaryValue)}>
+              {formatCount(data.totals.requests)}
+            </dd>
+            <dd
+              {...stylex.props(
+                foundationStyles.metadata,
+                styles.healthDetail,
+                (data.totals.requestErrors > 0 ||
+                  !data.totals.requestErrorsComplete) &&
+                  styles.failure,
+              )}
+            >
+              {requestFailureText(data.totals)}
+            </dd>
+          </div>
+        </dl>
+
+        {savedRecordTotal ? (
+          <dl {...stylex.props(styles.savedGrid)}>
+            <SavedTotal first label="Reviews" counts={data.saved.reviews} />
+            <SavedTotal label="Prices" counts={data.saved.prices} />
+            <SavedTotal
+              label="Catalog listings"
+              counts={data.saved.catalogListings}
+            />
+          </dl>
+        ) : hasRequestActivity || data.totals.runs > 0 ? (
+          <p {...stylex.props(foundationStyles.body, styles.savedEmpty)}>
+            No reviews, prices or catalog listings saved.
+          </p>
+        ) : null}
+
+        {hasSavedActivity || hasRequestActivity ? (
+          <>
+            <div
+              {...stylex.props(
+                styles.chartGrid,
+                hasSavedActivity && hasRequestActivity
+                  ? styles.chartGridSplit
+                  : styles.chartGridSingle,
+              )}
+            >
+              {hasSavedActivity ? (
+                <SavedActivityChart days={chartDays} />
+              ) : null}
+              {hasRequestActivity ? (
+                <RequestActivityChart
+                  days={chartDays}
+                  divided={hasSavedActivity}
+                />
+              ) : null}
+            </div>
+            <details {...stylex.props(styles.dailyDetails)}>
+              <summary
+                {...stylex.props(
+                  foundationStyles.interactiveSmall,
+                  styles.dailySummary,
+                )}
+              >
+                Daily details
+              </summary>
+              <ol {...stylex.props(styles.dailyList)}>
+                {activeDays.map((day) => (
+                  <li key={day.date} {...stylex.props(styles.dailyRow)}>
+                    <time
+                      dateTime={day.date}
+                      {...stylex.props(
+                        foundationStyles.compactRowTitle,
+                        styles.day,
+                      )}
+                    >
+                      {formatDay(day.date)}
+                    </time>
+                    <div {...stylex.props(styles.dailyResults)}>
+                      <span>{formatNamedCount(day.reviews, "review")}</span>
+                      <span>{formatNamedCount(day.prices, "price")}</span>
+                      <span>
+                        {formatNamedCount(
+                          day.catalogListings,
+                          "catalog listing",
+                        )}
+                      </span>
+                    </div>
+                    <div
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.dailyHealth,
+                      )}
+                    >
+                      <span>
+                        {formatNamedCount(day.runs, "run")} ·{" "}
+                        {formatNamedCount(day.requests, "request")}
+                      </span>
+                      <span
+                        {...stylex.props(hasFailures(day) && styles.failure)}
+                      >
+                        {failureText(day)}
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </details>
+          </>
+        ) : (
+          <p {...stylex.props(foundationStyles.body, styles.empty)}>
+            No scraper activity in the last 30 days.
+          </p>
+        )}
+      </section>
     </div>
   );
 }
@@ -502,14 +557,25 @@ const styles = stylex.create({
     display: "flex",
     minWidth: 0,
     flexDirection: "column",
-    rowGap: space.x8,
+    rowGap: space.x6,
+  },
+  sourceHeader: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: space.x6,
+    marginBottom: space.x4,
+    "@media (max-width: 559px)": {
+      flexDirection: "column",
+      gap: space.x2,
+    },
   },
   sectionHeading: {
     display: "flex",
     minWidth: 0,
     flexDirection: "column",
     rowGap: space.x2,
-    marginBottom: space.x4,
   },
   sectionDescription: {
     maxWidth: "68ch",
@@ -533,9 +599,9 @@ const styles = stylex.create({
   },
   savedTotal: {
     minWidth: 0,
-    paddingTop: space.x6,
+    paddingTop: space.x4,
     paddingRight: space.x6,
-    paddingBottom: space.x6,
+    paddingBottom: space.x4,
     paddingLeft: space.x6,
     "@media (max-width: 639px)": {
       paddingRight: 0,
@@ -555,10 +621,10 @@ const styles = stylex.create({
   savedLabel: { color: colors.ink },
   savedValue: {
     margin: 0,
-    marginTop: space.x3,
+    marginTop: space.x2,
     color: colors.ink,
     fontFamily: fonts.display,
-    fontSize: "40px",
+    fontSize: "32px",
     fontWeight: 700,
     letterSpacing: "-0.04em",
     lineHeight: 1,
@@ -570,69 +636,59 @@ const styles = stylex.create({
     flexDirection: "column",
     rowGap: space.x1,
     margin: 0,
-    marginTop: space.x3,
+    marginTop: space.x2,
     color: colors.inkMuted,
   },
   breakdownValue: { color: colors.ink, fontWeight: 600 },
-  healthGrid: {
-    display: "grid",
+  healthSummary: {
+    display: "flex",
     minWidth: 0,
-    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    flexWrap: "wrap",
+    gap: space.x4,
     margin: 0,
+    marginBottom: space.x3,
     padding: 0,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
   },
-  healthItem: {
+  healthSummaryItem: {
     display: "grid",
     minWidth: 0,
-    gridTemplateColumns: "minmax(72px, auto) auto 1fr",
+    gridTemplateColumns: "auto auto auto",
     alignItems: "baseline",
-    columnGap: space.x3,
-    paddingTop: space.x4,
-    paddingRight: space.x6,
-    paddingBottom: space.x4,
-    paddingLeft: space.x6,
+    columnGap: space.x2,
     "@media (max-width: 639px)": {
-      gridTemplateColumns: "1fr",
-      rowGap: space.x1,
-      paddingRight: space.x4,
-      paddingLeft: 0,
+      gridTemplateColumns: "auto auto",
     },
   },
-  healthDivider: {
-    borderLeftWidth: "1px",
-    borderLeftStyle: "solid",
-    borderLeftColor: colors.hairline,
-    "@media (max-width: 639px)": { paddingLeft: space.x4 },
-  },
   healthLabel: { color: colors.inkMuted },
-  healthValue: {
+  healthSummaryValue: {
     margin: 0,
     color: colors.ink,
     fontFamily: fonts.display,
-    fontSize: "24px",
+    fontSize: "18px",
     fontWeight: 700,
     lineHeight: 1,
     fontVariantNumeric: "tabular-nums",
   },
-  healthDetail: { margin: 0, color: colors.inkMuted },
+  healthDetail: {
+    margin: 0,
+    color: colors.inkMuted,
+    "@media (max-width: 639px)": { gridColumn: "1 / -1" },
+  },
   failure: { color: colors.critical },
   chartGrid: {
     display: "grid",
     minWidth: 0,
-    gridTemplateColumns: {
-      default: "repeat(2, minmax(0, 1fr))",
-      "@media (max-width: 759px)": "1fr",
-    },
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.sectionRule,
     borderBottomWidth: "1px",
     borderBottomStyle: "solid",
     borderBottomColor: colors.sectionRule,
   },
+  chartGridSplit: {
+    gridTemplateColumns: {
+      default: "repeat(2, minmax(0, 1fr))",
+      "@media (max-width: 759px)": "1fr",
+    },
+  },
+  chartGridSingle: { gridTemplateColumns: "1fr" },
   chart: {
     minWidth: 0,
     margin: 0,
@@ -738,7 +794,7 @@ const styles = stylex.create({
   },
   reviews: { backgroundColor: colors.ratingFill },
   prices: { backgroundColor: colors.dataAccent },
-  bottles: { backgroundColor: colors.dataRange },
+  catalogListings: { backgroundColor: colors.dataRange },
   requests: { backgroundColor: colors.dataAccent },
   failures: { backgroundColor: colors.critical },
   chartDates: {
@@ -840,6 +896,47 @@ const styles = stylex.create({
     borderBottomColor: colors.hairline,
     color: colors.inkMuted,
   },
+  savedEmpty: {
+    paddingTop: space.x3,
+    paddingBottom: space.x3,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.sectionRule,
+    color: colors.inkMuted,
+  },
+  problemSection: {
+    minWidth: 0,
+    padding: { default: space.x4, "@media (max-width: 639px)": space.x3 },
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: colors.criticalQuiet,
+    backgroundColor: colors.surface,
+  },
+  problemSectionHeader: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: space.x3,
+    marginBottom: space.x3,
+  },
+  problemCount: {
+    display: "inline-flex",
+    minWidth: "24px",
+    height: "24px",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingRight: space.x2,
+    paddingLeft: space.x2,
+    borderRadius: "12px",
+    backgroundColor: colors.critical,
+    color: colors.ground,
+    fontFamily: fonts.display,
+    fontSize: "13px",
+    fontWeight: 700,
+    lineHeight: 1,
+    fontVariantNumeric: "tabular-nums",
+  },
   problemList: {
     margin: 0,
     padding: 0,
@@ -854,7 +951,7 @@ const styles = stylex.create({
     flexDirection: "column",
     rowGap: space.x2,
     paddingTop: space.x4,
-    paddingBottom: space.x4,
+    paddingBottom: space.x3,
     borderBottomWidth: "1px",
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,

--- a/apps/web/src/components/admin/scraperActivity.test.tsx
+++ b/apps/web/src/components/admin/scraperActivity.test.tsx
@@ -22,8 +22,9 @@ const data = {
   saved: {
     reviews: { total: 20, new: 8, existing: 12 },
     prices: { total: 17, new: 6, existing: 11 },
-    bottles: { total: 7, new: 2, existing: 5 },
+    catalogListings: { total: 7, new: 2, existing: 5 },
   },
+  bottleResolution: { unknown: 3, created: 2, matched: 32 },
   days: [
     {
       date: "2026-09-05",
@@ -34,7 +35,7 @@ const data = {
       failedRuns: 1,
       reviews: 12,
       prices: 9,
-      bottles: 4,
+      catalogListings: 4,
     },
     {
       date: "2026-09-04",
@@ -45,7 +46,7 @@ const data = {
       failedRuns: 0,
       reviews: 8,
       prices: 8,
-      bottles: 3,
+      catalogListings: 3,
     },
   ],
   recentFailures: [],
@@ -62,10 +63,12 @@ describe("ScraperActivity", () => {
     expect(savedChart!.indexOf("September 4, 2026")).toBeLessThan(
       savedChart!.indexOf("September 5, 2026"),
     );
-    expect(savedChart).toContain("12 reviews, 9 prices, 4 bottles");
+    expect(savedChart).toContain("12 reviews, 9 prices, 4 catalog listings");
     expect(html).toContain('aria-label="Requests by day"');
     expect(html).toContain("42 requests, 4 runs, 2 failed requests");
     expect(html).toContain("Daily details");
+    expect(html).toContain("Source activity");
+    expect(html).toContain("Catalog listings");
   });
 
   it("omits empty charts", () => {
@@ -76,15 +79,16 @@ describe("ScraperActivity", () => {
           saved: {
             reviews: { total: 0, new: 0, existing: 0 },
             prices: { total: 0, new: 0, existing: 0 },
-            bottles: { total: 0, new: 0, existing: 0 },
+            catalogListings: { total: 0, new: 0, existing: 0 },
           },
+          bottleResolution: { unknown: 0, created: 0, matched: 0 },
           days: [
             {
               date: "2026-09-05",
               ...emptyHealth,
               reviews: 0,
               prices: 0,
-              bottles: 0,
+              catalogListings: 0,
             },
           ],
           recentFailures: [],
@@ -96,7 +100,7 @@ describe("ScraperActivity", () => {
     expect(html).not.toContain('aria-label="Saved items by day"');
   });
 
-  it("explains when runs saved no items", () => {
+  it("keeps an empty run summary compact", () => {
     const html = renderToStaticMarkup(
       <ScraperActivity
         data={{
@@ -104,8 +108,9 @@ describe("ScraperActivity", () => {
           saved: {
             reviews: { total: 0, new: 0, existing: 0 },
             prices: { total: 0, new: 0, existing: 0 },
-            bottles: { total: 0, new: 0, existing: 0 },
+            catalogListings: { total: 0, new: 0, existing: 0 },
           },
+          bottleResolution: { unknown: 0, created: 0, matched: 0 },
           days: [
             {
               date: "2026-09-05",
@@ -113,7 +118,7 @@ describe("ScraperActivity", () => {
               runs: 1,
               reviews: 0,
               prices: 0,
-              bottles: 0,
+              catalogListings: 0,
             },
           ],
           recentFailures: [],
@@ -121,7 +126,9 @@ describe("ScraperActivity", () => {
       />,
     );
 
-    expect(html).toContain("No items saved");
-    expect(html).toContain("No reviews, prices or bottles were saved.");
+    expect(html).toContain("1</dd><dd");
+    expect(html).toContain("No reviews, prices or catalog listings saved.");
+    expect(html).toContain("No scraper activity in the last 30 days.");
+    expect(html).not.toContain('aria-label="Saved items by day"');
   });
 });

--- a/docs/features/moderation-workspace.md
+++ b/docs/features/moderation-workspace.md
@@ -31,6 +31,7 @@ History combines completed listing decisions, reviewed catalog changes, and
 closed checks. Show only facts recorded by those sources. Label a missing actor
 or reason as unavailable.
 
-The admin overview shows live queue totals and recent price-matching results.
-Background work shows retry runs and catalog changes that stopped. It is not a
-measure of decision accuracy and cannot approve a catalog change.
+The admin overview shows live queue totals, recent price-matching results, and
+the current Bottle resolution of review and price inputs added in the last 30
+days. Background work shows retry runs and catalog changes that stopped. It is
+not a measure of decision accuracy and cannot approve a catalog change.


### PR DESCRIPTION
The admin overview now reports Bottle resolution for new reviews and prices from the last 30 days as unknown, newly created Bottles, or matches to existing Bottles. Scraper-produced Bottle rows retain their source meaning under the clearer “Catalog listings” label instead of being presented as new Bottles.

The page is reorganized around operator decisions: Bottle outcomes and live system status lead, recent scraper failures appear before historical activity, and source totals, health, and charts form one compact section. Empty states collapse cleanly, a lone activity chart uses the available width, and populated and quiet Storybook states cover the responsive presentation.
