### PR TITLE
ref(scraper): retire Edradour legacy source

### DIFF
--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -11,7 +11,6 @@ const registeredSources = [
   "douglaslaing",
   "dramface",
   "dramfool",
-  "edradour",
   "finedrams",
   "fredminnick",
   "glenallachie",
@@ -42,6 +41,7 @@ const configuredSources = [
   "bruichladdich",
   "cadenheads",
   "compassbox",
+  "edradour",
   "gordonmacphail",
   "kilchoman",
   "ncnean",
@@ -136,7 +136,7 @@ test("registers each built-in scraper source with its target", () => {
 
 test("dispatches built-in sources to the scraper job", async ({ fixtures }) => {
   const requestedBy = await fixtures.User({ admin: true });
-  const site = await fixtures.ExternalSite({ type: "edradour" });
+  const site = await fixtures.ExternalSite({ type: "dramfool" });
   const enqueue = vi.fn(async () => undefined);
 
   const run = await createScraperLifecycle({

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -14,7 +14,6 @@ import scrapeBerryBrosRudd from "./adapters/legacy/scrapeBerryBrosRudd";
 import scrapeDecadentDrinks from "./adapters/legacy/scrapeDecadentDrinks";
 import scrapeDouglasLaing from "./adapters/legacy/scrapeDouglasLaing";
 import scrapeDramfool from "./adapters/legacy/scrapeDramfool";
-import scrapeEdradour from "./adapters/legacy/scrapeEdradour";
 import scrapeFineDrams from "./adapters/legacy/scrapeFineDrams";
 import scrapeGlenAllachie from "./adapters/legacy/scrapeGlenAllachie";
 import scrapeHealthySpirits from "./adapters/legacy/scrapeHealthySpirits";
@@ -81,11 +80,6 @@ const legacyPriceSources = [
     scrape: scrapeDouglasLaing,
   },
   { type: "dramfool", origin: "https://dramfool.com", scrape: scrapeDramfool },
-  {
-    type: "edradour",
-    origin: "https://www.edradour.com",
-    scrape: scrapeEdradour,
-  },
   {
     type: "finedrams",
     origin: "https://www.finedrams.com",
@@ -235,6 +229,15 @@ export const scraperRegistry = createScraperRegistry({
       origins: [
         {
           origin: "https://www.compassboxwhisky.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
+      key: "edradour",
+      origins: [
+        {
+          origin: "https://www.edradour.com",
           robots: { mode: "enforce" },
         },
       ],


### PR DESCRIPTION
Edradour now runs through its active saved parsing rules, so this removes the legacy adapter registration while retaining the store's request target and robots policy.

The saved revision passed production preview and its first collection updated all eight current price records without creating replacements. Registry coverage now treats Edradour as configured and uses another legacy source for the built-in dispatch check.
