### PR TITLE
fix(scraper): continue past duplicate bottle conflicts

### DIFF
--- a/apps/server/src/scraper/legacy/scraper.test.ts
+++ b/apps/server/src/scraper/legacy/scraper.test.ts
@@ -146,6 +146,60 @@ describe("handleBottle", () => {
     });
   });
 
+  it("keeps scraping when two Bottles claim the same SMWS cask", async ({
+    fixtures,
+  }) => {
+    const society = await fixtures.Entity({
+      name: "The Scotch Malt Whisky Society",
+      shortName: "SMWS",
+    });
+    const original = await fixtures.Bottle({
+      name: "35.331 Original title",
+      brandId: society.id,
+      bottlerId: society.id,
+      caskNumber: "35.331",
+      singleCask: true,
+    });
+    const duplicate = await fixtures.Bottle({
+      name: "35.331 Current title",
+      brandId: society.id,
+      bottlerId: society.id,
+      caskNumber: "35.331",
+      singleCask: true,
+    });
+    const site = await fixtures.ExternalSiteOrExisting({ type: "smws" });
+
+    await expect(
+      handleBottle(
+        {
+          name: duplicate.name,
+          brand: society.id,
+          bottler: society.id,
+          caskNumber: "35.331",
+          singleCask: true,
+        },
+        priceInput,
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(
+      await db.query.bottles.findMany({
+        orderBy: (table, { asc }) => asc(table.id),
+      }),
+    ).toMatchObject([
+      { id: original.id, name: original.name },
+      { id: duplicate.id, name: duplicate.name },
+    ]);
+    expect(
+      await db.query.storePrices.findFirst({
+        where: and(
+          eq(storePrices.externalSiteId, site.id),
+          eq(storePrices.price, priceInput.price),
+        ),
+      }),
+    ).toMatchObject({ price: priceInput.price });
+  });
+
   it("rejects invalid flat Bottle input before persistence", async () => {
     await expect(handleBottle({ ...bottleInput, name: "" })).rejects.toThrow();
 

--- a/apps/server/src/scraper/legacy/scraper.ts
+++ b/apps/server/src/scraper/legacy/scraper.ts
@@ -16,8 +16,11 @@ import {
 import { createStorePricesAsPeated } from "@peated/server/lib/createStorePrices";
 import { buildBottleCreateInput } from "@peated/server/lib/flatBottleInput";
 import { formatBottleName } from "@peated/server/lib/format";
-import { logError, logInfo } from "@peated/server/lib/log";
-import { updateBottleAsPeated } from "@peated/server/lib/updateBottle";
+import { logError, logInfo, logWarn } from "@peated/server/lib/log";
+import {
+  BottleUpdateConflictError,
+  updateBottleAsPeated,
+} from "@peated/server/lib/updateBottle";
 import { updateBottleImageAsPeated } from "@peated/server/lib/updateBottleImage";
 import type {
   BottleInputSchema,
@@ -184,15 +187,29 @@ export async function persistBottleObservation(
     const backfillPatch = Object.fromEntries(
       Object.entries(bottle).filter(([, value]) => value != null),
     );
-    resultBottle = (
-      await updateBottleAsPeated({
-        bottleId: error.bottleId,
-        input: backfillPatch,
-      })
-    ).bottle;
+    try {
+      resultBottle = (
+        await updateBottleAsPeated({
+          bottleId: error.bottleId,
+          input: backfillPatch,
+        })
+      ).bottle;
+    } catch (updateError) {
+      if (!(updateError instanceof BottleUpdateConflictError)) {
+        throw updateError;
+      }
+      // Only a moderator can decide which duplicate Bottle to keep. Leave both
+      // unchanged, but still save a retailer price because it has its own source.
+      logWarn("Skipped scraped Bottle update because another Bottle matches", {
+        extra: {
+          bottleId: error.bottleId,
+          conflictingBottleId: updateError.conflictingBottleId,
+        },
+      });
+    }
   }
 
-  if (!resultBottle.imageUrl && imageUrl) {
+  if (resultBottle && !resultBottle.imageUrl && imageUrl) {
     try {
       const blob = await downloadFileAsBlob(imageUrl);
       await updateBottleImageAsPeated({


### PR DESCRIPTION
SMWS catalog runs now continue when a scraped cask maps to two existing Bottles. The scraper leaves both records and any ambiguous image unchanged, records their IDs as a warning, and still saves an independent retailer price. Other update failures still stop the run.

This preserves the rule that a moderator must choose which duplicate Bottle to keep while preventing one duplicate from aborting the remaining archive pages. The regression test creates two Bottles with the same cask code and confirms that neither changes while the price persists.

Fixes PEATED-4C3
