### PR TITLE
fix(moderation): create reviewed bottles from match proposals

### DIFF
--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -330,10 +330,11 @@ export class InvalidStorePriceMatchProposalTypeError extends Error {
   constructor(
     readonly proposalId: number,
     readonly proposalType: StorePriceMatchProposal["proposalType"],
-    readonly expectedProposalType: StorePriceMatchProposal["proposalType"],
+    readonly expectedProposalTypes: readonly StorePriceMatchProposal["proposalType"][],
   ) {
+    const expected = expectedProposalTypes.join(" or ");
     super(
-      `Price match proposal has invalid type (${proposalId}, expected ${expectedProposalType}, got ${proposalType}).`,
+      `Price match proposal has invalid type (${proposalId}, expected ${expected}, got ${proposalType}).`,
     );
     this.name = "InvalidStorePriceMatchProposalTypeError";
   }
@@ -943,7 +944,7 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
 
   const proposal = await getStorePriceMatchProposalForReviewInTransaction(tx, {
     proposalId,
-    expectedProposalType: "create_new",
+    expectedProposalTypes: ["create_new", "match_existing"],
     allowedStatuses: ["pending_review"],
     expectedProcessingToken,
   });
@@ -1536,12 +1537,12 @@ export async function getStorePriceMatchProposalForReviewInTransaction(
   tx: AnyDatabase,
   {
     proposalId,
-    expectedProposalType,
+    expectedProposalTypes,
     allowedStatuses = REVIEWABLE_STORE_PRICE_MATCH_PROPOSAL_STATUSES,
     expectedProcessingToken,
   }: {
     proposalId: number;
-    expectedProposalType?: StorePriceMatchProposal["proposalType"];
+    expectedProposalTypes?: readonly StorePriceMatchProposal["proposalType"][];
     allowedStatuses?: readonly StorePriceMatchProposal["status"][];
     expectedProcessingToken?: string;
   },
@@ -1586,13 +1587,13 @@ export async function getStorePriceMatchProposalForReviewInTransaction(
   }
 
   if (
-    expectedProposalType &&
-    row.proposal.proposalType !== expectedProposalType
+    expectedProposalTypes &&
+    !expectedProposalTypes.includes(row.proposal.proposalType)
   ) {
     throw new InvalidStorePriceMatchProposalTypeError(
       proposalId,
       row.proposal.proposalType,
-      expectedProposalType,
+      expectedProposalTypes,
     );
   }
 
@@ -1947,7 +1948,7 @@ export async function applyStorePriceBottleRepairFromProposal({
       tx,
       {
         proposalId,
-        expectedProposalType: "correction",
+        expectedProposalTypes: ["correction"],
         expectedProcessingToken,
       },
     );

--- a/apps/server/src/orpc/routes/prices/matchQueue/create-bottle.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/create-bottle.ts
@@ -37,7 +37,7 @@ export default procedure
     path: "/prices/match-queue/{proposal}/create-bottle",
     summary: "Create bottle from price match proposal",
     description:
-      "Create a new bottle from a store price match proposal and approve the proposal in a single transaction. Requires moderator privileges",
+      "Create a new bottle from a proposed create or match and approve the proposal in a single transaction. Requires moderator privileges",
     operationId: "createBottleFromPriceMatchQueueItem",
   })
   .input(IndependentInputSchema)

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -3386,13 +3386,18 @@ describe("price match queue", () => {
     expect(groupsAfter).toHaveLength(groupsBefore.length);
   });
 
-  test("rejects proposal-backed bottle creation for non-create_new proposals", async ({
+  test("creates a reviewed Bottle from a match_existing proposal", async ({
     fixtures,
   }) => {
     const user = await fixtures.User({ mod: true });
     const brand = await fixtures.Entity({ name: "Mismatch Brand" });
+    const suggestedBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Conflicting Candidate",
+      abv: 40,
+    });
     const price = await fixtures.StorePrice({
-      name: "Existing Match Candidate",
+      name: "Evidence Backed Release",
     });
 
     const [proposal] = await db
@@ -3401,10 +3406,67 @@ describe("price match queue", () => {
         priceId: price.id,
         status: "pending_review",
         proposalType: "match_existing",
-        proposedBottle: completeProposedBottle({
-          name: "Should Not Exist",
-          brand: { id: brand.id, name: brand.name },
-        }),
+        suggestedBottleId: suggestedBottle.id,
+      })
+      .returning();
+
+    const createdBottle = await routerClient.prices.matchQueue.createBottle(
+      {
+        proposal: proposal.id,
+        independentBottle: {
+          name: "Evidence Backed Release",
+          brand: brand.id,
+          category: "blend",
+          abv: 43,
+        },
+      },
+      { context: { user } },
+    );
+
+    const [updatedProposal, updatedPrice, decisionLog] = await Promise.all([
+      db.query.storePriceMatchProposals.findFirst({
+        where: eq(storePriceMatchProposals.id, proposal.id),
+      }),
+      db.query.storePrices.findFirst({ where: eq(storePrices.id, price.id) }),
+      db.query.incomingBottleDecisionLogs.findFirst({
+        where: and(
+          eq(incomingBottleDecisionLogs.sourceKind, "store_price"),
+          eq(incomingBottleDecisionLogs.sourceId, price.id),
+        ),
+      }),
+    ]);
+
+    expect(createdBottle).toMatchObject({
+      name: "Evidence Backed Release",
+      category: "blend",
+      abv: 43,
+    });
+    expect(updatedProposal).toMatchObject({
+      status: "approved",
+      currentBottleId: createdBottle.id,
+      suggestedBottleId: createdBottle.id,
+    });
+    expect(updatedPrice).toMatchObject({ bottleId: createdBottle.id });
+    expect(decisionLog).toMatchObject({
+      proposalId: proposal.id,
+      bottleId: createdBottle.id,
+      decision: "create_bottle",
+      createdBottle: true,
+    });
+  });
+
+  test("rejects proposal-backed bottle creation for correction proposals", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const brand = await fixtures.Entity({ name: "Mismatch Brand" });
+    const price = await fixtures.StorePrice({ name: "Correction Candidate" });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "correction",
       })
       .returning();
 
@@ -3424,9 +3486,8 @@ describe("price match queue", () => {
     const createdBottle = await db.query.bottles.findFirst({
       where: eq(bottles.fullName, "Mismatch Brand Should Not Exist"),
     });
-
     expect(err).toMatchInlineSnapshot(
-      `[Error: Price match proposal has invalid type (${proposal.id}, expected create_new, got match_existing).]`,
+      `[Error: Price match proposal has invalid type (${proposal.id}, expected create_new or match_existing, got correction).]`,
     );
     expect(createdBottle).toBeUndefined();
   });

--- a/skills/peated-scraper-queue/SKILL.md
+++ b/skills/peated-scraper-queue/SKILL.md
@@ -56,8 +56,10 @@ from another release or use model confidence as evidence.
    from the classifier: a `create_new` proposal may match an existing Bottle, a
    proposed match may use a different exact Bottle, and an unsupported listing may
    be ignored. Use the atomic queue endpoints: `create-bottle` with the reviewed
-   `independentBottle`, `apply-bottle-repair` for a proven repair, or the proposal
-   action endpoint for match and ignore.
+   `independentBottle` for `create_new` or `match_existing`,
+   `apply-bottle-repair` for a proven repair, or the proposal action endpoint for
+   match and ignore. Never create a Bottle separately and then match it merely to
+   work around a missing atomic queue action.
 6. Verify the proposal and moderation history after each action. For a match,
    create, or repair, also verify the listing's Bottle and the Bottle record.
    Check retries for a limited time; report any still processing.


### PR DESCRIPTION
Moderators can now atomically create and assign an independently reviewed Bottle when the classifier proposed an existing match but the evidence proves a distinct release. This clears the queue safely without a standalone catalog create followed by a separate assignment.

The existing proposal lock, current-state checks, exact create-or-reuse behavior, and durable decision history still apply. The route accepts only `create_new` and `match_existing`; correction proposals remain on their dedicated repair path. The moderation skill documents those boundaries and forbids the non-atomic workaround.

Integration coverage exercises the complete `match_existing` create-and-assign transaction and preserves rejection for correction proposals.
