### PR TITLE
perf(entities): share catalog cache with members

### DIFF
--- a/apps/web/src/lib/publicCatalog.server.test.ts
+++ b/apps/web/src/lib/publicCatalog.server.test.ts
@@ -129,7 +129,7 @@ describe("public catalog page reads", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it("refreshes catalog snapshots after five minutes and bypasses them for members", async () => {
+  it("refreshes catalog snapshots after five minutes and shares them with members", async () => {
     vi.useFakeTimers({ toFake: ["Date", "performance"] });
     const catalog = await getPageEntityCatalog(1);
     expect(await getPageEntityCatalog(1)).toEqual(catalog);
@@ -137,11 +137,12 @@ describe("public catalog page reads", () => {
 
     vi.advanceTimersByTime(301_000);
     expect(await getPageEntityCatalog(1)).toEqual(catalog);
-    expect(await getPageEntityCatalog(1)).not.toEqual(catalog);
+    const refreshedCatalog = await getPageEntityCatalog(1);
+    expect(refreshedCatalog).not.toEqual(catalog);
+
     accessToken = "test-member";
-    await getPageEntityCatalog(1);
-    await getPageEntityCatalog(1);
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(await getPageEntityCatalog(1)).toEqual(refreshedCatalog);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("propagates failures without caching an empty catalog", async () => {

--- a/apps/web/src/lib/publicCatalog.server.ts
+++ b/apps/web/src/lib/publicCatalog.server.ts
@@ -66,13 +66,8 @@ const loadCompanyPortfolio = unstable_cache(
   { revalidate: 300 },
 );
 
-/** Public page summaries revalidate every five minutes; member reads stay fresh. */
+/** Entity catalog summaries are public and revalidate every five minutes. */
 export async function getPageEntityCatalog(entity: number) {
-  const session = await getSession();
-  if (session.accessToken) {
-    const { client } = await getPublicPageServerClient();
-    return client.entities.catalog({ entity });
-  }
   return loadEntityCatalog(entity);
 }
 


### PR DESCRIPTION
Entity overview server renders now reuse the same five-minute public catalog snapshot for signed-in and anonymous visitors. The catalog response has no member-specific state, so this removes repeated aggregate work without changing personalized Entity details or Bottle-list paths.

The existing cache key and refresh behavior are unchanged. Focused coverage verifies that member requests share the refreshed snapshot.
