### PR TITLE
fix(scraper): simplify request settings

### DIFF
--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -36,10 +36,10 @@ It covers review publishing, source approval, and rollback.
 ## Registering a source
 
 1. Define a target in `registry.ts`. A target groups sources that must share a
-   request limit. List every website address it may use and either enforce
+   request pace. List every website address it may use and either enforce
    robots.txt or record why robots.txt does not apply.
 2. Define the source with its external-site key, allowed targets, schemas for
-   saved progress and parsed results, request limit, adapter, and save function.
+   saved progress and parsed results, adapter, and save function.
 3. Make the adapter use only its current run. After saving a page, save the
    place where the next run should continue. Repeating the prior page must be
    safe.
@@ -55,12 +55,13 @@ sources must not use it. When converting an old source, remove those helpers
 and move the source out of `adapters/legacy/`.
 
 Give sources the same target only when the same organization runs them and they
-must share one request limit. A target may list several web addresses when that
+must share one request pace. A target may list several web addresses when that
 organization uses more than one host. Do not group sites from their domain
 names alone.
 
 Set `requestsPerHour` for each target. Requests are spread evenly across the
-hour: 60 means one request per minute. A value above 60 needs a short reason.
+hour: 120 means one request every 30 seconds. A value above 120 needs a short
+reason.
 
 ## Scrape sources
 

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -38,14 +38,10 @@ import {
   SCRAPE_SOURCE_MAX_LIST_PAGES,
   parseScrapeRules,
   scrapeRulesLimit,
-  scrapeRunRequestLimit,
   type StoredScrapeRules,
 } from "./rules";
 import { recordScrapeSourcePreview } from "./service";
-import {
-  MAX_SUGGESTION_DETAIL_PAGES,
-  suggestionRequestLimit,
-} from "./setupAgent";
+import { MAX_SUGGESTION_DETAIL_PAGES } from "./setupAgent";
 import { suggestScrapeSourceRevision } from "./suggestion";
 import { loadScrapeSourceTarget } from "./target";
 
@@ -318,7 +314,6 @@ export function createLocalScrapeSourcePreview(input: {
     externalSiteKey: input.siteKey,
     recordType: input.rules.kind,
     targetKeys: [input.targetKey],
-    requestLimit: scrapeRunRequestLimit(input.rules),
     resumeFromLastRun: false,
     cursorSchema: ConfiguredScrapeCursorSchema,
     observationSchema: observationSchemaForRules(input.rules),
@@ -409,7 +404,6 @@ function createScrapeSourceDefinition(input: {
     externalSiteKey: input.siteKey,
     recordType: input.rules.kind,
     targetKeys: [input.targetKey],
-    requestLimit: scrapeRunRequestLimit(input.rules),
     resumeFromLastRun: false,
     cursorSchema: ConfiguredScrapeCursorSchema,
     observationSchema,
@@ -584,7 +578,6 @@ export async function resolveScrapeSourceRunRegistry(
       key: `source-${suggestion.source.id}`,
       externalSiteKey: suggestion.siteKey,
       targetKeys: [target.key],
-      requestLimit: suggestionRequestLimit(suggestion.source.sampleUrls.length),
       resumeFromLastRun: false,
       cursorSchema: z.null(),
       observationSchema: z.unknown(),

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -109,7 +109,7 @@ test("creates a site and its admin-owned request rows", async () => {
       key: "reviews-example",
       managedBy: "admin",
       enabled: true,
-      minimumSpacingMs: 60_000,
+      minimumSpacingMs: 30_000,
     }),
   ]);
   expect(await db.select().from(scrapeOrigins)).toEqual([

--- a/apps/server/src/scraper/definitions.test.ts
+++ b/apps/server/src/scraper/definitions.test.ts
@@ -24,7 +24,7 @@ function source(
   });
 }
 
-test("applies conservative target and run defaults", () => {
+test("applies target defaults", () => {
   const target = defineScrapeTarget({
     key: "retailer",
     origins: [{ origin: "https://example.com", robots: { mode: "enforce" } }],
@@ -33,14 +33,13 @@ test("applies conservative target and run defaults", () => {
 
   expect(target).toMatchObject({
     enabled: true,
-    minimumSpacingMs: 60_000,
-    requestsPerWindow: 60,
+    minimumSpacingMs: 30_000,
+    requestsPerWindow: 120,
     windowMs: 3_600_000,
     timeoutMs: 30_000,
     maxResponseBytes: 10 * 1024 * 1024,
     maxRetries: 2,
   });
-  expect(definition.requestLimit).toBe(100);
   expect(definition.resumeFromLastRun).toBe(false);
 });
 

--- a/apps/server/src/scraper/definitions.ts
+++ b/apps/server/src/scraper/definitions.ts
@@ -17,8 +17,7 @@ export class ScraperTargetDisabledError extends Error {
 }
 
 export const DEFAULT_SCRAPER_SETTINGS = Object.freeze({
-  requestsPerHour: 60,
-  requestLimit: 100,
+  requestsPerHour: 120,
   timeoutMs: 30_000,
   maxResponseBytes: 10 * 1024 * 1024,
   maxRetries: 2,
@@ -156,12 +155,6 @@ const SourceDefinitionSchema = z
     externalSiteKey: z.enum(REGISTERED_EXTERNAL_SITE_KEY_LIST),
     recordType: z.enum(["review", "price", "catalog", "bottle"]).optional(),
     targetKeys: z.tuple([DefinitionKeySchema], DefinitionKeySchema),
-    requestLimit: z
-      .number()
-      .int()
-      .positive()
-      .max(DEFAULT_SCRAPER_SETTINGS.requestLimit)
-      .default(DEFAULT_SCRAPER_SETTINGS.requestLimit),
     resumeFromLastRun: z.boolean().default(false),
     cursorSchema: ZodSchemaSchema,
     observationSchema: ZodSchemaSchema,
@@ -194,16 +187,14 @@ export function defineScrapeTarget(
 export function defineScraperSource<TCursor, TObservation>(
   input: Omit<
     BuiltInScraperSourceDefinition<TCursor, TObservation>,
-    "requestLimit" | "resumeFromLastRun"
+    "resumeFromLastRun"
   > & {
-    requestLimit?: number;
     resumeFromLastRun?: boolean;
   },
 ): BuiltInScraperSourceDefinition<TCursor, TObservation> {
   const parsed = SourceDefinitionSchema.parse(input);
   return {
     ...input,
-    requestLimit: parsed.requestLimit,
     resumeFromLastRun: parsed.resumeFromLastRun,
   };
 }

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -87,7 +87,6 @@ async function setupRuntime({
         key: "finedrams",
         externalSiteKey: "finedrams",
         targetKeys: ["operator"],
-        requestLimit,
         cursorSchema: z.null(),
         observationSchema: z.string(),
         adapter,

--- a/apps/server/src/scraper/lifecycle.ts
+++ b/apps/server/src/scraper/lifecycle.ts
@@ -28,6 +28,7 @@ import type { ScraperRegistry } from "./types";
 
 const STALE_EXTERNAL_SITE_RUN_MS = 10 * 60_000;
 const EXTERNAL_SITE_RUN_RECONCILE_LIMIT = 100;
+const REQUESTS_BEFORE_PAUSE = 100;
 
 type RunTrigger = ExternalSiteRun["trigger"];
 export type ScraperEnqueue = (
@@ -118,7 +119,7 @@ async function insertRun(
       trigger,
       purpose: "collect",
       requestedById,
-      requestLimit: source.requestLimit,
+      requestLimit: REQUESTS_BEFORE_PAUSE,
       requestErrorCount: 0,
       recordType: source.recordType,
       cursor,

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -89,16 +89,13 @@ test("registers each built-in scraper source with its target", () => {
   expect(scraperRegistry.targets.get("compassbox")).toBeDefined();
   expect(EXTERNAL_SITE_DEFINITIONS.dramface.initialRunEvery).toBe(1440);
   expectHourlyLimit("dramface", 25);
-  expect(scraperRegistry.sources.get("dramface")?.requestLimit).toBe(30);
   expect(EXTERNAL_SITE_DEFINITIONS.fredminnick.initialRunEvery).toBe(1440);
   expectHourlyLimit("fredminnick", 10);
-  expect(scraperRegistry.sources.get("fredminnick")?.requestLimit).toBe(9);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskeyreviewer.initialRunEvery).toBe(1440);
   expectHourlyLimit("whiskeyreviewer", 10);
   expect(scraperRegistry.targets.get("kilchoman")).toBeDefined();
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyadvocate.initialRunEvery).toBeNull();
-  expectHourlyLimit("whiskyadvocate", 20);
-  expect(scraperRegistry.sources.get("whiskyadvocate")?.requestLimit).toBe(30);
+  expectHourlyLimit("whiskyadvocate", 120);
   expect(scraperRegistry.sources.get("whiskyadvocate")?.resumeFromLastRun).toBe(
     true,
   );
@@ -106,7 +103,6 @@ test("registers each built-in scraper source with its target", () => {
   expectHourlyLimit("whiskynotes", 30);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyfun.initialRunEvery).toBe(1440);
   expectHourlyLimit("whiskyfun", 25);
-  expect(scraperRegistry.sources.get("whiskyfun")?.requestLimit).toBe(30);
   expect(scraperRegistry.sources.get("whiskyfun")?.resumeFromLastRun).toBe(
     true,
   );

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -313,7 +313,6 @@ export const scraperRegistry = createScraperRegistry({
     }),
     defineScrapeTarget({
       key: "whiskyadvocate",
-      requestsPerHour: 20,
       origins: [
         {
           origin: "https://whiskyadvocate.com",
@@ -404,7 +403,6 @@ export const scraperRegistry = createScraperRegistry({
       externalSiteKey: "dramface",
       recordType: "review",
       targetKeys: ["dramface"],
-      requestLimit: 30,
       cursorSchema: DramfaceCursorSchema,
       observationSchema: DramfaceObservationSchema,
       adapter: dramfaceAdapter,
@@ -415,7 +413,6 @@ export const scraperRegistry = createScraperRegistry({
       externalSiteKey: "fredminnick",
       recordType: "review",
       targetKeys: ["fredminnick"],
-      requestLimit: 9,
       cursorSchema: FredMinnickCursorSchema,
       observationSchema: FredMinnickObservationSchema,
       adapter: fredMinnickAdapter,
@@ -426,9 +423,6 @@ export const scraperRegistry = createScraperRegistry({
       externalSiteKey: "whiskyadvocate",
       recordType: "review",
       targetKeys: ["whiskyadvocate"],
-      // Keep the run limit above the hourly limit so the run waits for the next
-      // hour instead of stopping.
-      requestLimit: 30,
       resumeFromLastRun: true,
       cursorSchema: WhiskyAdvocateCursorSchema,
       observationSchema: WhiskyAdvocateObservationSchema,
@@ -440,7 +434,6 @@ export const scraperRegistry = createScraperRegistry({
       externalSiteKey: "whiskyfun",
       recordType: "review",
       targetKeys: ["whiskyfun"],
-      requestLimit: 30,
       resumeFromLastRun: true,
       cursorSchema: WhiskyfunCursorSchema,
       observationSchema: WhiskyfunObservationSchema,

--- a/apps/server/src/scraper/runs.test.ts
+++ b/apps/server/src/scraper/runs.test.ts
@@ -84,7 +84,6 @@ async function setupRun({
         key: "fixture-source",
         externalSiteKey: "finedrams",
         targetKeys: ["fixture-target"],
-        requestLimit,
         cursorSchema: FixtureCursorSchema,
         observationSchema: FixtureObservationSchema,
         adapter,
@@ -299,7 +298,7 @@ test("does not count planned spacing as another run attempt", async () => {
     ),
   ).resolves.toEqual({
     status: "waiting",
-    nextAttemptAt: new Date("2026-08-18T12:01:00Z"),
+    nextAttemptAt: new Date("2026-08-18T12:00:30Z"),
   });
   const [waiting] = await db
     .select()
@@ -318,7 +317,7 @@ test("does not count planned spacing as another run attempt", async () => {
       {
         registry,
         fetchImpl,
-        clock: fixedClock("2026-08-18T12:01:00Z"),
+        clock: fixedClock("2026-08-18T12:00:30Z"),
         executionToken: "second",
       },
     ),

--- a/apps/server/src/scraper/types.ts
+++ b/apps/server/src/scraper/types.ts
@@ -63,7 +63,6 @@ export type ScraperSourceDefinition<TCursor = any, TObservation = any> = {
   externalSiteKey: ExternalSiteKey;
   recordType?: "review" | "price" | "catalog" | "bottle";
   targetKeys: readonly [string, ...string[]];
-  requestLimit: number;
   resumeFromLastRun: boolean;
   cursorSchema: z.ZodType<TCursor>;
   observationSchema: z.ZodType<TObservation>;


### PR DESCRIPTION
New scraper targets now wait 30 seconds between page loads, and Whisky Advocate uses that default instead of its old, slower setting. Existing sites with a deliberately slower pace keep it.

Built-in scrapers no longer set a second request count. They all use one internal safety stop, so each website has only one request setting to understand.
