### PR TITLE
fix(reviews): restore Whisky Advocate ratings

### DIFF
--- a/apps/server/src/externalReviews/repairWhiskyAdvocateScores.ts
+++ b/apps/server/src/externalReviews/repairWhiskyAdvocateScores.ts
@@ -1,0 +1,126 @@
+import { db } from "@peated/server/db";
+import {
+  externalReviewArticles,
+  externalReviews,
+  externalSites,
+} from "@peated/server/db/schema";
+import { eq, inArray, sql } from "drizzle-orm";
+
+const WHISKY_ADVOCATE_SITE = "whiskyadvocate";
+const WHISKY_ADVOCATE_SCORE_SCALE = 100;
+
+export interface WhiskyAdvocateScoreRepairResult {
+  siteId: number;
+  totalReviews: number;
+  updatedReviews: number;
+  unchangedReviews: number;
+  preservedNativeScores: number;
+  skippedLegacyScores: number;
+  affectedBottleIds: number[];
+}
+
+export class WhiskyAdvocateSiteNotFoundError extends Error {
+  constructor() {
+    super("Whisky Advocate site not found.");
+    this.name = "WhiskyAdvocateSiteNotFoundError";
+  }
+}
+
+function isValidLegacyScore(score: number | null): score is number {
+  return (
+    score !== null &&
+    Number.isInteger(score) &&
+    score >= 1 &&
+    score <= WHISKY_ADVOCATE_SCORE_SCALE
+  );
+}
+
+/** Restores raw publisher scores retained by Peated's legacy Whisky Advocate import. */
+export async function repairWhiskyAdvocateScores(): Promise<WhiskyAdvocateScoreRepairResult> {
+  return await db.transaction(async (tx) => {
+    const [site] = await tx
+      .select({ id: externalSites.id })
+      .from(externalSites)
+      .where(eq(externalSites.type, WHISKY_ADVOCATE_SITE))
+      .limit(1)
+      .for("update");
+    if (!site) throw new WhiskyAdvocateSiteNotFoundError();
+
+    const reviews = await tx
+      .select({
+        id: externalReviews.id,
+        bottleId: externalReviews.bottleId,
+        legacyScore: externalReviews.legacyNormalizedScore,
+        nativeScoreValue: externalReviews.nativeScoreValue,
+        nativeScoreScale: externalReviews.nativeScoreScale,
+        nativeScoreDisplay: externalReviews.nativeScoreDisplay,
+      })
+      .from(externalReviews)
+      .innerJoin(
+        externalReviewArticles,
+        eq(externalReviewArticles.id, externalReviews.articleId),
+      )
+      .where(eq(externalReviewArticles.externalSiteId, site.id))
+      .for("update", { of: externalReviews });
+
+    const repairable = reviews.filter(
+      (review) =>
+        isValidLegacyScore(review.legacyScore) &&
+        review.nativeScoreValue === null &&
+        review.nativeScoreScale === null &&
+        review.nativeScoreDisplay === null,
+    );
+
+    if (repairable.length) {
+      await tx
+        .update(externalReviews)
+        .set({
+          nativeScoreValue: sql`${externalReviews.legacyNormalizedScore}`,
+          nativeScoreScale: WHISKY_ADVOCATE_SCORE_SCALE,
+          nativeScoreDisplay: sql`CAST(${externalReviews.legacyNormalizedScore} AS text) || '/100'`,
+          updatedAt: new Date(),
+        })
+        .where(
+          inArray(
+            externalReviews.id,
+            repairable.map((review) => review.id),
+          ),
+        );
+    }
+
+    const repairedIds = new Set(repairable.map((review) => review.id));
+    const affectedBottleIds = [
+      ...new Set(
+        reviews.flatMap((review) => {
+          if (!isValidLegacyScore(review.legacyScore)) return [];
+          const hasRestoredScore =
+            repairedIds.has(review.id) ||
+            (review.nativeScoreValue === review.legacyScore &&
+              review.nativeScoreScale === WHISKY_ADVOCATE_SCORE_SCALE &&
+              review.nativeScoreDisplay === `${review.legacyScore}/100`);
+          return hasRestoredScore && review.bottleId !== null
+            ? [review.bottleId]
+            : [];
+        }),
+      ),
+    ].sort((left, right) => left - right);
+    const preservedNativeScores = reviews.filter(
+      (review) => review.nativeScoreValue !== null,
+    ).length;
+    const skippedLegacyScores = reviews.filter(
+      (review) =>
+        review.nativeScoreValue === null &&
+        !isValidLegacyScore(review.legacyScore),
+    ).length;
+
+    return {
+      siteId: site.id,
+      totalReviews: reviews.length,
+      updatedReviews: repairable.length,
+      unchangedReviews: reviews.length - repairable.length,
+      preservedNativeScores,
+      skippedLegacyScores,
+      affectedBottleIds,
+    };
+  });
+}

--- a/apps/server/src/lib/auditLog.ts
+++ b/apps/server/src/lib/auditLog.ts
@@ -26,6 +26,7 @@ export enum AuditEvent {
   // External review publishing
   EXTERNAL_REVIEW_PUBLICATION_UPDATED = "external_review.publication.updated",
   EXTERNAL_REVIEW_SCORING_UPDATED = "external_review.scoring.updated",
+  EXTERNAL_REVIEW_SCORES_REPAIRED = "external_review.scores.repaired",
 }
 
 interface AuditLogEntry {

--- a/apps/server/src/orpc/routes/external-sites/index.ts
+++ b/apps/server/src/orpc/routes/external-sites/index.ts
@@ -5,6 +5,7 @@ import details from "./details";
 import { healthDetails, healthList } from "./health";
 import icon from "./icon";
 import list from "./list";
+import repairWhiskyAdvocateScores from "./repair-whisky-advocate-scores";
 import reviewPublication from "./review-publication";
 import reviewScoring from "./review-scoring";
 import runs from "./runs";
@@ -14,6 +15,7 @@ import triggerJob from "./trigger-job";
 
 export default base.tag("sites").router({
   list,
+  repairWhiskyAdvocateScores,
   healthList,
   healthDetails,
   icon,

--- a/apps/server/src/orpc/routes/external-sites/repair-whisky-advocate-scores.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/repair-whisky-advocate-scores.test.ts
@@ -1,0 +1,200 @@
+import { db } from "@peated/server/db";
+import { externalReviews } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { pushJob } from "@peated/server/lib/test/workerDispatch";
+import { routerClient } from "@peated/server/orpc/router";
+import { asc, inArray } from "drizzle-orm";
+
+const STATS_JOB_OPTIONS = {
+  delay: 5000,
+  removeOnComplete: true,
+  removeOnFail: false,
+};
+
+describe("POST /admin/external-sites/whiskyadvocate/repair-review-scores", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("requires an administrator", async ({ fixtures }) => {
+    const site = await fixtures.ExternalSiteOrExisting({
+      type: "whiskyadvocate",
+    });
+    const review = await fixtures.ExternalReview({
+      externalSiteId: site.id,
+      legacyNormalizedScore: 92,
+    });
+    const moderator = await fixtures.User({ mod: true, admin: false });
+
+    const error = await waitError(() =>
+      routerClient.externalSites.repairWhiskyAdvocateScores(
+        {},
+        { context: { user: moderator } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+    expect(
+      await db.query.externalReviews.findFirst({
+        where: (reviews, { eq }) => eq(reviews.id, review.id),
+      }),
+    ).toMatchObject({
+      legacyNormalizedScore: 92,
+      nativeScoreValue: null,
+      nativeScoreScale: null,
+      nativeScoreDisplay: null,
+    });
+    expect(pushJob).not.toHaveBeenCalled();
+  });
+
+  test("repairs only eligible Whisky Advocate scores and can safely repeat", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({
+      type: "whiskyadvocate",
+    });
+    const otherSite = await fixtures.ExternalSiteOrExisting({
+      type: "whiskyfun",
+    });
+    const bottle = await fixtures.Bottle();
+    const matched = await fixtures.ExternalReview({
+      externalSiteId: site.id,
+      bottleId: bottle.id,
+      legacyNormalizedScore: 92,
+    });
+    const sameBottle = await fixtures.ExternalReview({
+      externalSiteId: site.id,
+      bottleId: bottle.id,
+      legacyNormalizedScore: 93,
+    });
+    const unmatched = await fixtures.ExternalReview({
+      externalSiteId: site.id,
+      bottleId: null,
+      legacyNormalizedScore: 88,
+    });
+    const currentNative = await fixtures.ExternalReview({
+      externalSiteId: site.id,
+      legacyNormalizedScore: 90,
+      nativeScoreValue: 9,
+      nativeScoreScale: 10,
+      nativeScoreDisplay: "9/10",
+    });
+    const missingLegacy = await fixtures.ExternalReview({
+      externalSiteId: site.id,
+      legacyNormalizedScore: null,
+    });
+    const zeroLegacy = await fixtures.ExternalReview({
+      externalSiteId: site.id,
+      legacyNormalizedScore: 0,
+    });
+    const otherSource = await fixtures.ExternalReview({
+      externalSiteId: otherSite.id,
+      legacyNormalizedScore: 87,
+    });
+    const admin = await fixtures.User({ admin: true });
+    vi.clearAllMocks();
+
+    await expect(
+      routerClient.externalSites.repairWhiskyAdvocateScores(
+        {},
+        { context: { user: admin } },
+      ),
+    ).resolves.toEqual({
+      totalReviews: 6,
+      updatedReviews: 3,
+      unchangedReviews: 3,
+      preservedNativeScores: 1,
+      skippedLegacyScores: 2,
+      affectedBottles: 1,
+      queuedBottleUpdates: 1,
+    });
+    expect(pushJob).toHaveBeenCalledTimes(1);
+    expect(pushJob).toHaveBeenCalledWith(
+      "UpdateBottleStats",
+      { bottleId: bottle.id },
+      STATS_JOB_OPTIONS,
+    );
+
+    const stored = await db
+      .select({
+        id: externalReviews.id,
+        nativeScoreValue: externalReviews.nativeScoreValue,
+        nativeScoreScale: externalReviews.nativeScoreScale,
+        nativeScoreDisplay: externalReviews.nativeScoreDisplay,
+      })
+      .from(externalReviews)
+      .where(
+        inArray(externalReviews.id, [
+          matched.id,
+          sameBottle.id,
+          unmatched.id,
+          currentNative.id,
+          missingLegacy.id,
+          zeroLegacy.id,
+          otherSource.id,
+        ]),
+      )
+      .orderBy(asc(externalReviews.id));
+    expect(
+      Object.fromEntries(stored.map((review) => [review.id, review])),
+    ).toMatchObject({
+      [matched.id]: {
+        nativeScoreValue: 92,
+        nativeScoreScale: 100,
+        nativeScoreDisplay: "92/100",
+      },
+      [sameBottle.id]: {
+        nativeScoreValue: 93,
+        nativeScoreScale: 100,
+        nativeScoreDisplay: "93/100",
+      },
+      [unmatched.id]: {
+        nativeScoreValue: 88,
+        nativeScoreScale: 100,
+        nativeScoreDisplay: "88/100",
+      },
+      [currentNative.id]: {
+        nativeScoreValue: 9,
+        nativeScoreScale: 10,
+        nativeScoreDisplay: "9/10",
+      },
+      [missingLegacy.id]: {
+        nativeScoreValue: null,
+        nativeScoreScale: null,
+        nativeScoreDisplay: null,
+      },
+      [zeroLegacy.id]: {
+        nativeScoreValue: null,
+        nativeScoreScale: null,
+        nativeScoreDisplay: null,
+      },
+      [otherSource.id]: {
+        nativeScoreValue: null,
+        nativeScoreScale: null,
+        nativeScoreDisplay: null,
+      },
+    });
+
+    vi.clearAllMocks();
+    await expect(
+      routerClient.externalSites.repairWhiskyAdvocateScores(
+        {},
+        { context: { user: admin } },
+      ),
+    ).resolves.toEqual({
+      totalReviews: 6,
+      updatedReviews: 0,
+      unchangedReviews: 6,
+      preservedNativeScores: 4,
+      skippedLegacyScores: 2,
+      affectedBottles: 1,
+      queuedBottleUpdates: 1,
+    });
+    expect(pushJob).toHaveBeenCalledTimes(1);
+    expect(pushJob).toHaveBeenCalledWith(
+      "UpdateBottleStats",
+      { bottleId: bottle.id },
+      STATS_JOB_OPTIONS,
+    );
+  });
+});

--- a/apps/server/src/orpc/routes/external-sites/repair-whisky-advocate-scores.ts
+++ b/apps/server/src/orpc/routes/external-sites/repair-whisky-advocate-scores.ts
@@ -1,0 +1,73 @@
+import {
+  repairWhiskyAdvocateScores,
+  WhiskyAdvocateSiteNotFoundError,
+} from "@peated/server/externalReviews/repairWhiskyAdvocateScores";
+import { AuditEvent, auditLog } from "@peated/server/lib/auditLog";
+import { dispatchBottleStatsRecomputes } from "@peated/server/lib/dispatchBottleStatsRecompute";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import { z } from "zod";
+
+const ResultSchema = z
+  .object({
+    totalReviews: z.number().int().nonnegative(),
+    updatedReviews: z.number().int().nonnegative(),
+    unchangedReviews: z.number().int().nonnegative(),
+    preservedNativeScores: z.number().int().nonnegative(),
+    skippedLegacyScores: z.number().int().nonnegative(),
+    affectedBottles: z.number().int().nonnegative(),
+    queuedBottleUpdates: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "POST",
+    path: "/admin/external-sites/whiskyadvocate/repair-review-scores",
+    summary: "Repair Whisky Advocate review scores",
+    description:
+      "Restore native scores retained by the legacy Whisky Advocate import and queue affected Bottle summary updates. Requires administrator privileges.",
+    operationId: "repairWhiskyAdvocateReviewScores",
+  })
+  .input(z.object({}).strict().default({}))
+  .output(ResultSchema)
+  .handler(async ({ context, errors }) => {
+    let repair;
+    try {
+      repair = await repairWhiskyAdvocateScores();
+    } catch (error) {
+      if (error instanceof WhiskyAdvocateSiteNotFoundError) {
+        throw errors.NOT_FOUND({ message: error.message, cause: error });
+      }
+      throw error;
+    }
+
+    await dispatchBottleStatsRecomputes(
+      "externalReview",
+      repair.siteId,
+      repair.affectedBottleIds,
+    );
+
+    const result = {
+      totalReviews: repair.totalReviews,
+      updatedReviews: repair.updatedReviews,
+      unchangedReviews: repair.unchangedReviews,
+      preservedNativeScores: repair.preservedNativeScores,
+      skippedLegacyScores: repair.skippedLegacyScores,
+      affectedBottles: repair.affectedBottleIds.length,
+      queuedBottleUpdates: repair.affectedBottleIds.length,
+    };
+    auditLog({
+      event: AuditEvent.EXTERNAL_REVIEW_SCORES_REPAIRED,
+      userId: context.user.id,
+      ip: context.ip,
+      userAgent: context.userAgent,
+      metadata: {
+        site: "whiskyadvocate",
+        ...result,
+      },
+    });
+
+    return result;
+  });

--- a/docs/operations/external-review-sources.md
+++ b/docs/operations/external-review-sources.md
@@ -53,6 +53,29 @@ A 5-point or 10-point scale does not by itself justify multiplying the score.
 The source's guide must support the comparison. Leave scores out when the
 comparison is uncertain. Review original 100-point sites by the same standard.
 
+## Repair Legacy Whisky Advocate Scores
+
+Use this one-time operation only while the temporary repair route is deployed.
+It copies valid 1–100 scores retained by the old Whisky Advocate importer into
+the native score fields. It does not fetch source pages, change Bottle matches,
+or overwrite a native score.
+
+Authenticate as an administrator, then run:
+
+```bash
+pnpm cli api post /admin/external-sites/whiskyadvocate/repair-review-scores --yes
+```
+
+Record the returned counts. `updatedReviews` is the number repaired by this
+call, while `affectedBottles` and `queuedBottleUpdates` count distinct matched
+Bottles sent to the summary dispatcher. A safe repeat returns zero updated
+reviews and sends the already repaired matched Bottles again.
+
+After the jobs finish, confirm a repaired review exposes its original score and
+its Bottle summary includes the review. Investigate worker errors before a
+retry. Remove the temporary route after production verification; do not clear
+the restored scores or their preserved legacy evidence.
+
 ## Stop Clip Generation
 
 Set `EXTERNAL_REVIEW_CLIPS_ENABLED=false` to stop all clip model calls for cost

--- a/openspec/changes/restore-whisky-advocate-scores/.openspec.yaml
+++ b/openspec/changes/restore-whisky-advocate-scores/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/restore-whisky-advocate-scores/design.md
+++ b/openspec/changes/restore-whisky-advocate-scores/design.md
@@ -1,0 +1,106 @@
+## Context
+
+The legacy Whisky Advocate importer stored the publisher's whole-number
+100-point score in `review.rating`. The article-model migration retained that
+column as `legacyNormalizedScore` but left the new native-score triplet empty.
+Current serializers and summary calculations intentionally ignore the legacy
+column. New Whisky Advocate imports already store native scores correctly.
+
+Production currently has 7,152 Whisky Advocate reviews, including 4,958 Bottle
+matches. The repair must use the authenticated API rather than a database-backed
+CLI command, preserve every review and Bottle relationship, and avoid source
+requests.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Restore the publisher score for every eligible legacy Whisky Advocate review.
+- Make the operation administrator-only, idempotent, source-scoped, and safe to
+  retry.
+- Preserve current native scores and every unrelated review field.
+- Refresh saved Bottle and BottleGroup summaries for affected Bottle matches.
+- Record the repair result in structured audit output.
+
+**Non-Goals:**
+
+- Add a preview or administrator interface.
+- Fetch or enrich Whisky Advocate articles.
+- Approve publication or schedule the Whisky Advocate scraper.
+- Convert scores for any other review source.
+- Remove the legacy rating column.
+
+## Decisions
+
+### Use a protected one-time API operation
+
+Add an administrator-only POST operation under the Whisky Advocate external
+site. The operation performs the repair immediately and returns changed,
+unchanged, skipped, affected-Bottle, and queued-update counts. This follows the
+supported production API boundary and avoids adding a legacy database CLI
+command.
+
+A generated schema migration is not appropriate because the schema does not
+change, and Peated does not hand-write data migrations. A read-time fallback was
+rejected because database correctness forbids silently repairing saved data
+during normal reads and it would keep two score representations indefinitely.
+
+### Restore only complete, known source facts
+
+The transaction resolves Whisky Advocate by its stored site type and locks that
+site row against concurrent ingestion. It updates only reviews owned by that
+site whose legacy score is an integer from 1 through 100 and whose entire
+native-score triplet is null. It sets the native value to the legacy value, the
+scale to 100, and the display value to `<score>/100`.
+
+Rows with any current native score remain unchanged. Missing, zero, or invalid
+legacy values remain unknown and are counted in the response. The operation
+does not change article metadata, visibility, names, Bottle matches, or the
+legacy score.
+
+### Refresh affected summaries after commit
+
+Collect distinct non-null Bottle IDs from changed reviews. After the repair
+transaction commits, queue the existing Bottle summary update for each distinct
+Bottle in bounded batches. `queuedBottleUpdates` reports the number handed to
+the shared dispatcher, which logs individual queue failures. A repeat call
+changes no scores but retries summary updates for every eligible repaired
+Whisky Advocate review, so operators can recover from a queue outage.
+
+### Audit the bounded repair
+
+Add a dedicated external-review score-repair audit event containing the stable
+site type and aggregate result counts. Do not include review names, URLs, source
+text, or user data.
+
+## Risks / Trade-offs
+
+- **Legacy values might not represent the source scale** → Restrict the repair
+  to Whisky Advocate, whose old importer parsed the publisher's 1–100 score and
+  stored it unchanged.
+- **A current import could race the repair** → Take an update lock on the
+  source row; current ingestion takes a shared source lock before storing.
+- **Summary job dispatch can partially fail** → Use the shared logged
+  dispatcher and allow an idempotent repeat call to queue affected Bottles
+  again.
+- **Restored scores affect Bottle totals** → This is existing scoring
+  behavior: a public, matched, whole-number native score out of 100 counts when
+  the source has no explicit scoring policy.
+
+## Migration Plan
+
+1. Deploy the protected operation and tests.
+2. Call it once through `pnpm cli api post` against production.
+3. Re-fetch review 1151 and Bottle 13170, then check aggregate repair and saved
+   summary counts.
+4. Retry the idempotent operation only if Bottle summary jobs failed to queue.
+5. Remove the temporary route after production verification; retain the audit
+   event, durable documentation, native scores, and legacy evidence.
+
+Rollback does not clear scores automatically. The preserved legacy value and
+the source-scoped audit counts identify the repaired population, but any rollback
+must avoid deleting native scores later refreshed by the source.
+
+## Open Questions
+
+None.

--- a/openspec/changes/restore-whisky-advocate-scores/proposal.md
+++ b/openspec/changes/restore-whisky-advocate-scores/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Whisky Advocate reviews imported before the article-model cutover retained their
+100-point scores only in the legacy rating column. Current APIs, Bottle totals,
+and review displays read native scores, so those reviews now appear unscored.
+
+## What Changes
+
+- Add an administrator-only, idempotent repair operation for legacy Whisky
+  Advocate reviews.
+- Copy preserved legacy scores into the native 100-point score fields without
+  overwriting scores supplied by current imports.
+- Queue summary refreshes for affected Bottles and report enough counts to
+  verify the repair.
+- Document the one-time production operation and remove the repair surface after
+  production verification.
+
+## Capabilities
+
+### New Capabilities
+
+- `legacy-external-review-score-repair`: Safely restore native Whisky Advocate
+  scores from Peated's preserved legacy values and refresh affected summaries.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects administrator API routes, external-review persistence,
+Bottle summary job dispatch, integration tests, and the external-review
+operations guide. It does not fetch publisher pages, change Bottle matches, or
+change source publication and scheduling settings.

--- a/openspec/changes/restore-whisky-advocate-scores/specs/legacy-external-review-score-repair/spec.md
+++ b/openspec/changes/restore-whisky-advocate-scores/specs/legacy-external-review-score-repair/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Source-scoped score restoration
+
+The system SHALL restore a Whisky Advocate review's native score from its
+preserved legacy score only when the legacy value is a whole number from 1
+through 100 and all native-score fields are empty.
+
+#### Scenario: Restore an eligible legacy score
+
+- **WHEN** an administrator runs the repair for a Whisky Advocate review with a
+  legacy score of 92 and no native score
+- **THEN** the review retains the legacy score and stores a native score of
+  `92/100`
+
+#### Scenario: Preserve a current native score
+
+- **WHEN** an eligible source review already has any complete native score
+- **THEN** the repair leaves that native score unchanged
+
+#### Scenario: Leave weak legacy data unknown
+
+- **WHEN** a Whisky Advocate review has no legacy score or a legacy score outside
+  the publisher's valid range
+- **THEN** the repair leaves its native score empty and reports it as skipped
+
+#### Scenario: Exclude another source
+
+- **WHEN** another review source has a legacy score and no native score
+- **THEN** the Whisky Advocate repair leaves it unchanged
+
+### Requirement: Protected idempotent operation
+
+The system MUST restrict the repair operation to administrators and SHALL make
+repeated calls safe.
+
+#### Scenario: Unauthorized request
+
+- **WHEN** a non-administrator calls the repair operation
+- **THEN** the request fails without changing reviews or queueing summary work
+
+#### Scenario: Repeat a completed repair
+
+- **WHEN** an administrator repeats the operation after scores were restored
+- **THEN** no native score is overwritten and affected Bottle summary updates
+  can be queued again
+
+### Requirement: Summary refresh and verification counts
+
+The system SHALL queue summary updates for distinct Bottles affected by restored
+Whisky Advocate scores and return aggregate repair counts.
+
+#### Scenario: Repair matched and unmatched reviews
+
+- **WHEN** the repair restores scores on matched and unmatched reviews
+- **THEN** it queues each distinct matched Bottle once and reports changed,
+  skipped, affected-Bottle, and queued-update counts
+
+#### Scenario: Record the repair
+
+- **WHEN** an administrator completes the operation
+- **THEN** the system records a source-scoped audit event containing aggregate
+  result counts without publisher text or private user data

--- a/openspec/changes/restore-whisky-advocate-scores/tasks.md
+++ b/openspec/changes/restore-whisky-advocate-scores/tasks.md
@@ -1,0 +1,10 @@
+## 1. Repair operation
+
+- [x] 1.1 Add a source-scoped repair that restores eligible legacy Whisky Advocate scores without overwriting native scores.
+- [x] 1.2 Add an admin-only API route, aggregate audit event, and Bottle summary recompute dispatch.
+- [x] 1.3 Register the route and document the one-time authenticated production operation.
+
+## 2. Verification
+
+- [x] 2.1 Add integration coverage for eligibility, source isolation, idempotency, permissions, result counts, and Bottle summary dispatch.
+- [x] 2.2 Run focused tests, typecheck, lint, formatting, and OpenSpec validation.


### PR DESCRIPTION
Legacy Whisky Advocate imports kept the publisher's 100-point rating only in the legacy score column, while current review display and Bottle summaries read the native score fields. This adds an administrator-only, idempotent repair endpoint that copies valid retained scores into the native fields without overwriting current scores or touching another source, then queues distinct matched Bottles for summary recomputation and records aggregate audit counts.

The operation is intentionally temporary and does not fetch publisher pages, change publication settings, or rematch reviews. After deployment, an administrator can run the documented API command, verify the returned counts and Bottle 13170, and remove the repair route after production confirmation.
