### PR TITLE
ref(scraper): simplify runtime internals

### DIFF
--- a/apps/cli/src/commands/scrapers.ts
+++ b/apps/cli/src/commands/scrapers.ts
@@ -57,9 +57,9 @@ subcommand
         limit: options.limit,
       },
       {
-        onDeferred: (nextAttemptAt) => {
+        onWaiting: (nextAttemptAt) => {
           console.error(
-            `Request controls paused the preview. Continuing after ${nextAttemptAt.toISOString()}.`,
+            `Waiting until ${nextAttemptAt.toISOString()} before continuing the preview.`,
           );
         },
       },

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -2746,7 +2746,7 @@ describe("POST /admin/scrape-sources/prepare", () => {
           },
         );
         if (result.status === "completed") return result;
-        if (!("nextAttemptAt" in result)) {
+        if (result.status !== "waiting") {
           throw new Error("The saved scraper is already running.");
         }
         now = result.nextAttemptAt;

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -1,35 +1,33 @@
 # Scraper Runtime
 
-This module owns Peated's outbound scraper boundary. It keeps four concerns
-separate:
+This module controls Peated's scraper requests and saved progress. It keeps four
+jobs separate:
 
-- definitions say which Peated source may use which remote target and origin;
-- runs limit their source work and can resume it;
-- coordination and HTTP own when and how remote requests happen;
-- adapters parse responses and emit source observations through an injected
-  session.
+- definitions list which websites each source may request;
+- runs limit work and save enough progress to resume;
+- coordination and HTTP space requests, retry temporary failures, and enforce
+  limits;
+- adapters read responses and pass results through the current run.
 
-Code outside this module uses `index.ts` to initialize, queue, or execute a
-durable run. It must not call adapters, target coordination, robots, or scraper
-HTTP internals directly. The internal layout keeps those ownership boundaries
-visible:
+Code outside this module uses `index.ts` to initialize, queue, or execute a run.
+It must not call adapters, request controls, robots checks, or scraper HTTP code
+directly. The files are split by responsibility:
 
-- `lifecycle.ts` owns durable run creation and dispatch through injected
-  registry and queue capabilities;
+- `lifecycle.ts` creates runs and sends them to the worker queue;
 - `runs.ts`, `session.ts`, `http.ts`, `robots.ts`, and `coordinator.ts` own core
   execution without importing production registry or worker infrastructure;
-- `registry.ts` is the production composition root;
+- `registry.ts` lists the built-in sources and request settings;
 - `adapters/legacy/` contains migrated source implementations that still use
-  the compatibility bridge in `legacy/`;
-- native adapters use only their injected session;
+  the old helpers in `legacy/`;
+- newer adapters use only the current run passed to them;
 - `adapters/dates.ts` parses common publisher date formats;
-- `adapters/currentReviews.ts` owns the repeated current-review cursor,
-  request, emit, ignore, and checkpoint lifecycle;
-- `sinks/` is the narrow boundary to Peated domain persistence.
+- `adapters/currentReviews.ts` shares the common steps for reading current
+  reviews and saving progress;
+- `sinks/` saves parsed results.
 
 Registered source implementations must not import raw HTTP, queue, database,
-or product persistence clients. Boundary tests inspect the sources composed by
-the production registry, rather than only the top level of `adapters/`.
+or product-saving clients. Tests check every source listed in the production
+registry, including sources in subfolders.
 
 External review sources must also follow the
 [external review source procedure](../../../../docs/operations/external-review-sources.md).
@@ -37,26 +35,24 @@ It covers review publishing, source approval, and rollback.
 
 ## Registering a source
 
-1. Define a target in `registry.ts`. A target represents one remote operator's
-   shared traffic capacity, not necessarily one hostname. Declare every exact
-   origin it may use and either enforce robots or record why robots do not
-   apply.
-2. Define the source with its external-site key, allowed target keys, strict
-   cursor and observation schemas, request limit, adapter, and sink.
-3. Make the adapter use only its injected session. Checkpoint after a page or
-   partition is safely emitted, before requesting the next one. A cursor must
-   describe the next safe work and remain valid if the prior page is replayed.
-4. Give every observation a stable source key. The sink owns product or review
-   persistence and must safely accept a replay after a worker loses ownership
-   between emit and checkpoint.
+1. Define a target in `registry.ts`. A target groups sources that must share a
+   request limit. List every website address it may use and either enforce
+   robots.txt or record why robots.txt does not apply.
+2. Define the source with its external-site key, allowed targets, schemas for
+   saved progress and parsed results, request limit, adapter, and save function.
+3. Make the adapter use only its current run. After saving a page, save the
+   place where the next run should continue. Repeating the prior page must be
+   safe.
+4. Give every parsed result a stable source key. Saving the same result again
+   must not create a duplicate if a worker stops between saving the result and
+   saving its place.
 5. Synchronize definitions before accepting scraper work. Production dispatch
    has one entry point: the `RunScraper` job with a run id.
 
 Existing retailer sources may use `legacy/scraper.ts` only from
-`adapters/legacy/`. That bridge translates their old helper calls into the
-active scraper session; new sources must not use it. Remove a legacy source's
-bridge dependency when converting it to a native adapter, then move it out of
-`adapters/legacy/`.
+`adapters/legacy/`. It connects their old helper calls to the current run; new
+sources must not use it. When converting an old source, remove those helpers
+and move the source out of `adapters/legacy/`.
 
 Give sources the same target only when the same organization runs them and they
 must share one request limit. A target may list several web addresses when that
@@ -178,7 +174,7 @@ these checks. The `trigger-evals` label runs the broader eval suite in CI.
 Before saving replacement rules, run the revision input through the local
 runtime. The command uses `.env.local`, the registered target, robots policy,
 request controls, production parser, and validators. It records the local run
-for inspection but uses a no-op sink, so it does not write reviews or prices:
+for inspection but does not save reviews or prices:
 
 ```bash
 pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 3
@@ -260,21 +256,21 @@ next eligible time and resumes from its saved page automatically.
 
 ## Source acceptance rules
 
-Every new or changed source must satisfy this contract. Prove a rule at the
-listed owner. Do not repeat a runtime test in every adapter.
+Every new or changed source must pass these checks. Test shared request rules
+once in the runtime instead of repeating them in every source test.
 
-| Rule                                                                                                                                                                                            | Owner and proof                                                                                                                                                              |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| The source requests only its declared targets and exact origins.                                                                                                                                | The registry owns the declaration. Definition and boundary tests prove it.                                                                                                   |
-| Discovery has fixed limits. The adapter does not crawl the whole website.                                                                                                                       | The adapter owns its exact entry points and maximum pages or items. A fixture test proves the limit.                                                                         |
-| Every request uses the injected session. Robots, spacing, quotas, retries, response limits, and `429` cooldowns stay active.                                                                    | The runtime owns request control. Boundary and HTTP tests prove it.                                                                                                          |
-| The configured limits let a run complete or make durable progress. Discovery plus the first work request must fit before a quota or slice boundary. Request spacing must not restart discovery. | The registry owns limits. A registered runtime test proves completion or a cursor advance.                                                                                   |
-| A cursor is strict and describes the next safe work. The adapter emits before it checkpoints. A replay is safe.                                                                                 | The adapter owns progress. Fixture tests prove resume, replay, and failed emit or parse behavior.                                                                            |
-| Observation keys are stable across runs. They are unique within their storage scope.                                                                                                            | The adapter owns source identity. Parser tests prove stable keys, multi-item keys, and known collision cases.                                                                |
-| Parsed output uses the registered strict schema. Product writes happen only in the registered sink.                                                                                             | The session and registry own validation and sink selection. Registry and sink tests prove it.                                                                                |
-| Expected remote deferrals remain non-terminal. Unexpected markup, validation, and persistence failures fail the run.                                                                            | The runtime owns deferrals. The adapter owns the difference between an expected non-item and malformed source data.                                                          |
-| A source change passes deterministic fixtures and one local acceptance run against the current public source.                                                                                   | The source author runs the registered adapter through the local runtime and inspects the run, cursor, request count, and emitted observations. Live checks use the CI label. |
-| The first production run is checked in Admin → Scrapers and Sentry.                                                                                                                             | The source author confirms status, counts, cursor progress, robots state, and any terminal error.                                                                            |
+| What to check                                                                                                           | Where it is checked                                                                                    |
+| ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| The source requests only its listed websites.                                                                           | Registry and import tests.                                                                             |
+| The source has a fixed page or item limit and cannot crawl the whole website.                                           | The source's fixture tests.                                                                            |
+| Every request uses the current run, so robots rules, spacing, retries, and response-size limits apply.                  | Import and HTTP tests.                                                                                 |
+| A run can finish or save its place before its request allowance runs out. Waiting between requests repeats no old work. | Registered runtime tests.                                                                              |
+| The saved place points to the next safe item. Results are saved before progress, and repeating work is safe.            | The source's resume and repeat-work tests.                                                             |
+| Each result has a stable source key that is unique where it is stored.                                                  | Parser tests for stable keys and known collisions.                                                     |
+| Parsed output passes the source's strict schema and is saved by its registered save function.                           | Registry and saving tests.                                                                             |
+| A planned wait keeps the run active. Bad markup, invalid data, and failed saves fail the run.                           | Runtime and source tests.                                                                              |
+| A source change passes fixture tests and one local run against the public website.                                      | Inspect its saved progress, request count, and parsed results. Use the CI label for live model checks. |
+| The first production run is checked in Admin → Scrapers and Sentry.                                                     | Confirm its status, counts, saved progress, robots state, and any final error.                         |
 
 Keep source-specific facts in the adapter tests and the owning feature or
 research document. Update a fixture when the publisher changes markup. Do not
@@ -288,28 +284,28 @@ to refresh them without keeping full articles.
 
 ## Run outcomes
 
-- `succeeded` means the adapter returned after validated observations and its
-  latest cursor were persisted.
-- `queued` with `nextAttemptAt` means the same run was durably deferred for a
-  budget, spacing, quota, lease, or remote cooldown. It is not a failure.
-- `failed` means validation, robots, configuration, persistence, or an
-  unexpected remote failure was terminal for that run. Stored errors are
-  limited; detailed unexpected failures belong in Sentry.
+- `succeeded` means the source finished after its valid results and latest
+  progress were saved.
+- `queued` with `nextAttemptAt` means the same run is saved and waiting for its
+  next request time. It is not a failure.
+- `failed` means invalid data, robots rules, settings, saving, or the remote
+  website stopped that run. Stored errors are brief; detailed unexpected
+  failures belong in Sentry.
 
-`sliceRequestCount` resets when a deferred run is reclaimed. Request, request
-error, retry, rate-limit, record, new-record, and seen-before counts cover the
+`sliceRequestCount` counts requests in the current worker attempt and resets
+when a waiting run starts again. The other request and result counts cover the
 full run. A null request-error count means the run finished before error
 tracking was added. Records without a saved type or new/seen result appear as
 not tracked in Admin. Preview and source suggestion runs do not appear in the
 Admin overview.
 
-Every network attempt, including robots refreshes and retries, requires a SQL
-permit and consumes the current slice budget. Response bodies are streamed
-within the configured bound and are never stored by the runtime.
+Every network attempt, including robots refreshes and retries, counts toward
+the current worker's request limit. Response bodies are read only up to the
+configured size and are never stored by the runtime.
 
 A planned wait between saved-rule requests does not count toward the
 ten-attempt safety limit. Other restarts do. Every run must finish within 24
-hours, so a bad cursor or permanent delay cannot live forever.
+hours, so invalid saved progress or a permanent wait cannot live forever.
 
 ## Bot identity
 

--- a/apps/server/src/scraper/adapters/bourbonCulture.ts
+++ b/apps/server/src/scraper/adapters/bourbonCulture.ts
@@ -13,8 +13,6 @@ import {
 import { parseDate } from "./dates";
 import { readReviewBody } from "./reviewBody";
 
-// This adapter owns Bourbon Culture parsing. The shared scraper runtime owns
-// every remote request and the shared review sink owns storage.
 const ORIGIN = "https://thebourbonculture.com";
 const TARGET = "bourbonculture";
 const MAX_CURRENT_ARTICLES = 6;

--- a/apps/server/src/scraper/adapters/dramface.ts
+++ b/apps/server/src/scraper/adapters/dramface.ts
@@ -14,8 +14,6 @@ import {
 import { parseDate } from "./dates";
 import { readReviewBody } from "./reviewBody";
 
-// This adapter owns Dramface-specific discovery and parsing. The shared
-// scraper runtime owns every remote request and the shared sink owns storage.
 const ORIGIN = "https://www.dramface.com";
 const TARGET = "dramface";
 const MAX_INDEX_ARTICLES = 20;

--- a/apps/server/src/scraper/adapters/fredMinnick.ts
+++ b/apps/server/src/scraper/adapters/fredMinnick.ts
@@ -13,8 +13,6 @@ import {
 import { parseDate } from "./dates";
 import { readReviewBody } from "./reviewBody";
 
-// This adapter owns Fred Minnick parsing. The shared scraper runtime owns
-// every remote request and the shared review sink owns storage.
 const ORIGIN = "https://www.fredminnick.com";
 const TARGET = "fredminnick";
 const MAX_CURRENT_ARTICLES = 5;

--- a/apps/server/src/scraper/adapters/whiskeyReviewer.ts
+++ b/apps/server/src/scraper/adapters/whiskeyReviewer.ts
@@ -13,8 +13,6 @@ import {
 import { parseDate } from "./dates";
 import { readReviewBody } from "./reviewBody";
 
-// This adapter owns The Whiskey Reviewer parsing. The shared scraper runtime
-// owns every remote request and the shared review sink owns storage.
 const ORIGIN = "https://whiskeyreviewer.com";
 const TARGET = "whiskeyreviewer";
 const MAX_CURRENT_ARTICLES = 5;

--- a/apps/server/src/scraper/adapters/whiskySaga.ts
+++ b/apps/server/src/scraper/adapters/whiskySaga.ts
@@ -14,8 +14,6 @@ import {
 import { parseDate } from "./dates";
 import { readReviewBody } from "./reviewBody";
 
-// This adapter owns Whisky Saga parsing. The shared scraper runtime owns every
-// remote request and the shared review sink owns storage.
 const ORIGIN = "https://www.whiskysaga.com";
 const TARGET = "whiskysaga";
 const MAX_CURRENT_ARTICLES = 20;

--- a/apps/server/src/scraper/adapters/whiskyStudy.ts
+++ b/apps/server/src/scraper/adapters/whiskyStudy.ts
@@ -14,8 +14,6 @@ import {
 import { parseDate } from "./dates";
 import { readReviewBody } from "./reviewBody";
 
-// This adapter owns The Whisky Study parsing. The shared scraper runtime owns
-// every remote request and the shared review sink owns storage.
 const ORIGIN = "https://thewhiskystudy.com";
 const TARGET = "whiskystudy";
 const MAX_CURRENT_ARTICLES = 20;

--- a/apps/server/src/scraper/adapters/wordsOfWhisky.ts
+++ b/apps/server/src/scraper/adapters/wordsOfWhisky.ts
@@ -14,8 +14,6 @@ import {
 import { parseDate } from "./dates";
 import { readReviewBody } from "./reviewBody";
 
-// This adapter owns Words of Whisky parsing. The shared scraper runtime owns
-// every remote request and the shared review sink owns storage.
 const ORIGIN = "https://wordsofwhisky.com";
 const TARGET = "wordsofwhisky";
 const MAX_HOMEPAGE_ARTICLES = 20;

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -3,19 +3,19 @@ import type { JsonValue } from "@peated/server/scraper/types";
 import { z } from "zod";
 import { ScrapeTextMatchesSchema } from "./textTemplate";
 
-export const SCRAPE_RULES_VERSION_1 = 1;
-export const SCRAPE_RULES_VERSION_2 = 2;
-export const SCRAPE_RULES_VERSION_3 = 3;
-export const SCRAPE_RULES_VERSION_4 = 4;
-export const SCRAPE_RULES_VERSION_5 = 5;
-export const SCRAPE_RULES_VERSION_6 = 6;
-export const SCRAPE_RULES_VERSION_7 = 7;
+const SCRAPE_RULES_VERSION_1 = 1;
+const SCRAPE_RULES_VERSION_2 = 2;
+const SCRAPE_RULES_VERSION_3 = 3;
+const SCRAPE_RULES_VERSION_4 = 4;
+const SCRAPE_RULES_VERSION_5 = 5;
+const SCRAPE_RULES_VERSION_6 = 6;
+const SCRAPE_RULES_VERSION_7 = 7;
 export const SCRAPE_RULES_VERSION = 8;
 // TODO(scraper-platform): Add event after scraped-event match and update rules are defined.
 export const SCRAPE_SOURCE_KIND_LIST = ["review", "price", "catalog"] as const;
 export type ScrapeSourceKind = (typeof SCRAPE_SOURCE_KIND_LIST)[number];
 export const SCRAPE_SOURCE_MAX_LIST_PAGES = 5;
-export const SCRAPE_SOURCE_DEFAULT_MAX_ITEMS = 25;
+const SCRAPE_SOURCE_DEFAULT_MAX_ITEMS = 25;
 export const SCRAPE_SOURCE_MAX_ITEMS = 99;
 
 const SCRAPE_VALUE_MAX_LENGTH = 200;
@@ -32,7 +32,7 @@ export const ScrapeSelectorSchema = z
     message: "The :has selector is not supported.",
   });
 
-export const ScrapeAttributeSchema = z.string().trim().min(1).max(100);
+const ScrapeAttributeSchema = z.string().trim().min(1).max(100);
 
 const ScrapeLiteralSchema = z
   .string()
@@ -50,7 +50,7 @@ const ScrapeCleanupSchema = {
   suffix: z.string().min(1).max(SCRAPE_VALUE_MAX_LENGTH).optional(),
 };
 
-export const ScrapeValueSelectorV1Schema = z
+const ScrapeValueSelectorV1Schema = z
   .object({
     selector: ScrapeSelectorSchema,
     attribute: ScrapeAttributeSchema.optional(),
@@ -100,7 +100,7 @@ const ListRulesV1Schema = z
   })
   .strict();
 
-export const ScrapeListExclusionSchema = z
+const ScrapeListExclusionSchema = z
   .object({
     selector: ScrapeSelectorSchema,
     startsWith: ScrapeLiteralListSchema.optional(),
@@ -179,7 +179,7 @@ const ScrapeUrlDateFormatSchema = z
     }
   });
 
-export const ScrapeUrlDateSchema = z
+const ScrapeUrlDateSchema = z
   .object({
     urlDateFormat: ScrapeUrlDateFormatSchema,
   })
@@ -192,6 +192,34 @@ const ScrapeScoreMapEntrySchema = z
   })
   .strict();
 
+function validateScoreMap(
+  score: {
+    scale: number;
+    map?: Array<z.infer<typeof ScrapeScoreMapEntrySchema>> | null;
+  },
+  context: z.RefinementCtx,
+) {
+  const labels = new Set<string>();
+  for (const [index, entry] of (score.map ?? []).entries()) {
+    if (entry.value > score.scale) {
+      context.addIssue({
+        code: "custom",
+        path: ["map", index, "value"],
+        message: "Mapped score cannot exceed its scale.",
+      });
+    }
+    const label = entry.text.toLocaleLowerCase("en");
+    if (labels.has(label)) {
+      context.addIssue({
+        code: "custom",
+        path: ["map", index, "text"],
+        message: "Mapped score labels must be unique.",
+      });
+    }
+    labels.add(label);
+  }
+}
+
 const ScrapeScoreSchema = z
   .object({
     value: ScrapeValueSchema,
@@ -203,27 +231,7 @@ const ScrapeScoreSchema = z
       .optional(),
   })
   .strict()
-  .superRefine((score, context) => {
-    const labels = new Set<string>();
-    for (const [index, entry] of (score.map ?? []).entries()) {
-      if (entry.value > score.scale) {
-        context.addIssue({
-          code: "custom",
-          path: ["map", index, "value"],
-          message: "Mapped score cannot exceed its scale.",
-        });
-      }
-      const label = entry.text.toLocaleLowerCase("en");
-      if (labels.has(label)) {
-        context.addIssue({
-          code: "custom",
-          path: ["map", index, "text"],
-          message: "Mapped score labels must be unique.",
-        });
-      }
-      labels.add(label);
-    }
-  });
+  .superRefine(validateScoreMap);
 
 const ScrapeScoreWithFirstReviewSchema = ScrapeScoreSchema.safeExtend({
   firstReviewFallback: ScrapeValueSchema.optional(),
@@ -422,27 +430,7 @@ function scrapeScoreSchema<T extends z.ZodType>(trySchema: T) {
         .nullable(),
     })
     .strict()
-    .superRefine((score, context) => {
-      const labels = new Set<string>();
-      for (const [index, entry] of (score.map ?? []).entries()) {
-        if (entry.value > score.scale) {
-          context.addIssue({
-            code: "custom",
-            path: ["map", index, "value"],
-            message: "Mapped score cannot exceed its scale.",
-          });
-        }
-        const label = entry.text.toLocaleLowerCase("en");
-        if (labels.has(label)) {
-          context.addIssue({
-            code: "custom",
-            path: ["map", index, "text"],
-            message: "Mapped score labels must be unique.",
-          });
-        }
-        labels.add(label);
-      }
-    });
+    .superRefine(validateScoreMap);
 }
 
 const ScrapeScoreV6Schema = scrapeScoreSchema(ScrapeReviewTryV6Schema);
@@ -593,7 +581,7 @@ const ScrapeFixedReadV8Schema = z
   })
   .strict();
 
-export const ScrapePageReadSchema = z.union([
+const ScrapePageReadSchema = z.union([
   ScrapeTextReadV8Schema,
   ScrapeAttributeReadV8Schema,
   ScrapeFixedReadV8Schema,
@@ -615,11 +603,11 @@ const ScrapeReviewReadV8Schema = z.union([
 
 const ScrapeReviewTryV8Schema = z.array(ScrapeReviewReadV8Schema).min(1).max(3);
 
-export const ScrapePageFieldSchema = z
+const ScrapePageFieldSchema = z
   .object({ try: z.array(ScrapePageReadSchema).min(1).max(3) })
   .strict();
 
-export const ScrapeReviewFieldSchema = z
+const ScrapeReviewFieldSchema = z
   .object({ try: ScrapeReviewTryV8Schema })
   .strict();
 
@@ -755,13 +743,12 @@ export const StoredScrapeRulesSchema = z.union([
   ScrapeRulesSchema,
 ]);
 
-export type ScrapeRulesV1 = z.infer<typeof ScrapeRulesV1Schema>;
 export type ScrapeRulesV5 = z.infer<typeof ScrapeRulesV5Schema>;
 export type ScrapeRules = z.infer<typeof ScrapeRulesSchema>;
 export type StoredScrapeRules = z.infer<typeof StoredScrapeRulesSchema>;
 export type ScrapePageRead = z.infer<typeof ScrapePageReadSchema>;
-export type ScrapePageField = z.infer<typeof ScrapePageFieldSchema>;
-export type ScrapeReviewField = z.infer<typeof ScrapeReviewFieldSchema>;
+type ScrapePageField = z.infer<typeof ScrapePageFieldSchema>;
+type ScrapeReviewField = z.infer<typeof ScrapeReviewFieldSchema>;
 export type StoredScrapePageRead =
   | z.infer<typeof ScrapePageReadV6Schema>
   | ScrapePageRead;
@@ -773,7 +760,6 @@ export type StoredScrapeReviewField =
   | ScrapeReviewField;
 export type ScrapeValueSelectorV1 = z.infer<typeof ScrapeValueSelectorV1Schema>;
 export type ScrapeValue = z.infer<typeof ScrapeValueSchema>;
-export type ScrapeListExclusion = z.infer<typeof ScrapeListExclusionSchema>;
 
 /** Parses rules only with the interpreter contract that owns their stored version. */
 export function parseScrapeRules(
@@ -811,6 +797,10 @@ export function scrapeRulesLimit(rules: StoredScrapeRules) {
   if ("articles" in rules) return rules.articles.limit;
   if ("products" in rules) return rules.products.limit;
   return rules.list.maxItems;
+}
+
+export function scrapeRunRequestLimit(rules: StoredScrapeRules) {
+  return scrapeRulesLimit(rules) + SCRAPE_SOURCE_MAX_LIST_PAGES;
 }
 
 export function withScrapeRulesLimit(

--- a/apps/server/src/scraper/configured/runs.ts
+++ b/apps/server/src/scraper/configured/runs.ts
@@ -6,11 +6,7 @@ import {
   scrapeSources,
 } from "@peated/server/db/schema";
 import { and, desc, eq } from "drizzle-orm";
-import {
-  SCRAPE_SOURCE_MAX_LIST_PAGES,
-  parseScrapeRules,
-  scrapeRulesLimit,
-} from "./rules";
+import { parseScrapeRules, scrapeRunRequestLimit } from "./rules";
 import {
   ScrapeSourceNotFoundError,
   ScrapeSourceValidationError,
@@ -69,7 +65,7 @@ export async function createPinnedScrapeSourceRun(
       trigger: input.trigger,
       purpose: input.purpose,
       requestedById: input.requestedById,
-      requestLimit: scrapeRulesLimit(rules) + SCRAPE_SOURCE_MAX_LIST_PAGES,
+      requestLimit: scrapeRunRequestLimit(rules),
       requestErrorCount: 0,
       recordType: rules.kind,
     })

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -73,7 +73,7 @@ async function runToCompletion({
       },
     );
     if (result.status === "completed") return result;
-    if (!("nextAttemptAt" in result)) {
+    if (result.status !== "waiting") {
       throw new Error("The test run is already owned by another execution.");
     }
     clock.advanceTo(result.nextAttemptAt);

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -38,6 +38,7 @@ import {
   SCRAPE_SOURCE_MAX_LIST_PAGES,
   parseScrapeRules,
   scrapeRulesLimit,
+  scrapeRunRequestLimit,
   type StoredScrapeRules,
 } from "./rules";
 import { recordScrapeSourcePreview } from "./service";
@@ -317,7 +318,7 @@ export function createLocalScrapeSourcePreview(input: {
     externalSiteKey: input.siteKey,
     recordType: input.rules.kind,
     targetKeys: [input.targetKey],
-    requestLimit: scrapeRulesLimit(input.rules) + SCRAPE_SOURCE_MAX_LIST_PAGES,
+    requestLimit: scrapeRunRequestLimit(input.rules),
     resumeFromLastRun: false,
     cursorSchema: ConfiguredScrapeCursorSchema,
     observationSchema: observationSchemaForRules(input.rules),
@@ -408,7 +409,7 @@ function createScrapeSourceDefinition(input: {
     externalSiteKey: input.siteKey,
     recordType: input.rules.kind,
     targetKeys: [input.targetKey],
-    requestLimit: scrapeRulesLimit(input.rules) + SCRAPE_SOURCE_MAX_LIST_PAGES,
+    requestLimit: scrapeRunRequestLimit(input.rules),
     resumeFromLastRun: false,
     cursorSchema: ConfiguredScrapeCursorSchema,
     observationSchema,

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -164,7 +164,7 @@ async function completeSavedRun({
   while (true) {
     const result = await executeScraperRun({ runId }, { fetchImpl, registry });
     if (result.status === "completed") return result;
-    if (!("nextAttemptAt" in result)) {
+    if (result.status !== "waiting") {
       throw new Error("The saved scraper is already running.");
     }
     await wait(Math.max(0, result.nextAttemptAt.getTime() - Date.now()));

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -17,8 +17,8 @@ import {
 import {
   parseRetryAfter,
   requestScraperUrl as requestScraperUrlImpl,
-  ScraperRequestDeferredError,
   ScraperRequestError,
+  ScraperRequestWaitError,
   type ScraperHttpClock,
   type ScraperHttpStatusError,
 } from "./http";
@@ -368,7 +368,7 @@ test("retries only transient failures and reacquires a permit", async () => {
   expect(failedRunState?.requestErrorCount).toBe(2);
 });
 
-test("honors Retry-After as a shared durable deferral", async () => {
+test("uses Retry-After as the shared next request time", async () => {
   const { registry, run } = await setupRuntime();
   const clock = clockAt();
   const request = requestScraperUrl({
@@ -386,7 +386,7 @@ test("honors Retry-After as a shared durable deferral", async () => {
       ),
     clock,
   });
-  const error = await waitError(request, ScraperRequestDeferredError);
+  const error = await waitError(request, ScraperRequestWaitError);
   expect(error).toMatchObject({
     reason: "rate_limited",
     nextEligibleAt: new Date("2026-08-18T12:02:00Z"),
@@ -495,7 +495,7 @@ test("classifies bounded timeout retries and rejects unsafe headers before conta
   expect(neverFetch).not.toHaveBeenCalled();
 });
 
-test("defers a retryable transport failure when the run budget is exhausted", async () => {
+test("waits after a retryable request uses the run's last request", async () => {
   const { registry, run } = await setupRuntime({ requestLimit: 1 });
   const fetchImpl = vi
     .fn<typeof fetch>()
@@ -513,7 +513,7 @@ test("defers a retryable transport failure when the run budget is exhausted", as
       fetchImpl,
       clock: clockAt(),
     }),
-    ScraperRequestDeferredError,
+    ScraperRequestWaitError,
   );
   expect(error).toMatchObject({
     reason: "run_budget",

--- a/apps/server/src/scraper/http.ts
+++ b/apps/server/src/scraper/http.ts
@@ -27,19 +27,19 @@ const EXPOSED_RESPONSE_HEADERS = new Set([
   "link",
 ]);
 
-export type ScraperDeferralReason =
+export type ScraperWaitReason =
   | PermitDenialReason
   | "rate_limited"
   | "robots_unavailable";
 
-export class ScraperRequestDeferredError extends Error {
-  override name = "ScraperRequestDeferredError";
+export class ScraperRequestWaitError extends Error {
+  override name = "ScraperRequestWaitError";
 
   constructor(
-    readonly reason: ScraperDeferralReason,
+    readonly reason: ScraperWaitReason,
     readonly nextEligibleAt: Date | null,
   ) {
-    super(`Scraper request deferred: ${reason}.`);
+    super(`Scraper request must wait: ${reason}.`);
   }
 }
 
@@ -246,7 +246,7 @@ async function acquireOrDefer({
     ) {
       throw new ScraperRequestError("invalid_request");
     }
-    throw new ScraperRequestDeferredError(result.reason, result.nextEligibleAt);
+    throw new ScraperRequestWaitError(result.reason, result.nextEligibleAt);
   }
 }
 
@@ -334,7 +334,7 @@ export async function requestScraperUrl({
           retry < permit.maxRetries &&
           (method === "GET" || request.retryable === true);
         if (canRetry && permit.remainingRequests <= 0) {
-          throw new ScraperRequestDeferredError("run_budget", null);
+          throw new ScraperRequestWaitError("run_budget", null);
         }
         if (canRetry) {
           retry += 1;
@@ -359,7 +359,7 @@ export async function requestScraperUrl({
           retryAt: retryAfter,
           now: clock.now(),
         });
-        throw new ScraperRequestDeferredError("rate_limited", nextEligibleAt);
+        throw new ScraperRequestWaitError("rate_limited", nextEligibleAt);
       }
 
       if (
@@ -375,7 +375,7 @@ export async function requestScraperUrl({
         });
         await recordScrapeRequestError({ runId, executionToken });
         if (permit.remainingRequests <= 0) {
-          throw new ScraperRequestDeferredError("run_budget", null);
+          throw new ScraperRequestWaitError("run_budget", null);
         }
         retry += 1;
         await clock.sleep(retryDelay(retry, clock.random()));

--- a/apps/server/src/scraper/index.ts
+++ b/apps/server/src/scraper/index.ts
@@ -1,9 +1,4 @@
-/**
- * Public application boundary for scraper lifecycle operations.
- *
- * Runtime internals and source implementations stay private to this module;
- * API routes and workers only queue, execute, or initialize durable runs.
- */
+/** Public scraper actions used by API routes and workers. */
 import type { ExternalSite } from "@peated/server/db/schema";
 import type { ExternalSiteKey } from "@peated/server/types";
 import { createScrapeSourceSuggestionRun } from "./configured/runs";

--- a/apps/server/src/scraper/legacy/scraper.ts
+++ b/apps/server/src/scraper/legacy/scraper.ts
@@ -1,8 +1,4 @@
-/**
- * Owns retailer fetching, normalization, and dispatch into durable server
- * capabilities. Persistence failures escape to the worker boundary; optional
- * image transfer may degrade without discarding the authoritative listing.
- */
+/** Compatibility helpers for retailer scrapers that have not moved to saved rules. */
 import config from "@peated/server/config";
 import {
   defaultHeaders,

--- a/apps/server/src/scraper/lifecycle.ts
+++ b/apps/server/src/scraper/lifecycle.ts
@@ -374,7 +374,7 @@ async function queueScheduledExternalSiteRun(
   return result.run;
 }
 
-/** Binds infrastructure once so lifecycle callers cannot bypass source ownership. */
+/** Creates the scraper actions used by API routes and scheduled jobs. */
 export function createScraperLifecycle({
   registry,
   enqueue,

--- a/apps/server/src/scraper/localPreview.ts
+++ b/apps/server/src/scraper/localPreview.ts
@@ -10,8 +10,7 @@ import { z } from "zod";
 import type { ScrapeSourcePreviewResult } from "./configured/preview";
 import {
   parseScrapeRules,
-  SCRAPE_SOURCE_MAX_LIST_PAGES,
-  scrapeRulesLimit,
+  scrapeRunRequestLimit,
   withScrapeRulesLimit,
 } from "./configured/rules";
 import { createLocalScrapeSourcePreview } from "./configured/runtime";
@@ -38,7 +37,7 @@ export async function runLocalScrapeSourcePreview(
     fetchImpl?: typeof fetch;
     clock?: ScraperHttpClock;
     executionToken?: string;
-    onDeferred?: (nextAttemptAt: Date) => void;
+    onWaiting?: (nextAttemptAt: Date) => void;
   } = {},
 ) {
   const parsed = InputSchema.parse(input);
@@ -115,7 +114,7 @@ export async function runLocalScrapeSourcePreview(
       externalSiteId: site.id,
       trigger: "manual",
       purpose: "preview",
-      requestLimit: scrapeRulesLimit(rules) + SCRAPE_SOURCE_MAX_LIST_PAGES,
+      requestLimit: scrapeRunRequestLimit(rules),
       requestErrorCount: 0,
     })
     .returning();
@@ -133,8 +132,8 @@ export async function runLocalScrapeSourcePreview(
         },
       );
       if (result.status === "completed") break;
-      if ("nextAttemptAt" in result) {
-        options.onDeferred?.(result.nextAttemptAt);
+      if (result.status === "waiting") {
+        options.onWaiting?.(result.nextAttemptAt);
         await clock.sleep(
           Math.max(0, result.nextAttemptAt.getTime() - clock.now().getTime()),
         );

--- a/apps/server/src/scraper/robots.test.ts
+++ b/apps/server/src/scraper/robots.test.ts
@@ -182,7 +182,7 @@ test("caches a missing robots document as allowed for the bounded period", async
   expect(runState?.requestCount).toBe(1);
 });
 
-test("defers when robots is unavailable without a fresh decision", async () => {
+test("waits when robots is unavailable without a fresh decision", async () => {
   const { registry, run } = await setupRobotsRuntime();
   await expect(
     ensureRobotsAllowed({

--- a/apps/server/src/scraper/robots.ts
+++ b/apps/server/src/scraper/robots.ts
@@ -11,8 +11,8 @@ import {
   requestScraperUrl,
   type ScraperHttpClock,
   ScraperHttpStatusError,
-  ScraperRequestDeferredError,
   ScraperRequestError,
+  ScraperRequestWaitError,
 } from "./http";
 import type { ScraperRegistry } from "./types";
 
@@ -185,7 +185,7 @@ export async function ensureRobotsAllowed({
       ),
     );
   if (!origin || origin.robotsMode !== "enforce") {
-    throw new ScraperRequestDeferredError("robots_unavailable", null);
+    throw new ScraperRequestWaitError("robots_unavailable", null);
   }
 
   const now = clock.now();
@@ -218,7 +218,7 @@ export async function ensureRobotsAllowed({
         const missing = { status: "missing" } as const;
         await writeRobotsCache(url.origin, missing, now);
         state = CachedRobotsRulesSchema.safeParse(missing);
-      } else if (error instanceof ScraperRequestDeferredError) {
+      } else if (error instanceof ScraperRequestWaitError) {
         throw error;
       } else if (
         error instanceof ScraperRequestError &&
@@ -226,7 +226,7 @@ export async function ensureRobotsAllowed({
       ) {
         throw error;
       } else {
-        throw new ScraperRequestDeferredError(
+        throw new ScraperRequestWaitError(
           "robots_unavailable",
           new Date(now.getTime() + ROBOTS_UNAVAILABLE_RETRY_MS),
         );
@@ -235,7 +235,7 @@ export async function ensureRobotsAllowed({
   }
 
   if (!state.success) {
-    throw new ScraperRequestDeferredError(
+    throw new ScraperRequestWaitError(
       "robots_unavailable",
       new Date(now.getTime() + ROBOTS_UNAVAILABLE_RETRY_MS),
     );

--- a/apps/server/src/scraper/runs.test.ts
+++ b/apps/server/src/scraper/runs.test.ts
@@ -18,7 +18,7 @@ import {
   ScraperTargetDisabledError,
 } from "./definitions";
 import type { ScraperHttpClock } from "./http";
-import { ScraperRequestDeferredError } from "./http";
+import { ScraperRequestWaitError } from "./http";
 import { executeScraperRun } from "./runs";
 import { ScraperRunOwnershipError } from "./session";
 import { syncScraperDefinitions } from "./syncDefinitions";
@@ -213,7 +213,7 @@ test("stores an expected setup failure without failing the worker", async () => 
   });
 });
 
-test("defers at the slice budget and resumes the same run from its cursor", async () => {
+test("waits at the request limit and resumes the same run from its saved place", async () => {
   const { registry, run, observations } = await setupRun({ requestLimit: 1 });
   const fetchImpl = pageFetch({
     1: { items: [{ id: "a", value: "A" }], nextPage: 2 },
@@ -226,14 +226,14 @@ test("defers at the slice budget and resumes the same run from its cursor", asyn
       { registry, fetchImpl, clock: fixedClock(), executionToken: "slice-1" },
     ),
   ).resolves.toEqual({
-    status: "deferred",
+    status: "waiting",
     nextAttemptAt: new Date("2026-08-18T12:01:00Z"),
   });
-  const [deferred] = await db
+  const [waiting] = await db
     .select()
     .from(externalSiteRuns)
     .where(eq(externalSiteRuns.id, run.id));
-  expect(deferred).toMatchObject({
+  expect(waiting).toMatchObject({
     status: "queued",
     cursor: { page: 2 },
     sliceRequestCount: 1,
@@ -298,14 +298,14 @@ test("does not count planned spacing as another run attempt", async () => {
       { registry, fetchImpl, clock: fixedClock(), executionToken: "first" },
     ),
   ).resolves.toEqual({
-    status: "deferred",
+    status: "waiting",
     nextAttemptAt: new Date("2026-08-18T12:01:00Z"),
   });
-  const [deferred] = await db
+  const [waiting] = await db
     .select()
     .from(externalSiteRuns)
     .where(eq(externalSiteRuns.id, run.id));
-  expect(deferred).toMatchObject({
+  expect(waiting).toMatchObject({
     status: "queued",
     attemptCount: 0,
     requestCount: 1,
@@ -435,7 +435,7 @@ test("reclaims an expired execution lease without changing run identity", async 
   expect(stored).toMatchObject({ id: run.id, status: "succeeded" });
 });
 
-test("does not claim a queued run before its durable next-attempt time", async () => {
+test("does not claim a queued run before its next attempt", async () => {
   const adapter = vi.fn<ScraperAdapter<FixtureCursor, FixtureObservation>>(
     async () => {},
   );
@@ -451,7 +451,7 @@ test("does not claim a queued run before its durable next-attempt time", async (
       { runId: run.id },
       { registry, clock: fixedClock(), executionToken: "early-worker" },
     ),
-  ).resolves.toEqual({ status: "not_ready", nextAttemptAt });
+  ).resolves.toEqual({ status: "waiting", nextAttemptAt });
   expect(adapter).not.toHaveBeenCalled();
 });
 
@@ -484,7 +484,7 @@ test("fails a run before an eleventh execution claim", async () => {
   });
 });
 
-test("fails a deferred run after its maximum lifetime", async () => {
+test("fails a waiting run after its maximum lifetime", async () => {
   const adapter = vi.fn<ScraperAdapter<FixtureCursor, FixtureObservation>>();
   const { registry, run } = await setupRun({ adapter });
   await db
@@ -523,7 +523,7 @@ test("replay-safe sink prevents duplicate records after a lost checkpoint", asyn
     });
     attempt += 1;
     if (attempt === 1) {
-      throw new ScraperRequestDeferredError(
+      throw new ScraperRequestWaitError(
         "target_cooldown",
         new Date("2026-08-18T12:01:00Z"),
       );
@@ -548,7 +548,7 @@ test("replay-safe sink prevents duplicate records after a lost checkpoint", asyn
   );
 });
 
-test("defers transient traffic coordination failures", async () => {
+test("waits after temporary traffic coordination failures", async () => {
   const adapter: ScraperAdapter<
     FixtureCursor,
     FixtureObservation
@@ -563,7 +563,7 @@ test("defers transient traffic coordination failures", async () => {
       { registry, clock: fixedClock(), executionToken: "owner" },
     ),
   ).resolves.toEqual({
-    status: "deferred",
+    status: "waiting",
     nextAttemptAt: new Date("2026-08-18T12:15:00Z"),
   });
   const [stored] = await db

--- a/apps/server/src/scraper/runs.ts
+++ b/apps/server/src/scraper/runs.ts
@@ -19,8 +19,8 @@ import {
 } from "./definitions";
 import {
   ScraperHttpStatusError,
-  ScraperRequestDeferredError,
   ScraperRequestError,
+  ScraperRequestWaitError,
   scraperSystemClock,
   type ScraperHttpClock,
 } from "./http";
@@ -35,8 +35,8 @@ import type {
 const RUN_EXECUTION_LEASE_MS = 60 * 60_000;
 const MAX_RUN_EXECUTION_ATTEMPTS = 10;
 const MAX_RUN_AGE_MS = 24 * 60 * 60_000;
-const DEFAULT_DEFERRAL_MS = 15 * 60_000;
-const BUDGET_DEFERRAL_MS = 60_000;
+const DEFAULT_WAIT_MS = 15 * 60_000;
+const REQUEST_LIMIT_WAIT_MS = 60_000;
 const RUN_LIMIT_ERROR = "Scraper run exceeded its execution limits.";
 
 const ScraperRunJobInputSchema = z
@@ -52,8 +52,7 @@ type ClaimedRun = {
 
 export type ScraperRunExecutionResult =
   | { status: "completed" | "duplicate" }
-  | { status: "not_ready"; nextAttemptAt: Date }
-  | { status: "deferred"; nextAttemptAt: Date };
+  | { status: "waiting"; nextAttemptAt: Date };
 
 function safeRunError(error: Error) {
   if (error instanceof ScraperTargetDisabledError) {
@@ -149,7 +148,7 @@ async function claimScraperRun({
       candidate.run.nextAttemptAt > now
     ) {
       return {
-        status: "not_ready",
+        status: "waiting",
         nextAttemptAt: candidate.run.nextAttemptAt,
       };
     }
@@ -247,20 +246,20 @@ async function failRun(claim: ClaimedRun, error: Error, completedAt: Date) {
   });
 }
 
-async function deferRun(
+async function queueRunForLater(
   claim: ClaimedRun,
-  error: ScraperRequestDeferredError | ScraperCoordinationError,
+  error: ScraperRequestWaitError | ScraperCoordinationError,
   now: Date,
 ) {
-  let nextAttemptAt = new Date(now.getTime() + DEFAULT_DEFERRAL_MS);
-  if (error instanceof ScraperRequestDeferredError) {
+  let nextAttemptAt = new Date(now.getTime() + DEFAULT_WAIT_MS);
+  if (error instanceof ScraperRequestWaitError) {
     nextAttemptAt =
       error.nextEligibleAt ??
       new Date(
         now.getTime() +
           (error.reason === "run_budget"
-            ? BUDGET_DEFERRAL_MS
-            : DEFAULT_DEFERRAL_MS),
+            ? REQUEST_LIMIT_WAIT_MS
+            : DEFAULT_WAIT_MS),
       );
   }
   await db
@@ -268,7 +267,7 @@ async function deferRun(
     .set({
       status: "queued",
       attemptCount:
-        error instanceof ScraperRequestDeferredError &&
+        error instanceof ScraperRequestWaitError &&
         error.reason === "target_spacing"
           ? Math.max(0, claim.run.attemptCount - 1)
           : claim.run.attemptCount,
@@ -341,11 +340,11 @@ export async function executeScraperRun(
     return { status: "completed" };
   } catch (error) {
     if (
-      error instanceof ScraperRequestDeferredError ||
+      error instanceof ScraperRequestWaitError ||
       error instanceof ScraperCoordinationError
     ) {
-      const nextAttemptAt = await deferRun(claimed, error, clock.now());
-      return { status: "deferred", nextAttemptAt };
+      const nextAttemptAt = await queueRunForLater(claimed, error, clock.now());
+      return { status: "waiting", nextAttemptAt };
     }
     if (error instanceof ScrapeSourceSetupError) {
       await failRun(claimed, error, clock.now());

--- a/apps/server/src/scraper/types.ts
+++ b/apps/server/src/scraper/types.ts
@@ -11,22 +11,15 @@ export type JsonValue =
 
 export type ScraperRunPayload = JsonValue | undefined;
 
-export type ScraperRecordType = "review" | "price" | "catalog" | "bottle";
-
-export type ScraperSinkResult = {
-  newItemCount: number;
-  existingItemCount: number;
-};
-
 export type ScraperRequest = {
   target: string;
   url: URL;
   method?: "GET" | "POST";
   body?: string;
   headers?: Readonly<Record<string, string>>;
-  /** Use only when this request can continue in another job. */
+  /** Use only when another worker can safely continue this request. */
   canResumeLater?: boolean;
-  /** Explicitly marks a read-only POST query as safe for transient retries. */
+  /** Marks a read-only POST request as safe to retry after a temporary failure. */
   retryable?: boolean;
 };
 
@@ -38,9 +31,9 @@ export type ScraperResponse = {
 };
 
 export type ScraperObservation<T> = {
-  /** Stable within a source so replay after a lost checkpoint is idempotent. */
+  /** Stable within a source so repeating saved work does not create duplicates. */
   sourceKey: string;
-  /** Number of source items represented when an adapter emits a bounded batch. */
+  /** Number of source items included when one save contains a limited batch. */
   itemCount?: number;
   value: T;
 };
@@ -60,12 +53,15 @@ export type ScraperAdapter<TCursor, TObservation> = (input: {
 export type ScraperSink<TObservation> = (input: {
   externalSiteId: number;
   observation: ScraperObservation<TObservation>;
-}) => Promise<ScraperSinkResult | void>;
+}) => Promise<{
+  newItemCount: number;
+  existingItemCount: number;
+} | void>;
 
 export type ScraperSourceDefinition<TCursor = any, TObservation = any> = {
   key: string;
   externalSiteKey: ExternalSiteKey;
-  recordType?: ScraperRecordType;
+  recordType?: "review" | "price" | "catalog" | "bottle";
   targetKeys: readonly [string, ...string[]];
   requestLimit: number;
   resumeFromLastRun: boolean;

--- a/apps/server/src/worker/jobs/runScraper.test.ts
+++ b/apps/server/src/worker/jobs/runScraper.test.ts
@@ -8,11 +8,11 @@ function createServices() {
   };
 }
 
-test("queues the same run id for its durable next-attempt time", async () => {
+test("queues the same run id for its next attempt", async () => {
   const services = createServices();
   const nextAttemptAt = new Date(Date.now() + 60_000);
   services.executeRun.mockResolvedValue({
-    status: "deferred",
+    status: "waiting",
     nextAttemptAt,
   });
 

--- a/apps/server/src/worker/jobs/runScraper.ts
+++ b/apps/server/src/worker/jobs/runScraper.ts
@@ -29,7 +29,7 @@ export async function runScraper(
 ) {
   const { runId } = InputSchema.parse(input);
   const result = await services.executeRun({ runId });
-  if (result.status !== "deferred" && result.status !== "not_ready") return;
+  if (result.status !== "waiting") return;
 
   const delay = Math.max(0, result.nextAttemptAt.getTime() - Date.now());
   await services.enqueueRun(runId, {


### PR DESCRIPTION
The scraper runtime now uses one `waiting` outcome whenever a run must resume later, from request handling through the worker and local preview command. Shared rule validation and request-limit calculations live in one place, and internal-only rule types are no longer exposed.

The scraper guide and nearby names now describe the same behavior in plain language, and repeated architecture comments were removed from individual adapters. This does not change saved rules, database fields, source parsing, request rates, or result storage. The run and HTTP code are the best places to start reviewing because they contain the only interface rename.
