### PR TITLE
docs: record live Dram Report review source

### DIFF
--- a/docs/research/external-review-source-audit-2026-08.md
+++ b/docs/research/external-review-source-audit-2026-08.md
@@ -30,7 +30,7 @@ site-specific search; it does not mean unrestricted use is allowed.
 | P0         | [Whisky Advocate](https://whiskyadvocate.com/ratings-reviews) | Existing Peated source; publisher describes an archive of more than 6,000 reviews | Ratings paths allowed for general crawlers; GPTBot, ChatGPT-User, and CCBot are blocked                    | Privacy policy references general terms, but no public general terms page or review-reuse restriction was located                                 | `public_index`, second bounded pilot          |
 | P0         | [Whisky Saga](https://www.whiskysaga.com/)                    | Active scored reviews; the Scotland category contains more than 2,000 articles    | Public category and article paths allowed; Squarespace APIs, search, filters, and internal formats blocked | Privacy and editorial pages contain no automated-access restriction                                                                               | `public_index`, daily Scotch feed             |
 | P1         | [The Whisky Study](https://thewhiskystudy.com/reviews-3)      | Active single-Bottle Scotch reviews with explicit dates and 100-point scores      | Public index and article paths allowed; Squarespace APIs, search, filters, and internal formats blocked    | No dedicated terms or privacy page is linked in the public navigation                                                                             | `public_index`, daily Scotch feed             |
-| P1         | [The Dram Report](https://dram.report/all)                    | 633 drams across three reviewers; active exact 100-point scores                   | Explicitly allows all public paths                                                                         | No dedicated terms, privacy, or reuse page linked from the public site                                                                            | `public_index`; pending production preview    |
+| P1         | [The Dram Report](https://dram.report/all)                    | 633 drams across three reviewers; active exact 100-point scores                   | Explicitly allows all public paths                                                                         | No dedicated terms, privacy, or reuse page linked from the public site                                                                            | `public_index`; active daily feed             |
 | P1         | [Whisky Magazine](https://www.whiskymag.com/search/tastings/) | Structured tasting archive spanning more than 200 magazine issues                 | Verification failed because the server reset the automated request                                         | Terms prohibit automated access, aggregation, and commercial reuse without written permission                                                     | `licensed_only`                               |
 | P1         | [Malt](https://malt-review.com/)                              | Large historical review archive with multiple contributors                        | Automated requests returned HTTP 429 during the audit                                                      | No current terms page verified because automated access was rate-limited                                                                          | `do_not_ingest`; do not work around the block |
 | P1         | [Breaking Bourbon](https://www.breakingbourbon.com/)          | Deep American whiskey archive with structured ratings and reviewers               | robots file exposes a sitemap and no reviewed article-path restriction                                     | Terms prohibit robots, spiders, retrieval/indexing applications, and reuse without written consent                                                | `licensed_only`                               |
@@ -130,16 +130,19 @@ a separate platform-terms and creator-rights review.
 - The three public reviewer profiles report 261, 190, and 182 drams. Review
   pages expose one reviewer, Bottle name, tasting notes, and an exact 100-point
   score. The archive is active and server-rendered.
-- Production source 17 is disabled and unpublished. Its AI setup fetched 12
-  pages without request errors, but rejected its rules because visible dates
-  such as `January 29th, 2024` were not accepted by the parser. Inactive rule
-  revision 28 remains pending.
+- Production source 17 is active and published with rule revision 37. It reads
+  the public archive and review pages directly, ignores unscored archive cards,
+  and runs every 1,440 minutes.
 - A full local version 8 acceptance preview after adding ordinal-date support
-  and icon-only skip markers read 20 scored reviews in 21 requests. All 20 had
-  a Bottle name, writer, date, and exact score; the run had no parser or request
-  errors, retries, or rate limits. Run the same governed preview in production
-  after those parser changes are deployed; do not activate or publish the
-  source before it passes.
+  and icon-only skip markers read 20 scored reviews in 21 requests. Production
+  preview run 598 repeated that result with no parser or request errors,
+  retries, or rate limits.
+- Production collection run 599 stored 20 reviews from 21 requests with no
+  errors, retries, or rate limits. Fourteen exact Bottle matches are public and
+  counted. Six reviews remain unpublished because their exact release is not
+  safely represented in the catalog: J.P. Wiser's 10 Year (two reviews),
+  Pendleton Whisky 12-Year Rye (two), Redbreast 27 Batch 3, and Cadenhead's
+  Tobermory 16 Oloroso Matured 2025.
 
 ### The Scotch Noob
 


### PR DESCRIPTION
## Summary

- mark The Dram Report as an active daily public-index source
- record local and production preview evidence
- record the first production collection and exact-match coverage

## Testing

- `pnpm exec prettier --write docs/research/external-review-source-audit-2026-08.md`
- production preview run 598
- production collection run 599