### PR TITLE
chore(agents): add PlanetScale MCP

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -2,6 +2,9 @@
   "mcpServers": {
     "sentry": {
       "url": "https://mcp.sentry.dev/mcp/peated/peated?experimental=1"
+    },
+    "planetscale": {
+      "url": "https://mcp.pscale.dev/mcp/planetscale"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,10 @@
     "peated-storybook": {
       "type": "http",
       "url": "http://localhost:6006/mcp"
+    },
+    "planetscale": {
+      "type": "http",
+      "url": "https://mcp.pscale.dev/mcp/planetscale"
     }
   }
 }

--- a/agents.toml
+++ b/agents.toml
@@ -15,3 +15,7 @@ source = "getsentry/dotagents"
 [[mcp]]
 name = "sentry"
 url = "https://mcp.sentry.dev/mcp/peated/peated?experimental=1"
+
+[[mcp]]
+name = "planetscale"
+url = "https://mcp.pscale.dev/mcp/planetscale"


### PR DESCRIPTION
Peated's shared agent configuration now declares PlanetScale's hosted MCP server, and the generated Claude-compatible and Cursor configurations include the same endpoint. Developers can authenticate with PlanetScale through OAuth and access database schema and Insights context without manually configuring each supported client; the permissions available to an agent remain limited by the scopes each developer grants during authorization.
