### PR TITLE
fix(scraper): resume saved runs between requests

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -2733,6 +2733,26 @@ describe("POST /admin/scrape-sources/prepare", () => {
       },
       random: () => 0,
     };
+    const completeRun = async (runId: number, executionToken: string) => {
+      let execution = 1;
+      while (true) {
+        const result = await executeScraperRun(
+          { runId },
+          {
+            registry,
+            fetchImpl,
+            clock,
+            executionToken: `${executionToken}-${execution}`,
+          },
+        );
+        if (result.status === "completed") return result;
+        if (!("nextAttemptAt" in result)) {
+          throw new Error("The saved scraper is already running.");
+        }
+        now = result.nextAttemptAt;
+        execution += 1;
+      }
+    };
     for (let attempt = 0; attempt < 2; attempt++) {
       await db
         .update(externalSites)
@@ -2754,15 +2774,7 @@ describe("POST /admin/scrape-sources/prepare", () => {
         }),
       ]);
       await expect(
-        executeScraperRun(
-          { runId: run.id },
-          {
-            registry,
-            fetchImpl,
-            clock,
-            executionToken: `migration-${attempt}`,
-          },
-        ),
+        completeRun(run.id, `migration-${attempt}`),
       ).resolves.toEqual({ status: "completed" });
     }
     expect(await db.select().from(externalReviewArticles)).toHaveLength(1);

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -63,9 +63,8 @@ must share one request limit. A target may list several web addresses when that
 organization uses more than one host. Do not group sites from their domain
 names alone.
 
-Set `requestsPerHour` for each target. The scraper waits between requests so
-they fill the hour evenly: 60 per hour means one request per minute. A value
-above 60 needs a short reason.
+Set `requestsPerHour` for each target. Requests are spread evenly across the
+hour: 60 means one request per minute. A value above 60 needs a short reason.
 
 ## Scrape sources
 
@@ -308,9 +307,9 @@ Every network attempt, including robots refreshes and retries, requires a SQL
 permit and consumes the current slice budget. Response bodies are streamed
 within the configured bound and are never stored by the runtime.
 
-A run may be claimed for at most ten execution slices and may remain active for
-at most 24 hours. The claim boundary fails older work before another adapter or
-network execution so a bad cursor or permanent deferral cannot live forever.
+A planned wait between saved-rule requests does not count toward the
+ten-attempt safety limit. Other restarts do. Every run must finish within 24
+hours, so a bad cursor or permanent delay cannot live forever.
 
 ## Bot identity
 

--- a/apps/server/src/scraper/adapters/fixture.ts
+++ b/apps/server/src/scraper/adapters/fixture.ts
@@ -7,7 +7,7 @@ export const FixtureCursorSchema = z
 export const FixtureObservationSchema = z
   .object({ id: z.string().min(1), value: z.string() })
   .strict();
-const FixturePageSchema = z
+export const FixturePageSchema = z
   .object({
     items: z.array(FixtureObservationSchema),
     nextPage: z.number().int().positive().nullable(),

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -34,7 +34,9 @@ import {
   recordScrapeSourcePreview,
 } from "./service";
 
-function fixedClock(): ScraperHttpClock {
+type TestClock = ScraperHttpClock & { advanceTo(value: Date): void };
+
+function fixedClock(): TestClock {
   let now = new Date("2026-08-28T12:00:00Z");
   return {
     now: () => now,
@@ -42,21 +44,41 @@ function fixedClock(): ScraperHttpClock {
       now = new Date(now.getTime() + milliseconds);
     },
     random: () => 0,
-  };
-}
-
-function controllableClock() {
-  let now = new Date("2026-08-28T12:00:00Z");
-  return {
-    now: () => now,
-    sleep: async (milliseconds: number) => {
-      now = new Date(now.getTime() + milliseconds);
-    },
-    random: () => 0,
     advanceTo: (value: Date) => {
       now = value;
     },
   };
+}
+
+async function runToCompletion({
+  runId,
+  fetchImpl,
+  clock = fixedClock(),
+  executionToken,
+}: {
+  runId: number;
+  fetchImpl: typeof fetch;
+  clock?: TestClock;
+  executionToken: string;
+}) {
+  const registry = createScraperRegistry({ targets: [], sources: [] });
+  for (let attempt = 1; attempt <= 20; attempt += 1) {
+    const result = await executeScraperRun(
+      { runId },
+      {
+        registry,
+        fetchImpl,
+        clock,
+        executionToken: `${executionToken}-${attempt}`,
+      },
+    );
+    if (result.status === "completed") return result;
+    if (!("nextAttemptAt" in result)) {
+      throw new Error("The test run is already owned by another execution.");
+    }
+    clock.advanceTo(result.nextAttemptAt);
+  }
+  throw new Error("The test run did not finish within 20 executions.");
 }
 
 function reviewRules(titleSelector = "h1", paginate = false) {
@@ -321,15 +343,11 @@ function previewFetch(paginate = false) {
 test("runs preview through the normal request controls without product writes", async () => {
   const { pinned, revision } = await setupPreview();
   await expect(
-    executeScraperRun(
-      { runId: pinned.run.id },
-      {
-        registry: createScraperRegistry({ targets: [], sources: [] }),
-        fetchImpl: previewFetch(),
-        clock: fixedClock(),
-        executionToken: "preview-owner",
-      },
-    ),
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl: previewFetch(),
+      executionToken: "preview-owner",
+    }),
   ).resolves.toEqual({ status: "completed" });
 
   const [storedRevision] = await db
@@ -361,15 +379,11 @@ test("previews an official catalog without writing listings", async () => {
   });
 
   await expect(
-    executeScraperRun(
-      { runId: pinned.run.id },
-      {
-        registry: createScraperRegistry({ targets: [], sources: [] }),
-        fetchImpl: catalogFetch(),
-        clock: fixedClock(),
-        executionToken: "catalog-preview-owner",
-      },
-    ),
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl: catalogFetch(),
+      executionToken: "catalog-preview-owner",
+    }),
   ).resolves.toEqual({ status: "completed" });
 
   const [storedRevision] = await db
@@ -429,15 +443,11 @@ test("collects and updates only catalog listings", async () => {
       purpose: "collect",
     });
     await expect(
-      executeScraperRun(
-        { runId: pinned.run.id },
-        {
-          registry: createScraperRegistry({ targets: [], sources: [] }),
-          fetchImpl: catalogFetch(name),
-          clock: fixedClock(),
-          executionToken: `catalog-collection-owner-${index}`,
-        },
-      ),
+      runToCompletion({
+        runId: pinned.run.id,
+        fetchImpl: catalogFetch(name),
+        executionToken: `catalog-collection-owner-${index}`,
+      }),
     ).resolves.toEqual({ status: "completed" });
   }
 
@@ -484,15 +494,11 @@ test("keeps a catalog product that is absent from a later run", async () => {
       trigger: "manual",
       purpose: "collect",
     });
-    await executeScraperRun(
-      { runId: pinned.run.id },
-      {
-        registry: createScraperRegistry({ targets: [], sources: [] }),
-        fetchImpl: catalogProductsFetch(products),
-        clock: fixedClock(),
-        executionToken,
-      },
-    );
+    await runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl: catalogProductsFetch(products),
+      executionToken,
+    });
   };
 
   const firstProducts = [
@@ -524,15 +530,11 @@ test("follows a bounded next-page selector", async () => {
   const fetchImpl = previewFetch(true);
 
   await expect(
-    executeScraperRun(
-      { runId: pinned.run.id },
-      {
-        registry: createScraperRegistry({ targets: [], sources: [] }),
-        fetchImpl,
-        clock: fixedClock(),
-        executionToken: "pagination-owner",
-      },
-    ),
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl,
+      executionToken: "pagination-owner",
+    }),
   ).resolves.toEqual({ status: "completed" });
 
   const [storedRevision] = await db
@@ -548,47 +550,15 @@ test("follows a bounded next-page selector", async () => {
   });
 });
 
-test("resumes configured previews without rereading completed pages", async () => {
+test("resumes configured previews between spaced requests", async () => {
   const { pinned, revision } = await setupPreview("h1", true);
-  await db
-    .update(externalSiteRuns)
-    .set({ requestLimit: 3 })
-    .where(eq(externalSiteRuns.id, pinned.run.id));
   const fetchImpl = previewFetch(true);
-  const clock = controllableClock();
-
-  const first = await executeScraperRun(
-    { runId: pinned.run.id },
-    {
-      registry: createScraperRegistry({ targets: [], sources: [] }),
-      fetchImpl,
-      clock,
-      executionToken: "first-preview-owner",
-    },
-  );
-  expect(first.status).toBe("deferred");
-  if (!("nextAttemptAt" in first)) throw new Error("Expected deferral.");
-
-  const [deferred] = await db
-    .select()
-    .from(externalSiteRuns)
-    .where(eq(externalSiteRuns.id, pinned.run.id));
-  expect(deferred?.cursor).toMatchObject({
-    detailIndex: 1,
-    previewPages: [{ url: "https://preview.example/one" }],
-  });
-
-  clock.advanceTo(first.nextAttemptAt);
   await expect(
-    executeScraperRun(
-      { runId: pinned.run.id },
-      {
-        registry: createScraperRegistry({ targets: [], sources: [] }),
-        fetchImpl,
-        clock,
-        executionToken: "second-preview-owner",
-      },
-    ),
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl,
+      executionToken: "preview-owner",
+    }),
   ).resolves.toEqual({ status: "completed" });
 
   const [storedRevision] = await db
@@ -607,20 +577,21 @@ test("resumes configured previews without rereading completed pages", async () =
   expect(requestedPaths.filter((path) => path === "/archive")).toHaveLength(2);
   expect(requestedPaths.filter((path) => path === "/one")).toHaveLength(1);
   expect(requestedPaths.filter((path) => path === "/two")).toHaveLength(1);
+  const [run] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, pinned.run.id));
+  expect(run?.attemptCount).toBe(1);
 });
 
 test("stores safe validation issues when a selector stops matching", async () => {
   const { pinned, revision } = await setupPreview("h3.missing");
   await expect(
-    executeScraperRun(
-      { runId: pinned.run.id },
-      {
-        registry: createScraperRegistry({ targets: [], sources: [] }),
-        fetchImpl: previewFetch(),
-        clock: fixedClock(),
-        executionToken: "preview-owner",
-      },
-    ),
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl: previewFetch(),
+      executionToken: "preview-owner",
+    }),
   ).rejects.toThrow("The page did not match the saved parsing rules.");
 
   const [storedRevision] = await db
@@ -653,15 +624,11 @@ test("a collection failure does not change the preview result", async () => {
   });
 
   await expect(
-    executeScraperRun(
-      { runId: pinned.run.id },
-      {
-        registry: createScraperRegistry({ targets: [], sources: [] }),
-        fetchImpl: previewFetch(),
-        clock: fixedClock(),
-        executionToken: "collection-owner",
-      },
-    ),
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl: previewFetch(),
+      executionToken: "collection-owner",
+    }),
   ).rejects.toThrow("The page did not match the saved parsing rules.");
 
   const [storedRevision] = await db

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -210,6 +210,7 @@ function createScrapeSourceAdapter(
         const listResponse = await session.request({
           target: input.targetKey,
           url: new URL(state.nextListUrl),
+          canResumeLater: true,
         });
         const listResult = parseScrapeList(
           input.rules,
@@ -238,6 +239,7 @@ function createScrapeSourceAdapter(
         const response = await session.request({
           target: input.targetKey,
           url: new URL(link),
+          canResumeLater: true,
         });
         const parsed = parseScrapeDetail(
           input.rules,

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@peated/server/db/schema";
 import { isAIGatewayConfigured } from "@peated/server/lib/openaiClient";
 import { and, eq } from "drizzle-orm";
+import { setTimeout as wait } from "node:timers/promises";
 import { createScraperRegistry } from "../definitions";
 import { executeScraperRun } from "../runs";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
@@ -149,6 +150,25 @@ function createFixtureWebsite() {
     });
   };
   return { fetchImpl, requests };
+}
+
+async function completeSavedRun({
+  runId,
+  fetchImpl,
+  registry,
+}: {
+  runId: number;
+  fetchImpl: typeof fetch;
+  registry: ReturnType<typeof createScraperRegistry>;
+}) {
+  while (true) {
+    const result = await executeScraperRun({ runId }, { fetchImpl, registry });
+    if (result.status === "completed") return result;
+    if (!("nextAttemptAt" in result)) {
+      throw new Error("The saved scraper is already running.");
+    }
+    await wait(Math.max(0, result.nextAttemptAt.getTime() - Date.now()));
+  }
 }
 
 describe.skipIf(!isAIGatewayConfigured("scraper"))(
@@ -309,10 +329,11 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         trigger: "manual",
       });
       await expect(
-        executeScraperRun(
-          { runId: previewRun.run.id },
-          { fetchImpl: fixtureWebsite.fetchImpl, registry },
-        ),
+        completeSavedRun({
+          runId: previewRun.run.id,
+          fetchImpl: fixtureWebsite.fetchImpl,
+          registry,
+        }),
       ).resolves.toEqual({ status: "completed" });
 
       const [previewedRevision] = await db

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -143,6 +143,35 @@ test("spaces requests from the hourly limit", async () => {
   expect(fetchImpl).toHaveBeenCalledTimes(2);
 });
 
+test("returns the next request time when saved work can continue later", async () => {
+  const { registry, run } = await setupRuntime({ requestsPerHour: 30 });
+  const clock = clockAt();
+  const fetchImpl = vi
+    .fn<typeof fetch>()
+    .mockResolvedValue(new Response("catalog"));
+  const request = {
+    runId: run.id,
+    sourceKey: "finedrams",
+    request: {
+      target: "operator",
+      url: new URL("https://example.com/catalog"),
+      canResumeLater: true,
+    },
+    registry,
+    fetchImpl,
+    clock,
+  };
+
+  await requestScraperUrl(request);
+  await expect(requestScraperUrl(request)).rejects.toMatchObject({
+    reason: "target_spacing",
+    nextEligibleAt: new Date("2026-08-18T12:02:00Z"),
+  });
+
+  expect(clock.sleepSpy).not.toHaveBeenCalled();
+  expect(fetchImpl).toHaveBeenCalledOnce();
+});
+
 test("sends an identified bounded GET and exposes only safe response headers", async () => {
   const { registry, run } = await setupRuntime();
   const fetchImpl = vi

--- a/apps/server/src/scraper/http.ts
+++ b/apps/server/src/scraper/http.ts
@@ -204,12 +204,14 @@ async function acquireOrDefer({
   executionToken,
   targetKey,
   isRetry,
+  canResumeLater,
   clock,
 }: {
   runId: number;
   executionToken: string;
   targetKey: string;
   isRetry: boolean;
+  canResumeLater: boolean;
   clock: ScraperHttpClock;
 }) {
   while (true) {
@@ -225,7 +227,11 @@ async function acquireOrDefer({
     const delay = result.nextEligibleAt
       ? result.nextEligibleAt.getTime() - clock.now().getTime()
       : null;
-    if (result.reason === "target_spacing" && delay !== null) {
+    if (
+      result.reason === "target_spacing" &&
+      delay !== null &&
+      !canResumeLater
+    ) {
       if (delay > 0) await clock.sleep(delay);
       continue;
     }
@@ -305,6 +311,7 @@ export async function requestScraperUrl({
         executionToken,
         targetKey: request.target,
         isRetry: retry > 0,
+        canResumeLater: request.canResumeLater ?? false,
         clock,
       });
       let response: Response;

--- a/apps/server/src/scraper/localPreview.ts
+++ b/apps/server/src/scraper/localPreview.ts
@@ -122,7 +122,7 @@ export async function runLocalScrapeSourcePreview(
   if (!run) throw new Error("Failed to create the local scraper preview run.");
 
   try {
-    for (let attempt = 0; attempt < 10; attempt += 1) {
+    while (true) {
       const result = await executeScraperRun(
         { runId: run.id },
         {

--- a/apps/server/src/scraper/robots.ts
+++ b/apps/server/src/scraper/robots.ts
@@ -156,6 +156,7 @@ export async function ensureRobotsAllowed({
   sourceKey,
   targetKey,
   url,
+  canResumeLater,
   registry,
   fetchImpl = fetch,
   clock,
@@ -165,6 +166,7 @@ export async function ensureRobotsAllowed({
   sourceKey: string;
   targetKey: string;
   url: URL;
+  canResumeLater?: boolean;
   registry: ScraperRegistry;
   fetchImpl?: typeof fetch;
   clock: ScraperHttpClock;
@@ -202,6 +204,7 @@ export async function ensureRobotsAllowed({
           target: targetKey,
           url: new URL("/robots.txt", url.origin),
           headers: { Accept: "text/plain,*/*;q=0.1" },
+          canResumeLater,
         },
         registry,
         fetchImpl,

--- a/apps/server/src/scraper/runs.test.ts
+++ b/apps/server/src/scraper/runs.test.ts
@@ -6,6 +6,7 @@ import type { z } from "zod";
 import {
   FixtureCursorSchema,
   FixtureObservationSchema,
+  FixturePageSchema,
   fixtureScraperAdapter,
 } from "./adapters/fixture";
 import { ScrapeSourceSetupError } from "./configured/setupError";
@@ -259,6 +260,76 @@ test("defers at the slice budget and resumes the same run from its cursor", asyn
     status: "succeeded",
     attemptCount: 2,
     sliceRequestCount: 1,
+    requestCount: 2,
+  });
+  expect(observations.size).toBe(2);
+});
+
+test("does not count planned spacing as another run attempt", async () => {
+  const adapter: ScraperAdapter<FixtureCursor, FixtureObservation> = async ({
+    cursor,
+    session,
+  }) => {
+    let page = cursor?.page ?? 1;
+    while (true) {
+      const response = await session.request({
+        target: "fixture-target",
+        url: new URL(`/catalog?page=${page}`, "https://fixture.invalid"),
+        canResumeLater: true,
+      });
+      const parsed = FixturePageSchema.parse(JSON.parse(response.body));
+      for (const item of parsed.items) {
+        await session.emit({ sourceKey: item.id, value: item });
+      }
+      if (parsed.nextPage === null) return;
+      await session.checkpoint({ page: parsed.nextPage });
+      page = parsed.nextPage;
+    }
+  };
+  const { registry, run, observations } = await setupRun({ adapter });
+  const fetchImpl = pageFetch({
+    1: { items: [{ id: "a", value: "A" }], nextPage: 2 },
+    2: { items: [{ id: "b", value: "B" }], nextPage: null },
+  });
+
+  await expect(
+    executeScraperRun(
+      { runId: run.id },
+      { registry, fetchImpl, clock: fixedClock(), executionToken: "first" },
+    ),
+  ).resolves.toEqual({
+    status: "deferred",
+    nextAttemptAt: new Date("2026-08-18T12:01:00Z"),
+  });
+  const [deferred] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, run.id));
+  expect(deferred).toMatchObject({
+    status: "queued",
+    attemptCount: 0,
+    requestCount: 1,
+    cursor: { page: 2 },
+  });
+
+  await expect(
+    executeScraperRun(
+      { runId: run.id },
+      {
+        registry,
+        fetchImpl,
+        clock: fixedClock("2026-08-18T12:01:00Z"),
+        executionToken: "second",
+      },
+    ),
+  ).resolves.toEqual({ status: "completed" });
+  const [completed] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, run.id));
+  expect(completed).toMatchObject({
+    status: "succeeded",
+    attemptCount: 1,
     requestCount: 2,
   });
   expect(observations.size).toBe(2);

--- a/apps/server/src/scraper/runs.ts
+++ b/apps/server/src/scraper/runs.ts
@@ -267,6 +267,11 @@ async function deferRun(
     .update(externalSiteRuns)
     .set({
       status: "queued",
+      attemptCount:
+        error instanceof ScraperRequestDeferredError &&
+        error.reason === "target_spacing"
+          ? Math.max(0, claim.run.attemptCount - 1)
+          : claim.run.attemptCount,
       nextAttemptAt,
       executionToken: null,
       executionExpiresAt: null,

--- a/apps/server/src/scraper/session.ts
+++ b/apps/server/src/scraper/session.ts
@@ -88,6 +88,7 @@ export function createScraperSession<TCursor, TObservation>({
           sourceKey: source.key,
           targetKey: request.target,
           url: request.url,
+          canResumeLater: request.canResumeLater,
           registry,
           fetchImpl,
           clock,

--- a/apps/server/src/scraper/types.ts
+++ b/apps/server/src/scraper/types.ts
@@ -24,6 +24,8 @@ export type ScraperRequest = {
   method?: "GET" | "POST";
   body?: string;
   headers?: Readonly<Record<string, string>>;
+  /** Use only when this request can continue in another job. */
+  canResumeLater?: boolean;
   /** Explicitly marks a read-only POST query as safe for transient retries. */
   retryable?: boolean;
 };


### PR DESCRIPTION
## Summary

- return saved-rule runs to the queue while waiting for their next allowed request
- keep planned request spacing out of the ten-attempt safety limit
- let local previews follow the same saved progress through completion
- leave legacy scrapers' inline waiting behavior unchanged

This prevents a worker restart or deploy from stranding a slow saved-rule run behind the one-hour ownership lease.

## Verification

- `pnpm --filter @peated/server test -- src/scraper/http.test.ts src/scraper/runs.test.ts`
- `pnpm --filter @peated/server test -- src/scraper/configured/runtime.test.ts`
- `pnpm --filter @peated/server test -- src/scraper/robots.test.ts src/worker/jobs/runScraper.test.ts`
- `pnpm --filter @peated/server typecheck`
- focused `oxlint` and Prettier checks

## Stack

Depends on #1154.