### PR TITLE
fix(web): handle older entity count responses

### DIFF
--- a/apps/web/src/app/(app)/locations/locationLists.tsx
+++ b/apps/web/src/app/(app)/locations/locationLists.tsx
@@ -7,6 +7,7 @@ import {
   LoadingPlaceholder,
   type DataTableColumn,
 } from "@peated/web/components";
+import { getEntityReviewAndTastingCount } from "@peated/web/lib/entityCatalogItem";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
 type LocationListItem = {
@@ -129,7 +130,8 @@ const distillerColumns: DataTableColumn<Entity>[] = [
   },
   {
     align: "right",
-    cell: (item) => item.publicReviewAndTastingCount.toLocaleString("en-US"),
+    cell: (item) =>
+      getEntityReviewAndTastingCount(item).toLocaleString("en-US"),
     header: "Reviews & tastings",
     key: "tastings",
     priority: "secondary",

--- a/apps/web/src/lib/entityCatalogItem.test.ts
+++ b/apps/web/src/lib/entityCatalogItem.test.ts
@@ -1,0 +1,27 @@
+import { mockEntity } from "@peated/server/orpc/mock/fixtures";
+import { describe, expect, it } from "vitest";
+
+import {
+  getEntityReviewAndTastingCount,
+  toEntityCatalogItem,
+} from "./entityCatalogItem";
+
+describe("entity catalog items", () => {
+  it("uses the combined public count", () => {
+    expect(
+      getEntityReviewAndTastingCount({
+        publicReviewAndTastingCount: 18,
+        totalTastings: 12,
+      }),
+    ).toBe(18);
+  });
+
+  it("uses the tasting count from an older response", () => {
+    const { publicReviewAndTastingCount: _newCount, ...olderEntity } =
+      mockEntity;
+
+    expect(toEntityCatalogItem(olderEntity)).toMatchObject({
+      publicReviewAndTastingCount: mockEntity.totalTastings,
+    });
+  });
+});

--- a/apps/web/src/lib/entityCatalogItem.ts
+++ b/apps/web/src/lib/entityCatalogItem.ts
@@ -6,8 +6,22 @@ import { getEntityUrl } from "@peated/web/lib/urls";
 
 import { getEntityIdentityProps } from "./entityIdentity";
 
+type EntityWithOptionalPublicCount = Omit<
+  Entity,
+  "publicReviewAndTastingCount"
+> &
+  Partial<Pick<Entity, "publicReviewAndTastingCount">>;
+
+export function getEntityReviewAndTastingCount(
+  entity: Pick<Entity, "totalTastings"> &
+    Partial<Pick<Entity, "publicReviewAndTastingCount">>,
+) {
+  // TODO(api-rollout): Remove this fallback after API releases without the combined count are retired.
+  return entity.publicReviewAndTastingCount ?? entity.totalTastings;
+}
+
 export function toEntityCatalogItem(
-  entity: Entity,
+  entity: EntityWithOptionalPublicCount,
   isFollowing = entity.isFollowing,
 ): EntityCatalogItem {
   return {
@@ -17,6 +31,6 @@ export function toEntityCatalogItem(
     id: entity.id,
     isFollowing,
     totalBottles: entity.totalBottles,
-    publicReviewAndTastingCount: entity.publicReviewAndTastingCount,
+    publicReviewAndTastingCount: getEntityReviewAndTastingCount(entity),
   };
 }


### PR DESCRIPTION
Entity lists now fall back to the existing tasting count when an API response predates the combined review-and-tasting count. This prevents the entity catalog and location distiller list from crashing while web and API deployments overlap; current responses continue to use the combined public count.

The fallback is limited to this renamed count and can be removed after older API releases are retired.

Fixes PEATED-4H6
