### PR TITLE
perf(web): load bottle sitemap pages together

### DIFF
--- a/apps/web/src/app/sitemaps/bottles/[id]/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/bottles/[id]/sitemap.xml/route.ts
@@ -1,47 +1,23 @@
+import { loadBottleSitemapPage } from "@peated/web/lib/bottleSitemaps";
 import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
-import { buildPagesSitemap, type Sitemap } from "@peated/web/lib/sitemaps";
-import { getBottleUrl } from "@peated/web/lib/urls";
+import { buildPagesSitemap } from "@peated/web/lib/sitemaps";
 
 const SITEMAP_CACHE_CONTROL =
   "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800";
 
 export const dynamic = "force-dynamic";
 
-const PAGE_LIMIT = 1000;
-
 export async function GET(
-  request: Request,
+  _request: Request,
   props: { params: Promise<{ id: string }> },
 ) {
-  const params = await props.params;
-
-  const { id } = params;
+  const { id } = await props.params;
 
   const { client } = await createAnonymousServerClient();
-
-  const startCursor = (Number(id) - 1) * (PAGE_LIMIT / 100) + 1;
-
-  let cursor: number | null = startCursor;
-  let count = 0;
-  const pages: Sitemap = [];
-  while (cursor && count < PAGE_LIMIT) {
-    const { results, rel } = await client.bottles.list({
-      cursor,
-      limit: 100,
-      sort: "created",
-    });
-
-    pages.push(
-      ...results.map((bottle) => ({
-        url: getBottleUrl(bottle),
-        lastModified: bottle.updatedAt,
-      })),
-    );
-
-    cursor = rel.nextCursor;
-    count += results.length;
-  }
-
+  const { pages, startCursor } = await loadBottleSitemapPage(
+    Number(id),
+    client.bottles.list,
+  );
   const pagesSitemapXML = await buildPagesSitemap(pages);
 
   return new Response(pagesSitemapXML, {

--- a/apps/web/src/lib/bottleSitemaps.test.ts
+++ b/apps/web/src/lib/bottleSitemaps.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadBottleSitemapPage,
+  type ListSitemapBottles,
+} from "./bottleSitemaps";
+
+type ListResult = Awaited<ReturnType<ListSitemapBottles>>;
+
+describe("Bottle sitemaps", () => {
+  it("loads all API pages for a sitemap together", async () => {
+    const requests: {
+      cursor: number;
+      resolve: (result: ListResult) => void;
+    }[] = [];
+    const listBottles = vi.fn(
+      ({ cursor }: Parameters<ListSitemapBottles>[0]) =>
+        new Promise<ListResult>((resolve) => {
+          requests.push({ cursor, resolve });
+        }),
+    );
+
+    const loading = loadBottleSitemapPage(2, listBottles);
+
+    expect(listBottles).toHaveBeenCalledTimes(10);
+    expect(requests.map(({ cursor }) => cursor)).toEqual([
+      11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    ]);
+
+    for (const request of requests) {
+      request.resolve({
+        results:
+          request.cursor === 11
+            ? [
+                {
+                  id: 11,
+                  name: "Release 11",
+                  brand: { name: "Example Distillery" },
+                  updatedAt: "2026-09-01T12:00:00.000Z",
+                },
+              ]
+            : [],
+      });
+    }
+
+    await expect(loading).resolves.toEqual({
+      pages: [
+        {
+          url: "/bottles/11-example-distillery-release-11",
+          lastModified: "2026-09-01T12:00:00.000Z",
+        },
+      ],
+      startCursor: 11,
+    });
+  });
+});

--- a/apps/web/src/lib/bottleSitemaps.ts
+++ b/apps/web/src/lib/bottleSitemaps.ts
@@ -1,0 +1,42 @@
+import type { Sitemap } from "./sitemaps";
+import { getBottleUrl } from "./urls";
+
+const PAGE_LIMIT = 1000;
+const API_PAGE_LIMIT = 100;
+
+type SitemapBottle = Parameters<typeof getBottleUrl>[0] & {
+  updatedAt: string;
+};
+
+export type ListSitemapBottles = (input: {
+  cursor: number;
+  limit: number;
+  sort: "created";
+}) => Promise<{ results: SitemapBottle[] }>;
+
+export async function loadBottleSitemapPage(
+  page: number,
+  listBottles: ListSitemapBottles,
+): Promise<{ pages: Sitemap; startCursor: number }> {
+  const pagesPerSitemap = PAGE_LIMIT / API_PAGE_LIMIT;
+  const startCursor = (page - 1) * pagesPerSitemap + 1;
+  const results = await Promise.all(
+    Array.from({ length: pagesPerSitemap }, (_, index) =>
+      listBottles({
+        cursor: startCursor + index,
+        limit: API_PAGE_LIMIT,
+        sort: "created",
+      }),
+    ),
+  );
+
+  return {
+    pages: results.flatMap((result) =>
+      result.results.map((bottle) => ({
+        url: getBottleUrl(bottle),
+        lastModified: bottle.updatedAt,
+      })),
+    ),
+    startCursor,
+  };
+}


### PR DESCRIPTION
Each Bottle sitemap page now starts its ten numbered API page reads together instead of waiting for one response before starting the next. Result order, the 1,000-Bottle limit, and the existing daily cache stay unchanged.

The loader test holds every response open and verifies that all ten requests start before any can finish.

Fixes PEATED-4FR
