### PR TITLE
docs(catalog): record SMWS reference repair

### DIFF
--- a/docs/research/catalog-research-examples-2026-09.md
+++ b/docs/research/catalog-research-examples-2026-09.md
@@ -555,6 +555,33 @@ approved all twelve exact matches. The final queue counts for both
   removed after explicit deletion approval. No replacement was uploaded because
   the exact Batch #1 sources did not state reusable image rights.
 
+## SMWS 19.90 reference repair — September 6, 2026
+
+This narrow production repair covered the conflicting SMWS 19.90 and 19.91
+Bottle identities reported by the archive scraper. It was not a full SMWS
+catalog audit. Two active Bottles needed no field or image changes, and one
+legacy import reference was quarantined. No Bottle was merged or deleted.
+
+- SMWS's exact product pages identify
+  [19.90 as Chilled toddy](https://smws.com/chilled-toddy/) and
+  [19.91 as Soul warming](https://smws.com/soul-warming/). The producer
+  [archive](https://smws.com/archive?limit=60&page=11&whisky_flavour=77) lists
+  the releases next to one another with those same codes and titles. These
+  sources prove that “SMWS 19.90 Soul warming” mixes the code from one release
+  with the subtitle from the other; it is not a historical title for either
+  Bottle.
+- B38302 remains the active 19.90 Chilled toddy Bottle, and B30107 remains the
+  active 19.91 Soul warming Bottle. Retired Bottle ID 29597 still resolves to
+  B30107, preserving its redirect and consumer history.
+- BottleReference 22362 was detached from B30107 and marked ignored so the
+  invalid combined name cannot claim cask 19.90 again. Its stable ID and audit
+  history were retained. Reference 3609 remains assigned to B38302, while
+  references 22368 and 11629 remain assigned to B30107.
+- Final production searches returned exactly one Bottle for each Society code:
+  B38302 for 19.90 and B30107 for 19.91. The invalid exact name had no matching
+  price or external-review records, and neither Bottle had member reviews or
+  tastings that needed inspection for reassignment.
+
 ## Laphroaig — September 6, 2026
 
 This review expanded from the current range and annual families into the named

--- a/docs/research/catalog-research-sources-2026-09.md
+++ b/docs/research/catalog-research-sources-2026-09.md
@@ -84,6 +84,9 @@ automatically. See the
 - Specialist-catalog bottler abbreviations such as Whiskybase's `Gs` are source
   notation, not marketed Bottle names. Keep them only as import references, and
   check for collisions before treating the complete reference as exact.
+- An SMWS cask code owns the release identity. A legacy reference that combines
+  one release's code with another release's subtitle is not evidence of an old
+  title; verify both parts against exact producer pages before assigning it.
 - Collector indexes can contain fabricated or misidentified lead entries. Verify
   the exact label against an independent auction, producer, or retailer source
   before creating a Bottle; a plausible old date and name are not evidence.


### PR DESCRIPTION
Records the evidence and post-write verification for quarantining legacy BottleReference 22362, which incorrectly combined the SMWS 19.90 cask code with the 19.91 subtitle. The catalog notes preserve the affected Bottle and reference IDs, confirm that redirects and consumers remain intact, and add a reusable warning to verify both parts of an SMWS identity before assigning old references.
