### PR TITLE
feat(scraper): convert Whiskyfun to saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -98,6 +98,15 @@ function prepareWhiskyNotes(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareWhiskyfun(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "whiskyfun", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareDramface(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "dramface", ...input },
@@ -215,6 +224,7 @@ function codeOwnedSource(
     | "northstarspirits"
     | "thompsonbros"
     | "whiskeyreviewer"
+    | "whiskyfun"
     | "whiskynotes"
     | "whiskysaga"
     | "whiskystudy"
@@ -269,6 +279,11 @@ const whiskyNotesCanonicalUrl =
 const whiskyNotesRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("whiskynotes")!],
   sources: [codeOwnedSource("whiskynotes")],
+});
+
+const whiskyfunRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("whiskyfun")!],
+  sources: [codeOwnedSource("whiskyfun")],
 });
 
 const dramfaceCanonicalUrl =
@@ -770,6 +785,61 @@ async function setupWhiskyNotesMigration(bottleIds: [number, number]) {
     completedAt: new Date(),
   });
   return { site, article, reviews };
+}
+
+async function setupWhiskyfunMigration(bottleIds: [number, number]) {
+  const [site] = await db
+    .insert(externalSites)
+    .values({ type: "whiskyfun", name: "Whiskyfun", runEvery: null })
+    .returning();
+  await syncScraperDefinitions(whiskyfunRegistry);
+  const articles = await db
+    .insert(externalReviewArticles)
+    .values([
+      {
+        externalSiteId: site.id,
+        canonicalUrl:
+          "https://www.whiskyfun.com/2026/A-little-example-trio.html",
+        title: "A little example trio",
+        publishedAt: new Date("2026-09-07"),
+      },
+      {
+        externalSiteId: site.id,
+        canonicalUrl:
+          "https://www.whiskyfun.com/archivejuly26-1-Caol-Ila.html#080726",
+        title: "A small example session",
+        publishedAt: new Date("2026-07-08"),
+      },
+    ])
+    .returning();
+  const reviews = await db
+    .insert(externalReviews)
+    .values([
+      {
+        articleId: articles[0]!.id,
+        sourceKey: `whiskyfun:${"a".repeat(64)}`,
+        name: "First Example (46%)",
+        reviewerName: "Serge Valentin",
+        bottleId: bottleIds[0],
+        hidden: true,
+        nativeScoreValue: 88,
+        nativeScoreScale: 100,
+        nativeScoreDisplay: "88 points",
+      },
+      {
+        articleId: articles[1]!.id,
+        sourceKey: `whiskyfun:${"b".repeat(64)}`,
+        name: "Second Example (51.2%)",
+        reviewerName: "Serge Valentin",
+        bottleId: bottleIds[1],
+        hidden: false,
+        nativeScoreValue: 91,
+        nativeScoreScale: 100,
+        nativeScoreDisplay: "91 points",
+      },
+    ])
+    .returning();
+  return { site, articles, reviews };
 }
 
 async function setupCompassBoxMigration() {
@@ -1481,6 +1551,56 @@ describe("POST /admin/scrape-sources/prepare", () => {
     expect(await db.select().from(externalReviews)).toEqual(before);
     expect(await db.select().from(scrapeTargets)).toEqual(targets);
     expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares Whiskyfun without replacing current or archive reviews", async ({
+    fixtures,
+  }) => {
+    const firstBottle = await fixtures.Bottle();
+    const secondBottle = await fixtures.Bottle();
+    const { site, articles, reviews } = await setupWhiskyfunMigration([
+      firstBottle.id,
+      secondBottle.id,
+    ]);
+
+    await expect(prepareWhiskyfun()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      reviewCount: 2,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(externalReviews)).toEqual(reviews);
+
+    const applied = await prepareWhiskyfun({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      reviewCount: 2,
+      applied: true,
+    });
+    await syncScraperDefinitions(whiskyfunRegistry);
+    expect(await db.select().from(externalReviewArticles)).toEqual(articles);
+    expect(await db.select().from(externalReviews)).toEqual([
+      {
+        ...reviews[0],
+        sourceKey: reviewSourceKey(reviews[0].name, reviews[0].reviewerName),
+      },
+      {
+        ...reviews[1],
+        sourceKey: reviewSourceKey(reviews[1].name, reviews[1].reviewerName),
+      },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "review",
+        listUrl: "https://www.whiskyfun.com/whatsnew.xml",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
   });
 
   test("prepares WhiskyNotes without replacing multi-review records", async ({
@@ -2734,6 +2854,7 @@ describe("POST /admin/scrape-sources/prepare", () => {
       rules: {
         kind: "review",
         articles: {
+          document: "html",
           oneArticlePer: "body",
           link: "a.review",
           skipWhen: null,
@@ -2770,6 +2891,7 @@ describe("POST /admin/scrape-sources/prepare", () => {
             inside: "body",
             oneReviewPer: "element",
             selector: ".entry-content",
+            contains: null,
             name: {
               try: [
                 {

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -17,6 +17,7 @@ import { prepareWhiskeyReviewerSource } from "@peated/server/scraper/configured/
 import { prepareWhiskyNotesSource } from "@peated/server/scraper/configured/prepareWhiskyNotes";
 import { prepareWhiskySagaSource } from "@peated/server/scraper/configured/prepareWhiskySaga";
 import { prepareWhiskyStudySource } from "@peated/server/scraper/configured/prepareWhiskyStudy";
+import { prepareWhiskyfunSource } from "@peated/server/scraper/configured/prepareWhiskyfun";
 import { prepareWordsOfWhiskySource } from "@peated/server/scraper/configured/prepareWordsOfWhisky";
 import {
   ScrapeSourceConflictError,
@@ -42,7 +43,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, dramface, edradour, glenallachie, gordonmacphail, kilchoman, ncnean, northstarspirits, thompsonbros, whiskeyreviewer, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
+          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, dramface, edradour, glenallachie, gordonmacphail, kilchoman, ncnean, northstarspirits, thompsonbros, whiskeyreviewer, whiskyfun, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -86,6 +87,7 @@ export default procedure
       northstarspirits: prepareNorthStarSource,
       thompsonbros: prepareThompsonBrosSource,
       whiskeyreviewer: prepareWhiskeyReviewerSource,
+      whiskyfun: prepareWhiskyfunSource,
       whiskynotes: prepareWhiskyNotesSource,
       whiskysaga: prepareWhiskySagaSource,
       whiskystudy: prepareWhiskyStudySource,

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/testUtils.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/testUtils.ts
@@ -7,6 +7,7 @@ import {
 export const reviewRules = {
   kind: "review" as const,
   articles: {
+    document: "html",
     oneArticlePer: "li",
     link: "a.review",
     skipWhen: null,
@@ -41,6 +42,7 @@ export const reviewRules = {
       inside: "body",
       oneReviewPer: "element" as const,
       selector: "article.review",
+      contains: null,
       name: {
         try: [
           {

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -80,12 +80,14 @@ admin can return to any older revision that passed. Pausing a source stops
 collection but keeps its revisions and run history.
 
 Older rule versions remain supported so saved sources keep working. New
-sources use version 8. A review source has `articles` for finding article links
+sources use version 9. A review source has `articles` for finding article links
 and `article` for reading an article. A price source uses `products` and
 `product` in the same way. `oneArticlePer` or `oneProductPer` identifies each
 result on the list page. `link` finds its link, `skipWhen` can leave out a
 result, and `nextPage` can continue to the next list page. Links must stay on
 the source website. Code follows at most five list pages and stops at `limit`.
+Review indexes set `document` to `html` or `xml`. HTML links use `href`; XML
+links use the selected element's text.
 
 Each field has an ordered `try` list. A read can get text, get an attribute, or
 use a fixed value. The parser uses the first non-empty result. A read can match
@@ -101,7 +103,8 @@ path with bounded `yyyy`, `yy`, `MM`, `dd`, and `*` parts. Scores can map up to
 
 For reviews, `article.reviews.inside` identifies the part of the article that
 contains reviews. `oneReviewPer: "element"` means each selected element is one
-review. `oneReviewPer: "section"` means each matching `startsAt` label starts a
+review. `contains` can require another selector inside each review element.
+`oneReviewPer: "section"` means each matching `startsAt` label starts a
 review; `stopBefore` can mark where the reviews end. `inside` must select the
 closest single area shared by every review start. This also works when layout
 elements wrap the labels and review content. A single section must say whether
@@ -182,16 +185,17 @@ pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 
 ```
 
 The input has the same `listUrl` and `rules` fields accepted by the revision
-API. Set `rulesVersion` to `8` when testing current operations. An omitted
+API. Set `rulesVersion` to `9` when testing current operations. An omitted
 version means version 1 so existing preview files keep their original behavior:
 
 ```json
 {
-  "rulesVersion": 8,
+  "rulesVersion": 9,
   "listUrl": "https://example.com/reviews",
   "rules": {
     "kind": "review",
     "articles": {
+      "document": "html",
       "oneArticlePer": "article",
       "link": "a[href]",
       "skipWhen": null,
@@ -228,6 +232,7 @@ version means version 1 so existing preview files keep their original behavior:
         "inside": "main",
         "oneReviewPer": "element",
         "selector": "article.review",
+        "contains": null,
         "name": {
           "try": [
             {

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -392,6 +392,7 @@ function reviewText(selector: string, take: "first" | "all" = "first") {
 const currentReviewRules = {
   kind: "review",
   articles: {
+    document: "html",
     oneArticlePer: "article.card",
     link: "a[href]",
     skipWhen: { selector: ".skip", match: null },
@@ -495,6 +496,7 @@ const currentReviewRules = {
 const dramfaceSavedRules = {
   kind: "review",
   articles: {
+    document: "html",
     oneArticlePer: "article.blog-basic-grid--container",
     link: "h1.blog-title a[href]",
     skipWhen: null,
@@ -578,6 +580,134 @@ const dramfaceSavedRules = {
     },
   },
 } as const satisfies ScrapeRules;
+
+const elementArticleRules = {
+  ...currentReviewRules,
+  articles: {
+    document: "html",
+    oneArticlePer: "body",
+    link: "a[href]",
+    skipWhen: null,
+    nextPage: null,
+    limit: 10,
+  },
+  article: {
+    ...currentReviewRules.article,
+    title: pageText("h1"),
+    publishedDate: {
+      try: [{ get: "dateFromUrl", format: "/yyyy/MM/dd/example.html" }],
+    },
+    reviews: {
+      inside: "body",
+      oneReviewPer: "element",
+      selector: "article.review",
+      contains: null,
+      name: reviewText("h2"),
+      reviewer: null,
+      tastingNotes: null,
+      score: {
+        try: [
+          {
+            get: "text",
+            from: "review",
+            selector: ".score",
+            take: "first",
+            match: ["{value} points"],
+            addStart: null,
+            addEnd: " points",
+          },
+        ],
+        scale: 100,
+        map: null,
+      },
+    },
+  },
+} as const satisfies ScrapeRules;
+
+test("reads text links from an XML review index", () => {
+  const rules = {
+    ...currentReviewRules,
+    articles: {
+      document: "xml",
+      oneArticlePer: "item",
+      link: "link",
+      skipWhen: {
+        selector: "title",
+        match: ["{anything}rum{anything}"],
+      },
+      nextPage: null,
+      limit: 20,
+    },
+  } as const satisfies ScrapeRules;
+
+  expect(
+    parseScrapeList(
+      rules,
+      `
+        <rss><channel>
+          <item>
+            <title>A little trio of malts</title>
+            <link>https://reviews.test/2026/malts.html</link>
+          </item>
+          <item>
+            <title>A few rums</title>
+            <link>https://reviews.test/2026/rums.html</link>
+          </item>
+        </channel></rss>
+      `,
+      new URL("https://reviews.test/whatsnew.xml"),
+    ),
+  ).toEqual({
+    links: ["https://reviews.test/2026/malts.html"],
+    nextPageUrl: null,
+    issues: [],
+  });
+});
+
+test("reads formatted dates from attributes and filters review elements", () => {
+  const rules = {
+    ...elementArticleRules,
+    article: {
+      ...elementArticleRules.article,
+      publishedDate: {
+        try: [
+          {
+            get: "dateFromAttribute",
+            selector: "a[name]",
+            attribute: "name",
+            format: "ddMMyy",
+          },
+        ],
+      },
+      reviews: {
+        ...elementArticleRules.article.reviews,
+        selector: "article",
+        contains: "h2",
+      },
+    },
+  } as const satisfies ScrapeRules;
+
+  const result = parseScrapeDetail(
+    rules,
+    `
+      <a name="070926"></a><h1>September seven</h1>
+      <article><p>Introduction</p></article>
+      <article><h2>Example Malt</h2><span class="score">88 points</span></article>
+    `,
+    new URL("https://reviews.test/2026/example.html"),
+  );
+
+  expect(result).toMatchObject({
+    kind: "review",
+    issues: [],
+    value: {
+      article: {
+        publishedAt: new Date("2026-09-07T00:00:00.000Z"),
+        externalReviews: [{ name: "Example Malt" }],
+      },
+    },
+  });
+});
 
 function expectReviewFactsAndEvidenceToMatch(
   configured: ReturnType<typeof parseScrapeDetail>,

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -370,7 +370,13 @@ function parseSavedList(
   html: string,
   pageUrl: URL,
 ): ScrapeListResult {
-  const $ = load(html);
+  const document =
+    "articles" in rules &&
+    "document" in rules.articles &&
+    rules.articles.document === "xml"
+      ? "xml"
+      : "html";
+  const $ = load(html, document === "xml" ? { xmlMode: true } : undefined);
   const issues: ScrapeIssue[] = [];
   const links = new Set<string>();
   const list = rules.kind === "review" ? rules.articles : rules.products;
@@ -383,7 +389,10 @@ function parseSavedList(
   let skippedItemCount = 0;
   try {
     for (const itemElement of itemElements) {
-      const item = load($.html(itemElement));
+      const item = load(
+        $.html(itemElement),
+        document === "xml" ? { xmlMode: true } : undefined,
+      );
       if (list.skipWhen) {
         const skipWhen = list.skipWhen;
         const matches = item(skipWhen.selector).toArray();
@@ -413,7 +422,9 @@ function parseSavedList(
       }
       const itemLinks = item(list.link).toArray();
       for (const element of itemLinks) {
-        const raw = item(element).attr("href");
+        const raw =
+          item(element).attr("href") ??
+          (document === "xml" ? readText(item(element)) : null);
         if (!raw?.trim()) continue;
         try {
           links.add(absoluteHttpUrl(raw.trim(), pageUrl));
@@ -476,7 +487,7 @@ function parseDate(value: string | null) {
   return Number.isFinite(timestamp) ? new Date(timestamp) : null;
 }
 
-function parseDateFromUrl(url: URL, format: string) {
+function parseDateWithFormat(value: string, format: string) {
   // Rules v3 owns this token grammar; literals are escaped so saved rules cannot run regex code.
   const tokens: string[] = [];
   let pattern = "^";
@@ -498,7 +509,7 @@ function parseDateFromUrl(url: URL, format: string) {
   pattern += format.slice(offset).replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
   pattern += "$";
 
-  const match = new RegExp(pattern, "u").exec(url.pathname);
+  const match = new RegExp(pattern, "u").exec(value);
   if (!match) return null;
   const values = new Map<string, number>();
   for (const [index, token] of tokens.entries()) {
@@ -526,6 +537,10 @@ function parseDateFromUrl(url: URL, format: string) {
     date.getUTCDate() === day
     ? date
     : null;
+}
+
+function parseDateFromUrl(url: URL, format: string) {
+  return parseDateWithFormat(url.pathname, format);
 }
 
 function parseNumber(value: string | null) {
@@ -933,6 +948,11 @@ function selectSavedReviewItems(
   if (rules.oneReviewPer === "element") {
     return area
       .find(rules.selector)
+      .filter((_, element) =>
+        "contains" in rules && rules.contains
+          ? $(element).find(rules.contains).length > 0
+          : true,
+      )
       .toArray()
       .map((element) => ({
         body: $(element),
@@ -1038,6 +1058,12 @@ function readPublishedDate(
   for (const rule of field.try) {
     if (rule.get === "dateFromUrl") {
       const date = parseDateFromUrl(pageUrl, rule.format);
+      if (date) return date;
+      continue;
+    }
+    if (rule.get === "dateFromAttribute") {
+      const value = $(rule.selector).first().attr(rule.attribute);
+      const date = value ? parseDateWithFormat(value, rule.format) : null;
       if (date) return date;
       continue;
     }

--- a/apps/server/src/scraper/configured/prepareWhiskyfun.ts
+++ b/apps/server/src/scraper/configured/prepareWhiskyfun.ts
@@ -1,0 +1,23 @@
+import {
+  prepareReviewSource,
+  type PrepareReviewSourceInput,
+} from "./prepareReviewSource";
+
+const CURRENT_ARTICLE_URL =
+  /^https:\/\/www\.whiskyfun\.com\/\d{4}\/[^/?#]+\.html$/;
+const ARCHIVE_ARTICLE_URL =
+  /^https:\/\/www\.whiskyfun\.com\/archive(?:january|february|march|april|avril|may|june|july|august|september|october|november|december)\d{2}-[12](?:-[^/?#]+)?\.html#\d{6}$/i;
+
+/** Checks Whiskyfun's existing reviews; applying keeps record IDs and pauses collection. */
+export async function prepareWhiskyfunSource(input: PrepareReviewSourceInput) {
+  return prepareReviewSource(input, {
+    siteKey: "whiskyfun",
+    siteName: "Whiskyfun",
+    targetKey: "whiskyfun",
+    origin: "https://www.whiskyfun.com",
+    listUrl: "https://www.whiskyfun.com/whatsnew.xml",
+    allowsMultipleReviews: true,
+    isCanonicalArticleUrl: (url) =>
+      CURRENT_ARTICLE_URL.test(url) || ARCHIVE_ARTICLE_URL.test(url),
+  });
+}

--- a/apps/server/src/scraper/configured/rules.test.ts
+++ b/apps/server/src/scraper/configured/rules.test.ts
@@ -34,6 +34,7 @@ test("bounds list and detail pages", () => {
   const rules = ScrapeRulesSchema.parse({
     kind: "review",
     articles: {
+      document: "html",
       oneArticlePer: "article",
       link: "a",
       skipWhen: null,
@@ -68,6 +69,7 @@ test("bounds list and detail pages", () => {
         inside: "main",
         oneReviewPer: "element",
         selector: "article.review",
+        contains: null,
         name: {
           try: [
             {
@@ -89,7 +91,20 @@ test("bounds list and detail pages", () => {
   });
   if (rules.kind !== "review") throw new Error("Expected review rules.");
   expect(rules.articles.limit).toBe(99);
-  expect(parseScrapeRules(8, rules)).toEqual(rules);
+  expect(parseScrapeRules(9, rules)).toEqual(rules);
+  expect(() => parseScrapeRules(8, rules)).toThrow();
+  if (rules.article.reviews.oneReviewPer !== "element") {
+    throw new Error("Expected element review rules.");
+  }
+  const { document: _document, ...version8Articles } = rules.articles;
+  const { contains: _contains, ...version8Reviews } = rules.article.reviews;
+  const version8Rules = {
+    ...rules,
+    articles: version8Articles,
+    article: { ...rules.article, reviews: version8Reviews },
+  };
+  expect(parseScrapeRules(8, version8Rules)).toEqual(version8Rules);
+  expect(() => parseScrapeRules(9, version8Rules)).toThrow();
   expect(() =>
     ScrapeRulesSchema.parse({
       ...rules,
@@ -104,8 +119,8 @@ test("bounds list and detail pages", () => {
 
 test("rejects rules for an unsupported stored format", () => {
   const rules = ScrapeRulesV5Schema.parse(reviewConfig(25));
-  expect(() => parseScrapeRules(9, rules)).toThrow(
-    "Unsupported scrape rules version: 9.",
+  expect(() => parseScrapeRules(10, rules)).toThrow(
+    "Unsupported scrape rules version: 10.",
   );
 });
 
@@ -118,7 +133,7 @@ test("loads old rules only through the version 1 contract", () => {
       list: { ...rules.list, item: ".card" },
     }),
   ).toThrow();
-  expect(SCRAPE_RULES_VERSION).toBe(8);
+  expect(SCRAPE_RULES_VERSION).toBe(9);
 });
 
 test("adds catalog rules only in version 7", () => {

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -1,7 +1,10 @@
 import { CURRENCY_LIST } from "@peated/server/constants";
 import type { JsonValue } from "@peated/server/scraper/types";
 import { z } from "zod";
-import { ScrapeTextMatchesSchema } from "./textTemplate";
+import {
+  ScrapeTextMatchesSchema,
+  ScrapeTextTemplateSchema,
+} from "./textTemplate";
 
 const SCRAPE_RULES_VERSION_1 = 1;
 const SCRAPE_RULES_VERSION_2 = 2;
@@ -10,7 +13,8 @@ const SCRAPE_RULES_VERSION_4 = 4;
 const SCRAPE_RULES_VERSION_5 = 5;
 const SCRAPE_RULES_VERSION_6 = 6;
 const SCRAPE_RULES_VERSION_7 = 7;
-export const SCRAPE_RULES_VERSION = 8;
+const SCRAPE_RULES_VERSION_8 = 8;
+export const SCRAPE_RULES_VERSION = 9;
 // TODO(scraper-platform): Add event after scraped-event match and update rules are defined.
 export const SCRAPE_SOURCE_KIND_LIST = ["review", "price", "catalog"] as const;
 export type ScrapeSourceKind = (typeof SCRAPE_SOURCE_KIND_LIST)[number];
@@ -620,6 +624,30 @@ const ScrapeDateFieldV8Schema = z
   })
   .strict();
 
+const ScrapeDateFromAttributeV9Schema = z
+  .object({
+    get: z.literal("dateFromAttribute"),
+    selector: ScrapeSelectorSchema,
+    attribute: ScrapeAttributeSchema,
+    format: ScrapeUrlDateFormatSchema,
+  })
+  .strict();
+
+const ScrapeDateFieldV9Schema = z
+  .object({
+    try: z
+      .array(
+        z.union([
+          ScrapePageReadSchema,
+          ScrapeDateFromUrlV6Schema,
+          ScrapeDateFromAttributeV9Schema,
+        ]),
+      )
+      .min(1)
+      .max(3),
+  })
+  .strict();
+
 const ScrapeScoreV8Schema = scrapeScoreSchema(ScrapeReviewTryV8Schema);
 
 const scrapeReviewFieldsV8 = {
@@ -668,11 +696,20 @@ const ScrapeArticlesV8Schema = ScrapeArticlesV6Schema.extend({
   skipWhen: ScrapeSkipV8Schema.nullable(),
 }).strict();
 
+const ScrapeSkipV9Schema = ScrapeSkipV8Schema.extend({
+  match: z.array(ScrapeTextTemplateSchema).min(1).max(10).nullable(),
+}).strict();
+
+const ScrapeArticlesV9Schema = ScrapeArticlesV8Schema.extend({
+  document: z.enum(["html", "xml"]),
+  skipWhen: ScrapeSkipV9Schema.nullable(),
+}).strict();
+
 const ScrapeProductsV8Schema = ScrapeProductsV6Schema.extend({
   skipWhen: ScrapeSkipV8Schema.nullable(),
 }).strict();
 
-export const ScrapeReviewRulesSchema = z
+const ScrapeReviewRulesV8Schema = z
   .object({
     kind: z.literal("review"),
     articles: ScrapeArticlesV8Schema,
@@ -682,6 +719,43 @@ export const ScrapeReviewRulesSchema = z
         title: ScrapePageFieldSchema,
         publishedDate: ScrapeDateFieldV8Schema,
         reviews: ScrapeReviewGroupsV8Schema,
+      })
+      .strict(),
+  })
+  .strict();
+
+const ScrapeReviewGroupsV9Schema = z.union([
+  z
+    .object({
+      inside: ScrapeSelectorSchema,
+      oneReviewPer: z.literal("element"),
+      selector: ScrapeSelectorSchema,
+      contains: ScrapeSelectorSchema.nullable(),
+      ...scrapeReviewFieldsV8,
+    })
+    .strict(),
+  z
+    .object({
+      inside: ScrapeSelectorSchema,
+      oneReviewPer: z.literal("section"),
+      startsAt: ScrapeTextMarkerV8Schema,
+      stopBefore: ScrapeTextMarkerV8Schema.nullable(),
+      whenOnlyOneReview: z.enum(["startAtReview", "useWholeArea"]),
+      ...scrapeReviewFieldsV8,
+    })
+    .strict(),
+]);
+
+export const ScrapeReviewRulesSchema = z
+  .object({
+    kind: z.literal("review"),
+    articles: ScrapeArticlesV9Schema,
+    article: z
+      .object({
+        canonicalUrl: ScrapePageFieldSchema.nullable(),
+        title: ScrapePageFieldSchema,
+        publishedDate: ScrapeDateFieldV9Schema,
+        reviews: ScrapeReviewGroupsV9Schema,
       })
       .strict(),
   })
@@ -740,6 +814,11 @@ export const StoredScrapeRulesSchema = z.union([
   ScrapeRulesV5Schema,
   ScrapeRulesV6Schema,
   ScrapeRulesV7Schema,
+  z.discriminatedUnion("kind", [
+    ScrapeReviewRulesV8Schema,
+    ScrapePriceRulesSchema,
+    ScrapeCatalogRulesSchema,
+  ]),
   ScrapeRulesSchema,
 ]);
 
@@ -786,6 +865,15 @@ export function parseScrapeRules(
   }
   if (rulesVersion === SCRAPE_RULES_VERSION_7) {
     return ScrapeRulesV7Schema.parse(rules);
+  }
+  if (rulesVersion === SCRAPE_RULES_VERSION_8) {
+    return z
+      .discriminatedUnion("kind", [
+        ScrapeReviewRulesV8Schema,
+        ScrapePriceRulesSchema,
+        ScrapeCatalogRulesSchema,
+      ])
+      .parse(rules);
   }
   if (rulesVersion === SCRAPE_RULES_VERSION) {
     return ScrapeRulesSchema.parse(rules);

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -85,6 +85,7 @@ function reviewRules(titleSelector = "h1", paginate = false) {
   return {
     kind: "review",
     articles: {
+      document: "html",
       oneArticlePer: "body",
       link: "a.review",
       skipWhen: null,
@@ -121,6 +122,7 @@ function reviewRules(titleSelector = "h1", paginate = false) {
         inside: "body",
         oneReviewPer: "element",
         selector: "article.review",
+        contains: null,
         name: {
           try: [
             {

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -26,6 +26,7 @@ import {
 const rules = {
   kind: "review",
   articles: {
+    document: "html",
     oneArticlePer: "body",
     link: "a.review",
     skipWhen: null,
@@ -60,6 +61,7 @@ const rules = {
       inside: "body",
       oneReviewPer: "element",
       selector: "article.review",
+      contains: null,
       name: {
         try: [
           {
@@ -245,7 +247,7 @@ test("database constraints keep source and revision identity valid", async () =>
     createdById: user.id,
   });
   expect(first.revision).toBe(1);
-  expect(first.rulesVersion).toBe(8);
+  expect(first.rulesVersion).toBe(9);
 
   await expect(
     db.insert(scrapeSources).values({

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -48,6 +48,7 @@ function reviewCandidate(
     rules: {
       kind: "review" as const,
       articles: {
+        document: "html" as const,
         oneArticlePer: listOptions.item ?? "body",
         link: "a.review",
         skipWhen: listOptions.excludeWhen ?? null,
@@ -73,6 +74,7 @@ function reviewCandidate(
           inside: "body",
           oneReviewPer: "element" as const,
           selector: "article.review",
+          contains: null,
           name: reviewField(nameSelector, { match: ["{value} Review"] }),
           reviewer: null,
           tastingNotes: reviewField(".body p", {

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -20,7 +20,7 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v18";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v19";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_SUGGESTION_DETAIL_PAGES = 3;
 const MAX_RULE_CHECKS = 3;
@@ -104,8 +104,9 @@ const RULE_INSTRUCTIONS = [
   "A field's try list is read from top to bottom until a value is found.",
   'A review field can read from the current review or from the article. Article reads must say whether they apply to "firstReview" or "everyReview".',
   "Set tastingNotes only when the page has a reliable narrower selection for flavor tags and clips. The full review body is saved from the review selection.",
-  "When a date exists only in the article URL, use dateFromUrl with a format made from yyyy, yy, MM, dd, and * tokens.",
-  "Use dateFromAttribute with the same bounded format when a selected attribute contains the complete date.",
+  "Prefer a machine-readable date or timestamp from page text or an attribute so available time and timezone data are kept.",
+  "Only when no complete machine-readable date is available, use dateFromUrl with a format made from yyyy, yy, MM, dd, and * tokens.",
+  "Use dateFromAttribute with the same bounded format only when a selected attribute contains the complete date but is not a standard machine-readable date or timestamp.",
   "Set canonicalUrl only when page markup provides a preferred article URL. Otherwise set it to null.",
   "Include an optional field only when the supplied pages clearly and consistently provide it.",
   "For catalog sources, collect only the displayed name, preferred product page URL, stable product ID, image URL, volume, ABV, age, edition, and release year fields offered by the catalog schema.",

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -20,7 +20,7 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v16";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v18";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_SUGGESTION_DETAIL_PAGES = 3;
 const MAX_RULE_CHECKS = 3;
@@ -94,10 +94,10 @@ const RULE_INSTRUCTIONS = [
   "You have at most three checks. Do not answer with an explanation.",
   "</tool>",
   "<success_criteria>",
-  "Use articles or products to find one link inside each result on the chosen start page.",
+  "Use articles or products to find one link inside each result on the chosen start page. Set articles.document to html for webpages or xml for a public XML index.",
   "Use short CSS selectors that work across the supplied pages.",
   "For reviews, inside selects the article area that contains the reviews.",
-  'Use oneReviewPer "element" when each selected element is a complete review.',
+  'Use oneReviewPer "element" when each selected element is a complete review. Set contains only when each review element must contain another selector; otherwise set contains to null.',
   'Use oneReviewPer "section" when a heading or label starts each review. startsAt finds those labels and stopBefore can mark the end of all reviews.',
   'For sections, use whenOnlyOneReview "useWholeArea" only when one review needs the introduction before its label. Otherwise use "startAtReview".',
   "For sections, inside must select the closest single area shared by all review starts. Each start must be in a separate direct part of that area, even when the start is nested inside layout elements.",
@@ -105,6 +105,7 @@ const RULE_INSTRUCTIONS = [
   'A review field can read from the current review or from the article. Article reads must say whether they apply to "firstReview" or "everyReview".',
   "Set tastingNotes only when the page has a reliable narrower selection for flavor tags and clips. The full review body is saved from the review selection.",
   "When a date exists only in the article URL, use dateFromUrl with a format made from yyyy, yy, MM, dd, and * tokens.",
+  "Use dateFromAttribute with the same bounded format when a selected attribute contains the complete date.",
   "Set canonicalUrl only when page markup provides a preferred article URL. Otherwise set it to null.",
   "Include an optional field only when the supplied pages clearly and consistently provide it.",
   "For catalog sources, collect only the displayed name, preferred product page URL, stable product ID, image URL, volume, ABV, age, edition, and release year fields offered by the catalog schema.",
@@ -112,7 +113,7 @@ const RULE_INSTRUCTIONS = [
   "A nextPage selector must add new article or product links.",
   "</success_criteria>",
   "<rules>",
-  "oneArticlePer or oneProductPer must select each result container. link selects an anchor inside it; its href is used automatically.",
+  "oneArticlePer or oneProductPer must select each result container. link selects an anchor inside an HTML result and its href is used automatically. For an XML review index, link selects the element whose text is the URL.",
   "skipWhen selects content inside a result that means it should be skipped. Set it to null when every result should be read.",
   "nextPage selects an anchor whose href leads to the next results page. Set it to null when there is no next page.",
   'Use "src" for image URLs and "datetime" for machine-readable time values when those attributes exist.',

--- a/apps/server/src/scraper/configured/suggestion.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.test.ts
@@ -9,6 +9,7 @@ import {
 const reviewRules = {
   kind: "review",
   articles: {
+    document: "html",
     oneArticlePer: "body",
     link: "a.review",
     skipWhen: null,
@@ -45,6 +46,7 @@ const reviewRules = {
       inside: "body",
       oneReviewPer: "element",
       selector: "article.review",
+      contains: null,
       name: {
         try: [
           {

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -409,6 +409,33 @@ output, trigger one manual collection, and confirm that it updates the same
 price IDs and Bottle matches without reviving old products. Check the run and
 Sentry before restoring the saved schedule.
 
+## Whiskyfun
+
+Use the preparation endpoint with `{"site": "whiskyfun"}`. The check-only
+request inventories every saved review without changing it. It accepts both
+standalone current article URLs under `/YYYY/` and dated fragments on archive
+pages. Applying rewrites only the old hashed review keys, keeps article and
+review IDs and Bottle matches, transfers the existing request settings, and
+creates a paused review source.
+
+Before applying, stop the `whiskyfun` schedule and wait for active collection
+to finish. Save the existing article and review IDs, canonical URLs, review
+keys, Bottle links, publication approval, request limits, and run history. Run
+the version 9 rules through the full local no-write preview. Use Whiskyfun's
+public `whatsnew.xml` index to discover its stable standalone article URLs; it
+does not require a partnership or private feed. Set `articles.document` to
+`xml`, omit rum and other non-whisky article titles, and extract reviews only
+from the linked HTML pages. Each review element must contain a bottle heading.
+Read the visible date, author metadata, complete bottle name, and 100-point
+score.
+
+After applying, save and preview the reviewed rules in production. Activate
+only exact output, trigger one manual collection, and confirm that it updates
+the same current article and review IDs rather than creating duplicates. Check
+the run, parsed item counts, publication state, request state, and Sentry before
+restoring the daily schedule. Keep the built-in adapter until that production
+run is verified; remove it in a later cleanup.
+
 ## If something goes wrong
 
 A request without `apply: true` leaves records unchanged. After applying, keep the
@@ -421,9 +448,9 @@ handles reviews added after the switch. Do not delete source or run history.
 The preparation API is shared. It currently supports Bourbon Culture,
 Bruichladdich, Cadenhead's, Compass Box, Dramface, Edradour, GlenAllachie,
 Gordon & MacPhail, Kilchoman, Nc'nean, North Star, Thompson Bros., The Whiskey Reviewer,
-WhiskyNotes, Whisky Saga, The Whisky Study, and Words of Whisky. Other sites are
-rejected without changing records. Add each site's conversion behind this route
-as its existing records are reviewed.
+Whiskyfun, WhiskyNotes, Whisky Saga, The Whisky Study, and Words of Whisky.
+Other sites are rejected without changing records. Add each site's conversion
+behind this route as its existing records are reviewed.
 
 Prepare each source using its own rules for recognizing existing records.
 Articles with several reviews need a verified match for each review. Store


### PR DESCRIPTION
## Summary

Convert Whiskyfun from its built-in review adapter to the saved-rule scraper path while preserving existing review records and Bottle matches.

The source uses Whiskyfun's public XML index to discover stable article URLs, then extracts all review data from the linked HTML pages. Rule version 9 adds the narrowly scoped XML-index, attribute-date, and contained-review selectors needed for that structure while keeping older saved revisions parseable.

## Verification

- `pnpm --filter @peated/server test -- src/orpc/routes/external-sites/scrape-sources/prepare.test.ts -t 'prepares Whiskyfun' --maxWorkers=1`
- configured scraper suite: 118 tests passed
- `pnpm --filter @peated/server typecheck`
- focused lint and formatting
- local no-write preview against current Whiskyfun pages: Caperdonich, Aberlour, and Jura articles parsed with 9 scored reviews; rum entries excluded

## Rollout

The preparation route creates the saved source paused and rewrites only legacy hashed review keys. After deploy: inventory production IDs and matches, stop the legacy schedule, dry-run and apply preparation, preview the saved revision, activate it, run one collection, verify IDs/counts/Sentry, then restore the daily schedule.

## Risk

The primary risk is Whiskyfun's unusual XML-to-HTML structure and older archive-fragment URLs. Both shapes are covered by parser and migration tests. The built-in adapter remains available until the first production saved-rule run is verified.
