### PR TITLE
fix(admin): clarify catalog summary rebuild

### DIFF
--- a/apps/server/src/orpc/routes/admin/index.ts
+++ b/apps/server/src/orpc/routes/admin/index.ts
@@ -2,13 +2,13 @@ import { base } from "../..";
 import catalogCoverage from "./catalog-coverage";
 import moderation from "./moderation";
 import oauthClients from "./oauth-clients";
-import repairBottleCounts from "./repair-bottle-counts";
+import rebuildCatalogSummaries from "./rebuild-catalog-summaries";
 import scraperActivity from "./scraper-activity";
 
 export default base.tag("admin").router({
   catalogCoverage,
   moderation,
   oauthClients,
-  repairBottleCounts,
+  rebuildCatalogSummaries,
   scraperActivity,
 });

--- a/apps/server/src/orpc/routes/admin/rebuild-catalog-summaries.test.ts
+++ b/apps/server/src/orpc/routes/admin/rebuild-catalog-summaries.test.ts
@@ -2,7 +2,7 @@ import waitError from "@peated/server/lib/test/waitError";
 import { pushUniqueJob } from "@peated/server/lib/test/workerDispatch";
 import { routerClient } from "@peated/server/orpc/router";
 
-describe("POST /admin/catalog/repair-bottle-counts", () => {
+describe("POST /admin/catalog/rebuild-summaries", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -13,7 +13,10 @@ describe("POST /admin/catalog/repair-bottle-counts", () => {
     const admin = await fixtures.User({ admin: true });
 
     await expect(
-      routerClient.admin.repairBottleCounts({}, { context: { user: admin } }),
+      routerClient.admin.rebuildCatalogSummaries(
+        {},
+        { context: { user: admin } },
+      ),
     ).resolves.toEqual({ status: "queued" });
     expect(pushUniqueJob).toHaveBeenCalledTimes(6);
     expect(pushUniqueJob).toHaveBeenNthCalledWith(
@@ -71,7 +74,7 @@ describe("POST /admin/catalog/repair-bottle-counts", () => {
 
     await expect(
       waitError(
-        routerClient.admin.repairBottleCounts({}, { context: { user } }),
+        routerClient.admin.rebuildCatalogSummaries({}, { context: { user } }),
       ),
     ).resolves.toMatchObject({ message: "Unauthorized." });
     expect(pushUniqueJob).not.toHaveBeenCalled();

--- a/apps/server/src/orpc/routes/admin/rebuild-catalog-summaries.ts
+++ b/apps/server/src/orpc/routes/admin/rebuild-catalog-summaries.ts
@@ -7,11 +7,11 @@ export default procedure
   .use(requireAdmin)
   .route({
     method: "POST",
-    path: "/admin/catalog/repair-bottle-counts",
-    summary: "Repair saved bottle counts",
+    path: "/admin/catalog/rebuild-summaries",
+    summary: "Rebuild saved catalog summaries",
     description:
-      "Check saved bottle totals and fix any that are wrong. Requires administrator privileges.",
-    operationId: "repairBottleCounts",
+      "Rebuild saved Bottle ratings, flavor notes, and catalog totals. Requires administrator privileges.",
+    operationId: "rebuildCatalogSummaries",
   })
   .input(z.object({}).strict().default({}))
   .output(z.object({ status: z.literal("queued") }).strict())

--- a/apps/web/e2e/maintenance.spec.ts
+++ b/apps/web/e2e/maintenance.spec.ts
@@ -3,7 +3,11 @@ import { expect, test } from "./test";
 import { adminUser } from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 
-test("runs the Bottle count repair", async ({ context, page, snapshot }) => {
+test("runs the catalog summary rebuild", async ({
+  context,
+  page,
+  snapshot,
+}) => {
   await signIn(context, {
     user: adminUser,
   });
@@ -14,15 +18,17 @@ test("runs the Bottle count repair", async ({ context, page, snapshot }) => {
     page.getByRole("heading", { name: "Maintenance", exact: true }),
   ).toBeVisible();
   await snapshot("admin/maintenance", {
-    ready: page.getByRole("button", { name: "Check Bottle counts" }),
+    ready: page.getByRole("button", { name: "Rebuild catalog summaries" }),
   });
 
-  const bottleCountRequest = page.waitForRequest((request) =>
-    request.url().includes("/rpc/admin/repairBottleCounts"),
+  const catalogSummaryRequest = page.waitForRequest((request) =>
+    request.url().includes("/rpc/admin/rebuildCatalogSummaries"),
   );
-  await page.getByRole("button", { name: "Check Bottle counts" }).click();
-  await bottleCountRequest;
-  await expect(page.getByText("Bottle count check started.")).toBeVisible();
+  await page.getByRole("button", { name: "Rebuild catalog summaries" }).click();
+  await catalogSummaryRequest;
+  await expect(
+    page.getByText("Catalog summary rebuild started."),
+  ).toBeVisible();
 });
 
 test("@mobile shows Maintenance", async ({ context, page, snapshot }) => {
@@ -33,6 +39,6 @@ test("@mobile shows Maintenance", async ({ context, page, snapshot }) => {
   await page.goto("/admin/maintenance");
 
   await snapshot("admin/maintenance-mobile", {
-    ready: page.getByRole("button", { name: "Check Bottle counts" }),
+    ready: page.getByRole("button", { name: "Rebuild catalog summaries" }),
   });
 });

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -706,7 +706,7 @@ async function handleRpcRequest({ request, response, url }) {
       sendRpcResponse(response, bottle);
       return true;
     }
-    case "admin/repairBottleCounts":
+    case "admin/rebuildCatalogSummaries":
       sendRpcResponse(response, { status: "queued" });
       return true;
     case "admin/moderation/listTasks": {

--- a/apps/web/src/app/(admin)/admin/(default)/maintenance/maintenancePage.stylex.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/maintenance/maintenancePage.stylex.tsx
@@ -18,22 +18,26 @@ import { space } from "../../../../../styles/tokens.stylex";
 
 export default function MaintenancePage() {
   const orpc = useORPC();
-  const bottleCountRepair = useMutation(
-    orpc.admin.repairBottleCounts.mutationOptions(),
+  const catalogSummaryRebuild = useMutation(
+    orpc.admin.rebuildCatalogSummaries.mutationOptions(),
   );
-  const [bottleCountError, setBottleCountError] = useState<string | null>(null);
-  const [bottleCountNotice, setBottleCountNotice] = useState<string | null>(
+  const [catalogSummaryError, setCatalogSummaryError] = useState<string | null>(
     null,
   );
+  const [catalogSummaryNotice, setCatalogSummaryNotice] = useState<
+    string | null
+  >(null);
 
-  async function startBottleCountRepair() {
-    setBottleCountError(null);
-    setBottleCountNotice(null);
+  async function startCatalogSummaryRebuild() {
+    setCatalogSummaryError(null);
+    setCatalogSummaryNotice(null);
     try {
-      await bottleCountRepair.mutateAsync({});
-      setBottleCountNotice("Bottle count check started.");
+      await catalogSummaryRebuild.mutateAsync({});
+      setCatalogSummaryNotice("Catalog summary rebuild started.");
     } catch {
-      setBottleCountError("The Bottle count check could not start. Try again.");
+      setCatalogSummaryError(
+        "The catalog summary rebuild could not start. Try again.",
+      );
     }
   }
 
@@ -55,25 +59,25 @@ export default function MaintenancePage() {
       />
 
       <AdminSection
-        title="Bottle counts"
-        description="Check saved Bottle counts and fix any that are wrong. Bottle editing can continue while this runs."
+        title="Catalog summaries"
+        description="Rebuild saved Bottle ratings, flavor notes, and catalog totals. Bottle editing can continue while this runs."
       >
         <div {...stylex.props(styles.sectionContent)}>
           <div {...stylex.props(styles.actionRow)}>
             <Button
-              disabled={bottleCountRepair.isPending}
-              loading={bottleCountRepair.isPending}
-              onClick={() => void startBottleCountRepair()}
+              disabled={catalogSummaryRebuild.isPending}
+              loading={catalogSummaryRebuild.isPending}
+              onClick={() => void startCatalogSummaryRebuild()}
               variant="default"
             >
-              Check Bottle counts
+              Rebuild catalog summaries
             </Button>
           </div>
-          {bottleCountNotice ? (
-            <Alert type="success">{bottleCountNotice}</Alert>
+          {catalogSummaryNotice ? (
+            <Alert type="success">{catalogSummaryNotice}</Alert>
           ) : null}
-          {bottleCountError ? (
-            <Alert type="error">{bottleCountError}</Alert>
+          {catalogSummaryError ? (
+            <Alert type="error">{catalogSummaryError}</Alert>
           ) : null}
         </div>
       </AdminSection>

--- a/docs/architecture/ratings.md
+++ b/docs/architecture/ratings.md
@@ -224,7 +224,7 @@ finishes. This includes member review writes, tasting band changes, external
 review imports, moderation changes, assignments, and review publication
 changes. Large publication changes queue work in batches.
 
-Use **Bottle counts** on Admin → Maintenance to rebuild active Bottle,
+Use **Catalog summaries** on Admin → Maintenance to rebuild active Bottle,
 BottleGroup, and Entity summaries. The repair queues active Bottles in bounded,
 resumable pages and also checks each saved external score count against the
 shared external-review rule.


### PR DESCRIPTION
The Maintenance action now says what it actually rebuilds: saved Bottle ratings, flavor notes, and catalog totals. The page, success and error messages, documentation, browser fixture, and protected admin route all use “Catalog summaries” instead of the narrower “Bottle counts.”

The protected admin RPC changes from `repairBottleCounts` to `rebuildCatalogSummaries`; the web caller ships with the same change. The underlying repair jobs and saved data are unchanged.
