### PR TITLE
feat(scraper): backfill missing review text

### DIFF
--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -310,9 +310,9 @@ Every network attempt, including robots refreshes and retries, counts toward
 the current worker's request limit. Response bodies are read only up to the
 configured size and are never stored by the runtime.
 
-A planned wait between saved-rule requests does not count toward the
-ten-attempt safety limit. Other restarts do. Every run must finish within 24
-hours, so invalid saved progress or a permanent wait cannot live forever.
+Planned waits do not count as failed attempts. Other restarts do. A run may last
+up to three days. This gives a historical review import time to finish while
+still stopping work that cannot make progress.
 
 ## Bot identity
 

--- a/apps/server/src/scraper/adapters/whiskyAdvocate.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyAdvocate.test.ts
@@ -13,6 +13,20 @@ import {
   WhiskyAdvocateCursorSchema,
 } from "./whiskyAdvocate";
 
+function keepFirstIssues(data: string, count: number) {
+  const $ = cheerio(data);
+  $("select")
+    .filter(
+      (_, element) =>
+        element.attribs.name === "filters[default][custom_rating_issue][]",
+    )
+    .find("option")
+    .filter((_, element) => element.attribs.value !== "")
+    .slice(count)
+    .remove();
+  return $.html();
+}
+
 test("accepts a cursor stored by the previous adapter", () => {
   expect(
     WhiskyAdvocateCursorSchema.parse({ processedIssues: ["Winter 2023"] }),
@@ -28,8 +42,11 @@ test("accepts a cursor stored by the previous adapter", () => {
   });
 });
 
-test("starts old saved progress again and checks older issues later", async () => {
-  const issueHtml = await loadFixture("whiskyadvocate", "empty-search.html");
+test("starts old saved progress again and finishes remaining issues", async () => {
+  const issueHtml = keepFirstIssues(
+    await loadFixture("whiskyadvocate", "empty-search.html"),
+    2,
+  );
   const reviewHtml = await loadFixture("whiskyadvocate", "bottle-list.html");
   const articleHtml = await loadFixture("whiskyadvocate", "review-page.html");
   const issueNames = parseIssueList(issueHtml);
@@ -68,6 +85,9 @@ test("starts old saved progress again and checks older issues later", async () =
       "custom_rating_issue[0]",
     ),
   ).toBe(issueNames[0]);
+  expect(oldRun.checkpoint).toHaveBeenLastCalledWith(
+    expect.objectContaining({ completedIssues: issueNames }),
+  );
 
   const nextRun = await run({
     checksReviewDates: true,
@@ -81,7 +101,7 @@ test("starts old saved progress again and checks older issues later", async () =
     ),
   ).toBe(issueNames[1]);
   expect(nextRun.checkpoint).toHaveBeenLastCalledWith(
-    expect.objectContaining({ completedIssues: issueNames.slice(0, 2) }),
+    expect.objectContaining({ completedIssues: issueNames }),
   );
 });
 
@@ -105,8 +125,11 @@ test("parses the publisher date template", async () => {
   ).toThrow("Whisky Advocate review date is invalid.");
 });
 
-test("fetches dates for the latest issue and checkpoints each review", async () => {
-  const issueHtml = await loadFixture("whiskyadvocate", "empty-search.html");
+test("fetches dates and checkpoints each review", async () => {
+  const issueHtml = keepFirstIssues(
+    await loadFixture("whiskyadvocate", "empty-search.html"),
+    1,
+  );
   const reviewHtml = await loadFixture("whiskyadvocate", "bottle-list.html");
   const articleHtml = await loadFixture("whiskyadvocate", "review-page.html");
   const $ = cheerio(issueHtml);
@@ -190,7 +213,10 @@ test("fetches dates for the latest issue and checkpoints each review", async () 
 });
 
 test("rechecks old saved reviews and resumes reviews checked for dates", async () => {
-  const issueHtml = await loadFixture("whiskyadvocate", "empty-search.html");
+  const issueHtml = keepFirstIssues(
+    await loadFixture("whiskyadvocate", "empty-search.html"),
+    1,
+  );
   const reviewHtml = await loadFixture("whiskyadvocate", "bottle-list.html");
   const articleHtml = await loadFixture("whiskyadvocate", "review-page.html");
   const $ = cheerio(reviewHtml);
@@ -262,7 +288,10 @@ test("rechecks old saved reviews and resumes reviews checked for dates", async (
 });
 
 test("fails when the newest issue has no review results", async () => {
-  const issueHtml = await loadFixture("whiskyadvocate", "empty-search.html");
+  const issueHtml = keepFirstIssues(
+    await loadFixture("whiskyadvocate", "empty-search.html"),
+    1,
+  );
   const request = vi.fn(async () => ({
     url: new URL("https://whiskyadvocate.com/ratings-reviews"),
     status: 200,

--- a/apps/server/src/scraper/adapters/whiskyAdvocate.ts
+++ b/apps/server/src/scraper/adapters/whiskyAdvocate.ts
@@ -36,8 +36,9 @@ const DatedWhiskyAdvocateCursorSchema = z
   })
   .strict();
 
-// Active runs can resume across deploys.
-// Accept cursors written by the prior adapter.
+// Runs can span deploys.
+// TODO(scraper): Remove the two old cursor shapes after this change has been
+// live for three days, when no older run can still be active.
 export const WhiskyAdvocateCursorSchema = z.union([
   DatedWhiskyAdvocateCursorSchema,
   LegacyWhiskyAdvocateCursorSchema,
@@ -182,88 +183,94 @@ export const whiskyAdvocateAdapter: ScraperAdapter<
   const completedIssues = new Set(
     cursor && "checksReviewDates" in cursor ? cursor.completedIssues : [],
   );
-  const activeIssue = cursor && "issue" in cursor ? cursor.issue : null;
-  const issue =
-    activeIssue ?? issueList.find((value) => !completedIssues.has(value));
-  if (!issue) return;
+  let issue = cursor && "issue" in cursor ? cursor.issue : null;
   const completedReviewUrls = new Set(
-    cursor && "completedReviewUrls" in cursor ? cursor.completedReviewUrls : [],
+    issue && cursor && "completedReviewUrls" in cursor
+      ? cursor.completedReviewUrls
+      : [],
   );
 
-  const reviewUrl = new URL("/ratings-reviews", ORIGIN);
-  reviewUrl.searchParams.set("custom_rating_issue[0]", issue);
-  reviewUrl.searchParams.set("order_by", "published_desc");
-  const reviewResponse = await session.request({
-    target: TARGET,
-    url: reviewUrl,
-  });
-  const externalReviews = parseReviews(
-    reviewResponse.body,
-    reviewResponse.url.href,
-  );
-  if (externalReviews.length === 0) {
-    throw new Error("Whisky Advocate issue contains no external reviews.");
-  }
+  while (true) {
+    issue ??= issueList.find((value) => !completedIssues.has(value)) ?? null;
+    if (!issue) return;
 
-  for (const review of externalReviews) {
-    if (completedReviewUrls.has(review.url)) continue;
-    const articleResponse = await session.request({
+    const reviewUrl = new URL("/ratings-reviews", ORIGIN);
+    reviewUrl.searchParams.set("custom_rating_issue[0]", issue);
+    reviewUrl.searchParams.set("order_by", "published_desc");
+    const reviewResponse = await session.request({
       target: TARGET,
-      url: new URL(review.url),
+      url: reviewUrl,
     });
-    const publishedAt = parseReviewPublishedAt(articleResponse.body);
-    const body = parseReviewBody(articleResponse.body);
-    const nativeScore = {
-      value: review.rating,
-      scale: 100,
-      display: `${review.rating}/100`,
-    };
-    const value = WhiskyAdvocateObservationSchema.parse({
-      article: {
-        canonicalUrl: review.url,
-        title: review.name,
-        issue: review.issue,
-        publishedAt,
-        contentHash: createHash("sha256")
-          .update(
-            JSON.stringify({
+    const externalReviews = parseReviews(
+      reviewResponse.body,
+      reviewResponse.url.href,
+    );
+    if (externalReviews.length === 0) {
+      throw new Error("Whisky Advocate issue contains no external reviews.");
+    }
+
+    for (const review of externalReviews) {
+      if (completedReviewUrls.has(review.url)) continue;
+      const articleResponse = await session.request({
+        target: TARGET,
+        url: new URL(review.url),
+      });
+      const publishedAt = parseReviewPublishedAt(articleResponse.body);
+      const body = parseReviewBody(articleResponse.body);
+      const nativeScore = {
+        value: review.rating,
+        scale: 100,
+        display: `${review.rating}/100`,
+      };
+      const value = WhiskyAdvocateObservationSchema.parse({
+        article: {
+          canonicalUrl: review.url,
+          title: review.name,
+          issue: review.issue,
+          publishedAt,
+          contentHash: createHash("sha256")
+            .update(
+              JSON.stringify({
+                name: review.name,
+                category: review.category,
+                rating: review.rating,
+                url: review.url,
+                issue: review.issue,
+                body,
+              }),
+            )
+            .digest("hex"),
+          externalReviews: [
+            {
+              sourceKey: review.url,
               name: review.name,
               category: review.category,
-              rating: review.rating,
-              url: review.url,
-              issue: review.issue,
-              body,
-            }),
-          )
-          .digest("hex"),
-        externalReviews: [
-          {
-            sourceKey: review.url,
-            name: review.name,
-            category: review.category,
-            reviewerName: null,
-            nativeScore,
-          },
-        ],
-      },
-      externalReviewTexts: {},
-      externalReviewBodies: { [review.url]: body },
-    });
-    await session.emit({ sourceKey: review.url, value });
-    completedReviewUrls.add(review.url);
+              reviewerName: null,
+              nativeScore,
+            },
+          ],
+        },
+        externalReviewTexts: {},
+        externalReviewBodies: { [review.url]: body },
+      });
+      await session.emit({ sourceKey: review.url, value });
+      completedReviewUrls.add(review.url);
+      await session.checkpoint({
+        checksReviewDates: true,
+        completedIssues: [...completedIssues],
+        issue,
+        completedReviewUrls: [...completedReviewUrls],
+      });
+    }
+
+    completedIssues.add(issue);
     await session.checkpoint({
       checksReviewDates: true,
       completedIssues: [...completedIssues],
-      issue,
-      completedReviewUrls: [...completedReviewUrls],
+      issue: null,
+      completedReviewUrls: [],
     });
+    issue = null;
+    completedReviewUrls.clear();
   }
-
-  completedIssues.add(issue);
-  await session.checkpoint({
-    checksReviewDates: true,
-    completedIssues: [...completedIssues],
-    issue: null,
-    completedReviewUrls: [],
-  });
 };

--- a/apps/server/src/scraper/lifecycle.test.ts
+++ b/apps/server/src/scraper/lifecycle.test.ts
@@ -1,5 +1,9 @@
 import { db } from "@peated/server/db";
-import { externalSiteRuns, externalSites } from "@peated/server/db/schema";
+import {
+  externalReviewBodies,
+  externalSiteRuns,
+  externalSites,
+} from "@peated/server/db/schema";
 import { eq } from "drizzle-orm";
 import { expect, test, vi } from "vitest";
 import {
@@ -117,6 +121,12 @@ test("opted-in source resumes the last successful run cursor", async ({
       completedAt: new Date("2026-08-21T00:00:00Z"),
     },
   ]);
+  const review = await fixtures.ExternalReview({ externalSiteId: site.id });
+  await db.insert(externalReviewBodies).values({
+    externalReviewId: review.id,
+    body: "Saved review text.",
+    fetchedAt: new Date(),
+  });
 
   const run = await queueManualExternalSiteRun({
     site,
@@ -125,6 +135,34 @@ test("opted-in source resumes the last successful run cursor", async ({
   });
 
   expect(run.cursor).toEqual(successfulCursor);
+});
+
+test("manual review run restarts when reviews are missing saved text", async ({
+  fixtures,
+}) => {
+  const requestedBy = await fixtures.User({ admin: true });
+  const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+  await fixtures.ExternalReview({ externalSiteId: site.id });
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    trigger: "scheduled",
+    status: "succeeded",
+    cursor: {
+      checksReviewDates: true,
+      completedIssues: ["Summer 2026"],
+      issue: null,
+      completedReviewUrls: [],
+    },
+    completedAt: new Date("2026-08-20T00:00:00Z"),
+  });
+
+  const run = await queueManualExternalSiteRun({
+    site,
+    requestedById: requestedBy.id,
+    enqueue: async () => undefined,
+  });
+
+  expect(run.cursor).toBeNull();
 });
 
 test("active run prevents overlap", async ({ fixtures }) => {

--- a/apps/server/src/scraper/lifecycle.ts
+++ b/apps/server/src/scraper/lifecycle.ts
@@ -1,5 +1,8 @@
 import { db, type AnyDatabase } from "@peated/server/db";
 import {
+  externalReviewArticles,
+  externalReviewBodies,
+  externalReviews,
   externalSiteRuns,
   externalSites,
   scrapeSources,
@@ -66,6 +69,31 @@ async function findActiveRun(siteId: number, connection: AnyDatabase = db) {
   return run;
 }
 
+async function hasReviewsWithoutSavedText(
+  connection: AnyDatabase,
+  externalSiteId: number,
+) {
+  const [review] = await connection
+    .select({ id: externalReviews.id })
+    .from(externalReviews)
+    .innerJoin(
+      externalReviewArticles,
+      eq(externalReviews.articleId, externalReviewArticles.id),
+    )
+    .leftJoin(
+      externalReviewBodies,
+      eq(externalReviewBodies.externalReviewId, externalReviews.id),
+    )
+    .where(
+      and(
+        eq(externalReviewArticles.externalSiteId, externalSiteId),
+        isNull(externalReviewBodies.externalReviewId),
+      ),
+    )
+    .limit(1);
+  return Boolean(review);
+}
+
 async function insertRun(
   connection: AnyDatabase,
   site: Pick<ExternalSite, "id" | "type">,
@@ -97,7 +125,11 @@ async function insertRun(
   }
   requireEnabledScraperTargets(registry, source);
   let cursor = null;
-  if (source.resumeFromLastRun) {
+  const restartForMissingReviewText =
+    trigger === "manual" &&
+    source.recordType === "review" &&
+    (await hasReviewsWithoutSavedText(connection, site.id));
+  if (source.resumeFromLastRun && !restartForMissingReviewText) {
     const [priorRun] = await connection
       .select({ cursor: externalSiteRuns.cursor })
       .from(externalSiteRuns)

--- a/apps/server/src/scraper/runs.test.ts
+++ b/apps/server/src/scraper/runs.test.ts
@@ -234,6 +234,7 @@ test("waits at the request limit and resumes the same run from its saved place",
     .where(eq(externalSiteRuns.id, run.id));
   expect(waiting).toMatchObject({
     status: "queued",
+    attemptCount: 0,
     cursor: { page: 2 },
     sliceRequestCount: 1,
     requestCount: 1,
@@ -257,7 +258,7 @@ test("waits at the request limit and resumes the same run from its saved place",
   expect(completed).toMatchObject({
     id: run.id,
     status: "succeeded",
-    attemptCount: 2,
+    attemptCount: 1,
     sliceRequestCount: 1,
     requestCount: 2,
   });
@@ -489,7 +490,7 @@ test("fails a waiting run after its maximum lifetime", async () => {
   await db
     .update(externalSiteRuns)
     .set({
-      createdAt: new Date("2026-08-17T11:59:59Z"),
+      createdAt: new Date("2026-08-15T11:59:59Z"),
       nextAttemptAt: new Date("2026-08-19T12:00:00Z"),
     })
     .where(eq(externalSiteRuns.id, run.id));

--- a/apps/server/src/scraper/runs.ts
+++ b/apps/server/src/scraper/runs.ts
@@ -34,7 +34,7 @@ import type {
 
 const RUN_EXECUTION_LEASE_MS = 60 * 60_000;
 const MAX_RUN_EXECUTION_ATTEMPTS = 10;
-const MAX_RUN_AGE_MS = 24 * 60 * 60_000;
+const MAX_RUN_AGE_MS = 3 * 24 * 60 * 60_000;
 const DEFAULT_WAIT_MS = 15 * 60_000;
 const REQUEST_LIMIT_WAIT_MS = 60_000;
 const RUN_LIMIT_ERROR = "Scraper run exceeded its execution limits.";
@@ -268,7 +268,7 @@ async function queueRunForLater(
       status: "queued",
       attemptCount:
         error instanceof ScraperRequestWaitError &&
-        error.reason === "target_spacing"
+        (error.reason === "target_spacing" || error.reason === "run_budget")
           ? Math.max(0, claim.run.attemptCount - 1)
           : claim.run.attemptCount,
       nextAttemptAt,

--- a/docs/features/external-reviews.md
+++ b/docs/features/external-reviews.md
@@ -79,6 +79,11 @@ the website. A new body replaces the previous one; missing text keeps the saved
 body and its date. Deleting a review also deletes its body. Existing reviews get
 bodies on their next import when text is available.
 
+When an admin starts a review scraper, it starts over if that site has reviews
+without saved text. Long imports remember where they stopped while waiting.
+Reviews that already have saved text are updated without fetching the website
+again.
+
 Scrapers select each bottle's full review, including its introduction and
 conclusion. For configurable sources, `article.reviews` defines each full
 review. Optional `tastingNotes` remains accepted for older rules when a full


### PR DESCRIPTION
Starting a review scraper by hand now fills in missing review text. If a site has reviews without saved text, the scraper starts over; otherwise, it continues where it stopped. Reviews that already have saved text are still updated without loading the website again.

Whisky Advocate now works through every issue in one run. It saves its place while waiting between requests and may run for up to three days, which is enough time to import its history at one request every 30 seconds.
