### PR TITLE
fix(scraper): request GlenAllachie UK prices

### DIFF
--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -771,6 +771,43 @@ describe("scrape source parser", () => {
     });
   });
 
+  it("requests UK prices from GlenAllachie product pages", () => {
+    const rules = {
+      kind: "price",
+      products: {
+        oneProductPer: "article.product",
+        link: "a[href]",
+        skipWhen: null,
+        nextPage: null,
+        limit: 20,
+      },
+      product: {
+        name: pageText("h1"),
+        price: pageText(".price"),
+        currency: "gbp",
+        volume: pageText(".volume"),
+        url: null,
+        externalProductId: null,
+        imageUrl: null,
+        barcode: null,
+      },
+    } as const satisfies ScrapeRules;
+
+    expect(
+      parseScrapeList(
+        rules,
+        '<article class="product"><a href="/products/glenallachie-12">Bottle</a></article>',
+        new URL("https://shop.theglenallachie.com/collections/all-products"),
+      ),
+    ).toEqual({
+      links: [
+        "https://shop.theglenallachie.com/products/glenallachie-12?country=GB",
+      ],
+      nextPageUrl: null,
+      issues: [],
+    });
+  });
+
   it("excludes unavailable list cards with bounded text matching", () => {
     const result = parseScrapeList(
       {

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -292,6 +292,18 @@ function absoluteHttpUrl(value: string, baseUrl: URL) {
   return url.toString();
 }
 
+function detailPageUrl(value: string, listUrl: URL) {
+  const url = new URL(absoluteHttpUrl(value, listUrl));
+  if (
+    url.hostname === "shop.theglenallachie.com" &&
+    url.pathname.startsWith("/products/")
+  ) {
+    // GlenAllachie source: its product pages require this to return UK prices.
+    url.searchParams.set("country", "GB");
+  }
+  return url.toString();
+}
+
 export function parseScrapeList(
   rules: StoredScrapeRules,
   html: string,
@@ -317,7 +329,7 @@ export function parseScrapeList(
           : item(element).text();
         if (!raw?.trim()) continue;
         try {
-          links.add(absoluteHttpUrl(raw.trim(), pageUrl));
+          links.add(detailPageUrl(raw.trim(), pageUrl));
         } catch (error) {
           issues.push({
             field: "list.detailLink",
@@ -427,7 +439,7 @@ function parseSavedList(
           (document === "xml" ? readText(item(element)) : null);
         if (!raw?.trim()) continue;
         try {
-          links.add(absoluteHttpUrl(raw.trim(), pageUrl));
+          links.add(detailPageUrl(raw.trim(), pageUrl));
         } catch (error) {
           issues.push({
             field: `${fieldRoot}.link`,


### PR DESCRIPTION
GlenAllachie product links now request the UK market before fetching their detail pages, preventing converted non-UK prices from being stored. The market requirement stays as a small built-in source adjustment instead of extending the saved-rule format; existing same-site URL checks and all saved rule versions remain unchanged.
