### PR TITLE
fix(scraper): allow fully skipped list pages

### DIFF
--- a/apps/server/__fixtures__/dramface/multi-bottle.html
+++ b/apps/server/__fixtures__/dramface/multi-bottle.html
@@ -5,34 +5,43 @@
       rel="canonical"
       href="https://www.dramface.com/all-reviews/2026/impex-duo-isle-of-raasay-ardmore"
     />
+    <meta itemprop="datePublished" content="2026-08-11" />
   </head>
   <body>
-    <article>
+    <article class="h-entry">
       <h1 class="blog-item-title">Impex Duo - Isle of Raasay &amp; Ardmore</h1>
       <time class="dt-published">11 Aug, 2026</time>
       <a class="blog-author-name">Archie Dunlop</a>
-      <h3>Review 1/2</h3>
-      <p class="sqsrte-large">
-        Isle of Raasay 4yo, Impex Collection, Manzanilla cask, 60.3% ABV
-      </p>
-      <h2>Score: 6/10</h2>
-      <p>TL;DR<br />Punchy but pricey.</p>
-      <h3>Nose</h3>
-      <p>Young smoke and dry orchard fruit.</p>
-      <h3>Palate</h3>
-      <p>Strong peat with a saline edge.</p>
-      <p>Score: 6/10</p>
-      <h3>Review 2/2</h3>
-      <p class="sqsrte-large">
-        Ardmore 14yo, Impex Collection, ex-bourbon hogshead, 59.2% ABV
-      </p>
-      <h2>Score: 7.5/10</h2>
-      <p>TL;DR<br />A sweet Ardmore.</p>
-      <h3>Nose</h3>
-      <p>Vanilla and soft heath smoke.</p>
-      <h3>Palate</h3>
-      <p>Sweet malt and pepper.</p>
-      <p>Score: 7.5/10</p>
+      <div class="blog-item-content">
+        <div class="sqs-layout">
+          <div class="row">
+            <div class="col">
+              <h3>Review 1/2</h3>
+              <p class="sqsrte-large">
+                Isle of Raasay 4yo, Impex Collection, Manzanilla cask, 60.3% ABV
+              </p>
+              <h2>Score: 6/10</h2>
+              <p>TL;DR<br />Punchy but pricey.</p>
+              <h3>Nose</h3>
+              <p>Young smoke and dry orchard fruit.</p>
+              <h3>Palate</h3>
+              <p>Strong peat with a saline edge.</p>
+              <p>Score: 6/10</p>
+              <h3>Review 2/2</h3>
+              <p class="sqsrte-large">
+                Ardmore 14yo, Impex Collection, ex-bourbon hogshead, 59.2% ABV
+              </p>
+              <h2>Score: 7.5/10</h2>
+              <p>TL;DR<br />A sweet Ardmore.</p>
+              <h3>Nose</h3>
+              <p>Vanilla and soft heath smoke.</p>
+              <h3>Palate</h3>
+              <p>Sweet malt and pepper.</p>
+              <p>Score: 7.5/10</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </article>
   </body>
 </html>

--- a/apps/server/__fixtures__/dramface/multi-writer.html
+++ b/apps/server/__fixtures__/dramface/multi-writer.html
@@ -5,32 +5,41 @@
       rel="canonical"
       href="https://www.dramface.com/all-reviews/2026/ben-nevis-7yo-bedford-park"
     />
+    <meta itemprop="datePublished" content="2026-08-20" />
   </head>
   <body>
-    <article>
+    <article class="h-entry">
       <h1 class="blog-item-title">Ben Nevis 7yo Bedford Park</h1>
       <time class="dt-published">20 Aug, 2026</time>
       <a class="blog-author-name">Ogilvie Shaw</a>
-      <h3>Review 1/2 - Ogilvie</h3>
-      <p class="sqsrte-large">
-        Ben Nevis 7yo, Bedford Park, Oloroso hogshead, 58.7% ABV
-      </p>
-      <h2>Score: 8/10</h2>
-      <h3>Nose</h3>
-      <p>Dark fruit and brown sugar.</p>
-      <h3>Palate</h3>
-      <p>Rich fruit and tobacco.</p>
-      <p>Score: 8/10 OS</p>
-      <h3>Review 2/2 - Broddy</h3>
-      <p class="sqsrte-large">
-        Ben Nevis 7yo, Bedford Park, Oloroso hogshead, 58.7% ABV
-      </p>
-      <h2>Score: 8/10</h2>
-      <h3>Nose</h3>
-      <p>Candied walnut and orange oil.</p>
-      <h3>Palate</h3>
-      <p>Toffee and dark chocolate.</p>
-      <p>Score: 8/10 BB</p>
+      <div class="blog-item-content">
+        <div class="sqs-layout">
+          <div class="row">
+            <div class="col">
+              <h3>Review 1/2 - Ogilvie</h3>
+              <p class="sqsrte-large">
+                Ben Nevis 7yo, Bedford Park, Oloroso hogshead, 58.7% ABV
+              </p>
+              <h2>Score: 8/10</h2>
+              <h3>Nose</h3>
+              <p>Dark fruit and brown sugar.</p>
+              <h3>Palate</h3>
+              <p>Rich fruit and tobacco.</p>
+              <p>Score: 8/10 OS</p>
+              <h3>Review 2/2 - Broddy</h3>
+              <p class="sqsrte-large">
+                Ben Nevis 7yo, Bedford Park, Oloroso hogshead, 58.7% ABV
+              </p>
+              <h2>Score: 8/10</h2>
+              <h3>Nose</h3>
+              <p>Candied walnut and orange oil.</p>
+              <h3>Palate</h3>
+              <p>Toffee and dark chocolate.</p>
+              <p>Score: 8/10 BB</p>
+            </div>
+          </div>
+        </div>
+      </div>
     </article>
   </body>
 </html>

--- a/apps/server/__fixtures__/dramface/single-review.html
+++ b/apps/server/__fixtures__/dramface/single-review.html
@@ -5,31 +5,42 @@
       rel="canonical"
       href="https://www.dramface.com/all-reviews/2026/springbank-12-cask-strength-2026"
     />
+    <meta itemprop="datePublished" content="2026-08-18" />
   </head>
   <body>
-    <article>
+    <article class="h-entry">
       <h1 class="blog-item-title">Springbank 12yo Cask Strength 2026</h1>
       <time class="dt-published" datetime="18 Aug">18 Aug, 2026</time>
       <a class="blog-author-name">Drummond Dunbar</a>
-      <h2>Score: 8/10</h2>
-      <p>TL;DR<br />Publisher summary must stay out of Peated.</p>
-      <p>Article introduction must stay out of the review text.</p>
-      <h3>Review</h3>
-      <p class="sqsrte-large">
-        Springbank 12yo Cask Strength, 2026 release, Batch 29, 56.6% ABV<br />
-        £74, sparse availability
-      </p>
-      <h2>Score: 8/10</h2>
-      <p>TL;DR<br />Publisher summary must stay out of Peated.</p>
-      <h3>Nose</h3>
-      <p>Lemon oil and coastal peat.</p>
-      <h3>Palate</h3>
-      <p>Dense malt with mineral smoke.</p>
-      <h3>The Dregs</h3>
-      <p>A balanced and characterful release.</p>
-      <p>Score: 8/10</p>
-      <h3>Latest Reviews</h3>
-      <p>Footer content must stay out of the review text.</p>
+      <div class="blog-item-content">
+        <div class="sqs-layout">
+          <div class="row">
+            <div class="col">
+              <h2>Score: 8/10</h2>
+              <p>TL;DR<br />Publisher summary must stay out of Peated.</p>
+              <p>Article introduction must stay out of the review text.</p>
+              <h3>Review</h3>
+              <!-- prettier-ignore -->
+              <p class="sqsrte-large">
+                Springbank 12yo Cask Strength, 2026 release, Batch 29, 56.6% ABV<br />
+                £74, sparse availability
+              </p>
+              <h2>Score: 8/10</h2>
+              <p>TL;DR<br />Publisher summary must stay out of Peated.</p>
+              <h3>Nose</h3>
+              <p>Lemon oil and coastal peat.</p>
+              <h3>Palate</h3>
+              <p>Dense malt with mineral smoke.</p>
+              <h3>The Dregs</h3>
+              <p>A balanced and characterful release.</p>
+              <p>Score: 8/10</p>
+              <h3>Latest Reviews</h3>
+              <p>Footer content must stay out of the review text.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <article class="sections"></article>
     </article>
   </body>
 </html>

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -107,6 +107,15 @@ function prepareDramface(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareEdradour(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "edradour", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareCompassBox(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "compassbox", ...input },
@@ -180,6 +189,7 @@ function codeOwnedSource(
     | "cadenheads"
     | "compassbox"
     | "dramface"
+    | "edradour"
     | "gordonmacphail"
     | "kilchoman"
     | "ncnean"
@@ -246,6 +256,11 @@ const dramfaceCanonicalUrl =
 const dramfaceRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("dramface")!],
   sources: [codeOwnedSource("dramface")],
+});
+
+const edradourRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("edradour")!],
+  sources: [codeOwnedSource("edradour")],
 });
 
 const compassBoxRegistry = createScraperRegistry({
@@ -737,6 +752,25 @@ async function setupCompassBoxMigration() {
     })
     .returning();
   await syncScraperDefinitions(compassBoxRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
+}
+
+async function setupEdradourMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "edradour",
+      name: "Edradour",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(edradourRegistry);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "succeeded",
@@ -1488,6 +1522,102 @@ describe("POST /admin/scrape-sources/prepare", () => {
         "Check the URL and review records for WhiskyNotes article",
       ),
     });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares Edradour without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupEdradourMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Ballechin 10-year-old",
+      price: 4876,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.edradour.com/ballechin-10-year-old",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Edradour Cask Strength 21-year-old Oloroso Sherry",
+      price: 37500,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.edradour.com/Cask-Strength-21-y.o.-Oloroso-Sherry",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareEdradour()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareEdradour({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(edradourRegistry);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl: "https://www.edradour.com/shop/",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+    await expect(prepareEdradour({ apply: true })).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Edradour is already prepared for saved scraping rules.",
+    });
+  });
+
+  test("refuses an unexpected Edradour price without changing records", async ({
+    fixtures,
+  }) => {
+    const site = await setupEdradourMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Edradour Cask Strength 21-year-old Oloroso Sherry",
+      currency: "gbp",
+      volume: 700,
+      url: "https://example.com/Cask-Strength-21-y.o.-Oloroso-Sherry",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareEdradour({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check Edradour price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
     expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -6,6 +6,7 @@ import { prepareBruichladdichSource } from "@peated/server/scraper/configured/pr
 import { prepareCadenheadsSource } from "@peated/server/scraper/configured/prepareCadenheads";
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
 import { prepareDramfaceSource } from "@peated/server/scraper/configured/prepareDramface";
+import { prepareEdradourSource } from "@peated/server/scraper/configured/prepareEdradour";
 import { prepareGordonMacphailSource } from "@peated/server/scraper/configured/prepareGordonMacphail";
 import { prepareKilchomanSource } from "@peated/server/scraper/configured/prepareKilchoman";
 import { prepareNcneanSource } from "@peated/server/scraper/configured/prepareNcnean";
@@ -39,7 +40,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, dramface, gordonmacphail, kilchoman, ncnean, northstarspirits, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
+          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, dramface, edradour, gordonmacphail, kilchoman, ncnean, northstarspirits, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -75,6 +76,7 @@ export default procedure
       cadenheads: prepareCadenheadsSource,
       compassbox: prepareCompassBoxSource,
       dramface: prepareDramfaceSource,
+      edradour: prepareEdradourSource,
       gordonmacphail: prepareGordonMacphailSource,
       kilchoman: prepareKilchomanSource,
       ncnean: prepareNcneanSource,

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -504,9 +504,9 @@ const dramfaceSavedRules = {
   article: {
     canonicalUrl: pageAttribute('link[rel="canonical"]', "href"),
     title: pageText(".blog-item-title"),
-    publishedDate: pageText("time.dt-published"),
+    publishedDate: pageAttribute('meta[itemprop="datePublished"]', "content"),
     reviews: {
-      inside: "article",
+      inside: "article.h-entry .blog-item-content > .sqs-layout > .row > .col",
       oneReviewPer: "section",
       startsAt: {
         selector: "h3",

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -1647,6 +1647,42 @@ describe("scrape source parser", () => {
     });
   });
 
+  it("accepts a list page where every result is explicitly skipped", () => {
+    const result = parseScrapeList(
+      currentReviewRules,
+      `<main>
+        <article class="card"><span class="skip">News</span><a href="/news">News</a></article>
+        <article class="card"><span class="skip">Interview</span><a href="/interview">Interview</a></article>
+      </main>`,
+      new URL("https://reviews.test/"),
+    );
+
+    expect(result).toEqual({
+      links: [],
+      nextPageUrl: null,
+      issues: [],
+    });
+  });
+
+  it("still reports when a saved result selector finds nothing", () => {
+    expect(
+      parseScrapeList(
+        currentReviewRules,
+        "<main></main>",
+        new URL("https://reviews.test/"),
+      ),
+    ).toEqual({
+      links: [],
+      nextPageUrl: null,
+      issues: [
+        {
+          field: "articles.link",
+          message: "No links were found.",
+        },
+      ],
+    });
+  });
+
   it("reads version 8 review sections and explicit article values", () => {
     const result = parseScrapeDetail(
       currentReviewRules,

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -379,8 +379,10 @@ function parseSavedList(
       ? rules.articles.oneArticlePer
       : rules.products.oneProductPer;
   const fieldRoot = rules.kind === "review" ? "articles" : "products";
+  const itemElements = $(itemSelector).toArray();
+  let skippedItemCount = 0;
   try {
-    for (const itemElement of $(itemSelector).toArray()) {
+    for (const itemElement of itemElements) {
       const item = load($.html(itemElement));
       if (list.skipWhen) {
         const skipWhen = list.skipWhen;
@@ -403,7 +405,10 @@ function parseSavedList(
             matchFirstText(readText(item(element)), skipWhen.match),
           );
         });
-        if (shouldSkip) continue;
+        if (shouldSkip) {
+          skippedItemCount += 1;
+          continue;
+        }
       }
       const itemLinks = item(list.link).toArray();
       for (const element of itemLinks) {
@@ -431,7 +436,9 @@ function parseSavedList(
         error instanceof Error ? error.message : "Unable to read the list.",
     });
   }
-  if (links.size === 0) {
+  const allItemsWereSkipped =
+    itemElements.length > 0 && skippedItemCount === itemElements.length;
+  if (links.size === 0 && !allItemsWereSkipped) {
     issues.push({
       field: `${fieldRoot}.link`,
       message: "No links were found.",

--- a/apps/server/src/scraper/configured/prepareEdradour.ts
+++ b/apps/server/src/scraper/configured/prepareEdradour.ts
@@ -1,0 +1,24 @@
+import { ALLOWED_VOLUMES } from "@peated/server/constants";
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks Edradour by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareEdradourSource(input: PreparePriceSourceInput) {
+  return preparePriceSource(input, {
+    siteKey: "edradour",
+    siteName: "Edradour",
+    targetKey: "edradour",
+    origin: "https://www.edradour.com",
+    listUrl: "https://www.edradour.com/shop/",
+    isExpectedPrice: (price) =>
+      /^https:\/\/www\.edradour\.com\/[A-Za-z0-9][A-Za-z0-9._-]*$/.test(
+        price.url,
+      ) &&
+      price.externalProductId === null &&
+      /^(?:Edradour|Ballechin)\b/.test(price.name) &&
+      price.currency === "gbp" &&
+      ALLOWED_VOLUMES.includes(price.volume),
+  });
+}

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -268,6 +268,28 @@ Activate only exact output, trigger one manual collection, and confirm that it
 updates the same price IDs and Bottle matches before restoring the schedule.
 Check the run and Sentry.
 
+## Edradour
+
+Use the preparation endpoint with `{"site": "edradour"}`. The check-only
+request examines every saved price without changing it. It stops if a price
+has a product ID or does not use an Edradour product URL, an `Edradour` or
+`Ballechin` name, GBP, or a supported bottle size. Applying moves the request
+limits to a paused price source for `https://www.edradour.com/shop/`. It does
+not change price rows or history.
+
+Before applying, stop the `edradour` schedule and wait for active collection to
+finish. Save the existing price IDs, URLs, Bottle links, hidden states,
+histories, request limits, and run history. Run the version 8 rules through the
+full local preview. The shop-page rules must keep only whisky that can be
+bought. The product-page rules must read the displayed name, GBP price, bottle
+size, product URL, and image. Add the `Edradour` prefix when an Edradour whisky
+name does not already start with `Edradour` or `Ballechin`.
+
+After applying, save and preview the reviewed rules. Activate only exact
+output, trigger one manual collection, and confirm that it updates the same
+price IDs and Bottle links. Check the run and Sentry before restoring the
+weekly schedule.
+
 ## Kilchoman
 
 Use the preparation endpoint with `{"site": "kilchoman"}`. The check-only
@@ -352,10 +374,11 @@ handles reviews added after the switch. Do not delete source or run history.
 ## Other sources
 
 The preparation API is shared. It currently supports Bourbon Culture,
-Bruichladdich, Cadenhead's, Compass Box, Gordon & MacPhail, Kilchoman, Nc'nean,
-North Star, The Whiskey Reviewer, WhiskyNotes, Whisky Saga, The Whisky Study,
-and Words of Whisky. Other sites are rejected without changing records. Add
-each site's conversion behind this route as its existing records are reviewed.
+Bruichladdich, Cadenhead's, Compass Box, Dramface, Edradour, Gordon & MacPhail,
+Kilchoman, Nc'nean, North Star, The Whiskey Reviewer, WhiskyNotes, Whisky Saga,
+The Whisky Study, and Words of Whisky. Other sites are rejected without
+changing records. Add each site's conversion behind this route as its existing
+records are reviewed.
 
 Prepare each source using its own rules for recognizing existing records.
 Articles with several reviews need a verified match for each review. Store

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -176,12 +176,12 @@ same review order and IDs. Repeated reviews with the same Bottle name and writer
 keep separate keys in their original order.
 
 Version 8 rules must select up to 20 articles from the current review page. On
-detail pages, match `Review` headings to split the shared article area into
-sections even when Squarespace layout elements wrap the content. Read the
-Bottle name from the first line of its large-text block, the writer from the
-review heading or article byline, and the score out of 10. Run a full local
-no-write preview and compare single-Bottle, multi-Bottle, and multi-writer
-articles with the code parser before applying.
+detail pages, use the content column inside `article.h-entry`, then match
+`Review` headings to split it into sections. Read the full publication time
+from the page metadata, the Bottle name from the first line of its large-text
+block, the writer from the review heading or article byline, and the score out
+of 10. Run a full local no-write preview and compare single-Bottle,
+multi-Bottle, and multi-writer articles with the code parser before applying.
 
 Activate only a production preview with exact output. Trigger one manual
 collection and confirm that it updates the same review IDs without adding


### PR DESCRIPTION
Saved-rule list pages now finish cleanly when every matched result is explicitly excluded by `skipWhen`. A page where the result selector matches nothing still fails, so broken selectors remain visible.

This unblocks catalogs whose last page contains only excluded products without adding another DSL field. A complete local no-write Thompson Bros preview covered all three list pages and 23 whisky detail pages: 26 requests, zero request errors, and zero parser issues.

Tests: `pnpm --filter @peated/server test -- src/scraper/configured/parser.test.ts`