### PR TITLE
fix(web): align rating scores without rater counts

### DIFF
--- a/apps/web/src/components/bottleRatings.stories.tsx
+++ b/apps/web/src/components/bottleRatings.stories.tsx
@@ -51,6 +51,7 @@ export const Overview: Story = {
         raterCount={5}
         scoreCount={5}
       />
+      <BottleRatings median={90} scoreCount={1} />
       <BottleRatings
         raterCount={7}
         tastingCounts={{ outstanding: 2, unicorn: 1, very_good: 4 }}

--- a/apps/web/src/components/scoring.stylex.tsx
+++ b/apps/web/src/components/scoring.stylex.tsx
@@ -577,6 +577,7 @@ const styles = stylex.create({
     whiteSpace: "nowrap",
   },
   compactValue: {
+    marginLeft: "auto",
     flexShrink: 0,
     color: colors.ink,
     fontFamily: fonts.display,


### PR DESCRIPTION
Rating summaries in Bottle rows now keep their score flush with the right edge when no rater count has been computed. The missing-count state is also included in Storybook alongside counted and tasting-only variants for visual review.
