### PR TITLE
feat(scraper): prepare GlenAllachie saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -152,6 +152,15 @@ function prepareGordonMacphail(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareGlenAllachie(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "glenallachie", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareKilchoman(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "kilchoman", ...input },
@@ -199,6 +208,7 @@ function codeOwnedSource(
     | "compassbox"
     | "dramface"
     | "edradour"
+    | "glenallachie"
     | "gordonmacphail"
     | "kilchoman"
     | "ncnean"
@@ -291,6 +301,11 @@ const bruichladdichRegistry = createScraperRegistry({
 const gordonMacphailRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("gordonmacphail")!],
   sources: [codeOwnedSource("gordonmacphail")],
+});
+
+const glenAllachieRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("glenallachie")!],
+  sources: [codeOwnedSource("glenallachie")],
 });
 
 const kilchomanRegistry = createScraperRegistry({
@@ -843,6 +858,25 @@ async function setupGordonMacphailMigration() {
     })
     .returning();
   await syncScraperDefinitions(gordonMacphailRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
+}
+
+async function setupGlenAllachieMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "glenallachie",
+      name: "GlenAllachie",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(glenAllachieRegistry);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "succeeded",
@@ -2166,6 +2200,105 @@ describe("POST /admin/scrape-sources/prepare", () => {
       message: expect.stringContaining("Check Gordon & MacPhail price"),
     });
     expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares GlenAllachie without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupGlenAllachieMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "9187573072212",
+      name: "The GlenAllachie 12-year-old",
+      price: 5699,
+      currency: "gbp",
+      volume: 700,
+      url: "https://shop.theglenallachie.com/products/glenallachie-12-year-old",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "9187894034772",
+      name: "White Heather 15-year-old",
+      price: 6999,
+      currency: "gbp",
+      volume: 700,
+      url: "https://shop.theglenallachie.com/products/white-heather-15-year-old",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareGlenAllachie()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareGlenAllachie({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(glenAllachieRegistry);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl: "https://shop.theglenallachie.com/collections/all-products",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+    await expect(prepareGlenAllachie({ apply: true })).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "GlenAllachie is already prepared for saved scraping rules.",
+    });
+  });
+
+  test("refuses an unexpected GlenAllachie price without changing records", async ({
+    fixtures,
+  }) => {
+    const site = await setupGlenAllachieMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "not-a-number",
+      name: "Unknown product",
+      currency: "gbp",
+      volume: 700,
+      url: "https://shop.theglenallachie.com/products/unknown-product",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareGlenAllachie({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check GlenAllachie price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
     expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -7,6 +7,7 @@ import { prepareCadenheadsSource } from "@peated/server/scraper/configured/prepa
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
 import { prepareDramfaceSource } from "@peated/server/scraper/configured/prepareDramface";
 import { prepareEdradourSource } from "@peated/server/scraper/configured/prepareEdradour";
+import { prepareGlenAllachieSource } from "@peated/server/scraper/configured/prepareGlenAllachie";
 import { prepareGordonMacphailSource } from "@peated/server/scraper/configured/prepareGordonMacphail";
 import { prepareKilchomanSource } from "@peated/server/scraper/configured/prepareKilchoman";
 import { prepareNcneanSource } from "@peated/server/scraper/configured/prepareNcnean";
@@ -41,7 +42,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, dramface, edradour, gordonmacphail, kilchoman, ncnean, northstarspirits, thompsonbros, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
+          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, dramface, edradour, glenallachie, gordonmacphail, kilchoman, ncnean, northstarspirits, thompsonbros, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -78,6 +79,7 @@ export default procedure
       compassbox: prepareCompassBoxSource,
       dramface: prepareDramfaceSource,
       edradour: prepareEdradourSource,
+      glenallachie: prepareGlenAllachieSource,
       gordonmacphail: prepareGordonMacphailSource,
       kilchoman: prepareKilchomanSource,
       ncnean: prepareNcneanSource,

--- a/apps/server/src/scraper/configured/prepareGlenAllachie.ts
+++ b/apps/server/src/scraper/configured/prepareGlenAllachie.ts
@@ -1,0 +1,27 @@
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks GlenAllachie by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareGlenAllachieSource(
+  input: PreparePriceSourceInput,
+) {
+  return preparePriceSource(input, {
+    siteKey: "glenallachie",
+    siteName: "GlenAllachie",
+    targetKey: "glenallachie",
+    origin: "https://shop.theglenallachie.com",
+    listUrl: "https://shop.theglenallachie.com/collections/all-products",
+    isExpectedPrice: (price) =>
+      /^https:\/\/shop\.theglenallachie\.com\/products\/[a-z0-9][a-z0-9-]*$/.test(
+        price.url,
+      ) &&
+      /^\d+$/.test(price.externalProductId ?? "") &&
+      /^(?:The GlenAllachie|Meikle Tòir|White Heather|MacNair's)\b/.test(
+        price.name,
+      ) &&
+      price.currency === "gbp" &&
+      price.volume === 700,
+  });
+}

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -387,6 +387,28 @@ output, trigger one manual collection, and confirm that it updates the same
 price IDs and Bottle links without reviving historical rows. Check the run and
 Sentry before restoring the weekly schedule.
 
+## GlenAllachie
+
+Use the preparation endpoint with `{"site": "glenallachie"}`. The check-only
+request locks and inventories every stored price without changing it. It stops
+if a price does not use the expected shop product URL, numeric Shopify product
+ID, supported whisky name, GBP currency, or 700 ml volume. Applying transfers
+the existing request settings to administrator ownership and adds a paused
+price source whose list page is
+`https://shop.theglenallachie.com/collections/all-products`.
+
+Before applying, stop the `glenallachie` schedule and wait for active runs.
+Save the existing price IDs, product IDs, URLs, Bottle links, hidden states,
+histories, request limits, and run history. Run the current rules through the
+full local no-write preview. Compare every current product with the code
+scraper. The rules must omit unavailable and non-whisky products and preserve
+the Shopify product ID used by existing prices.
+
+After applying, save and preview the reviewed rules. Activate only exact
+output, trigger one manual collection, and confirm that it updates the same
+price IDs and Bottle matches without reviving old products. Check the run and
+Sentry before restoring the saved schedule.
+
 ## If something goes wrong
 
 A request without `apply: true` leaves records unchanged. After applying, keep the
@@ -397,8 +419,8 @@ handles reviews added after the switch. Do not delete source or run history.
 ## Other sources
 
 The preparation API is shared. It currently supports Bourbon Culture,
-Bruichladdich, Cadenhead's, Compass Box, Dramface, Edradour, Gordon & MacPhail,
-Kilchoman, Nc'nean, North Star, Thompson Bros., The Whiskey Reviewer,
+Bruichladdich, Cadenhead's, Compass Box, Dramface, Edradour, GlenAllachie,
+Gordon & MacPhail, Kilchoman, Nc'nean, North Star, Thompson Bros., The Whiskey Reviewer,
 WhiskyNotes, Whisky Saga, The Whisky Study, and Words of Whisky. Other sites are
 rejected without changing records. Add each site's conversion behind this route
 as its existing records are reviewed.


### PR DESCRIPTION
Depends on #1174.

## Context

Add the production safety check needed before moving GlenAllachie from its code scraper to saved rules. This PR does not change production records or activate new rules.

## Behavior

- verify every existing GlenAllachie price uses its expected shop URL, Shopify product ID, whisky name, GBP currency, and 700 ml size
- preserve price rows, histories, hidden state, and Bottle matches while creating a paused saved source
- document the live migration and rollback checks

## Validation

- `pnpm --filter @peated/server test -- src/orpc/routes/external-sites/scrape-sources/prepare.test.ts -t GlenAllachie --maxWorkers=1`
- `pnpm --filter @peated/server typecheck`
- focused oxlint and Prettier checks
- local no-write preview against the live shop preserved product ID `15633852137812` with zero parser or request issues