### PR TITLE
feat(scraper): authenticate PeatedBot with Web Bot Auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ AI_GATEWAY_API_KEY=
 # Optional scraper override. When unset, scraper web evidence uses FIRECRAWL_API_KEY.
 # SCRAPER_FIRECRAWL_API_KEY=
 # FIRECRAWL_API_URL=https://api.firecrawl.dev
+# Optional private Ed25519 JWK used to sign PeatedBot scraper requests.
+# Configure the same secret for the server and web deployments.
+# PEATED_BOT_PRIVATE_JWK=
 
 # Optional override for the public OAuth client used by `pnpm cli auth login`.
 # PEATED_OAUTH_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ AI_GATEWAY_API_KEY=
 # Optional scraper override. When unset, scraper web evidence uses FIRECRAWL_API_KEY.
 # SCRAPER_FIRECRAWL_API_KEY=
 # FIRECRAWL_API_URL=https://api.firecrawl.dev
-# Optional private Ed25519 JWK used to sign PeatedBot scraper requests.
+# Optional private Ed25519 key in JWK format used to sign PeatedBot requests.
 # Configure the same secret for the server and web deployments.
 # PEATED_BOT_PRIVATE_JWK=
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,6 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "check:peated-bot-signature": "tsx ./scripts/check-peated-bot-signature.ts",
+    "generate:peated-bot-key": "node ./scripts/generate-peated-bot-key.mjs",
     "dev": "concurrently 'npm:dev:api' 'npm:dev:worker'",
     "dev:api": "tsx watch --require dotenv/config ./src/run-server.ts",
     "dev:mock": "tsx watch ./src/orpc/mock/run-server.ts",
@@ -67,6 +69,7 @@
     "toad-scheduler": "^3.0.1",
     "tsx": "catalog:",
     "typescript": "catalog:",
+    "web-bot-auth": "0.2.0",
     "wkx": "^0.5.0",
     "zod": "catalog:"
   },

--- a/apps/server/scripts/check-peated-bot-signature.ts
+++ b/apps/server/scripts/check-peated-bot-signature.ts
@@ -1,0 +1,20 @@
+import { BOT_USER_AGENT } from "@peated/server/constants";
+import { signScraperRequest } from "@peated/server/scraper/signing";
+
+const url = new URL("https://crawltest.com/cdn-cgi/web-bot-auth");
+const headers = await signScraperRequest(
+  url,
+  { "User-Agent": BOT_USER_AGENT },
+  new Date(),
+);
+
+if (!headers.has("Signature")) {
+  throw new Error("PEATED_BOT_PRIVATE_JWK must be configured for this check.");
+}
+
+const response = await fetch(url, { headers });
+console.log(`Cloudflare crawl test returned HTTP ${response.status}.`);
+
+if (response.status !== 200 && response.status !== 401) {
+  process.exitCode = 1;
+}

--- a/apps/server/scripts/generate-peated-bot-key.mjs
+++ b/apps/server/scripts/generate-peated-bot-key.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync } from "node:crypto";
+import { chmod, mkdir, realpath, stat, writeFile } from "node:fs/promises";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  parse,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const repositoryDirectory = resolve(scriptDirectory, "../../..");
+const filename = "peated-bot-private.jwk";
+
+function isWithin(parent, candidate) {
+  const pathFromParent = relative(parent, candidate);
+  return (
+    pathFromParent === "" ||
+    (pathFromParent !== ".." &&
+      !pathFromParent.startsWith(`..${sep}`) &&
+      isAbsolute(pathFromParent) === false)
+  );
+}
+
+async function resolveThroughExistingAncestor(path) {
+  const missingSegments = [];
+  let existingPath = path;
+
+  while (true) {
+    try {
+      await stat(existingPath);
+      break;
+    } catch (error) {
+      if (error?.code !== "ENOENT") {
+        throw error;
+      }
+
+      const parent = dirname(existingPath);
+      if (parent === existingPath) {
+        throw error;
+      }
+      missingSegments.unshift(basename(existingPath));
+      existingPath = parent;
+    }
+  }
+
+  return resolve(await realpath(existingPath), ...missingSegments);
+}
+
+async function main() {
+  const arguments_ = process.argv.slice(2);
+  if (arguments_[0] === "--") {
+    arguments_.shift();
+  }
+  const [outputArgument] = arguments_;
+  if (!outputArgument || arguments_.length !== 1) {
+    throw new Error(
+      "Usage: pnpm --filter @peated/server generate:peated-bot-key -- /absolute/private/directory",
+    );
+  }
+  if (!isAbsolute(outputArgument)) {
+    throw new Error("The output directory must be an absolute path.");
+  }
+
+  const outputDirectory = resolve(outputArgument);
+  if (outputDirectory === parse(outputDirectory).root) {
+    throw new Error("The output directory must be a dedicated subdirectory.");
+  }
+
+  const actualRepositoryDirectory = await realpath(repositoryDirectory);
+  const prospectiveOutputDirectory =
+    await resolveThroughExistingAncestor(outputDirectory);
+  if (isWithin(actualRepositoryDirectory, prospectiveOutputDirectory)) {
+    throw new Error("Refusing to create a private key inside the repository.");
+  }
+
+  await mkdir(outputDirectory, { recursive: true, mode: 0o700 });
+  const actualOutputDirectory = await realpath(outputDirectory);
+  if (isWithin(actualRepositoryDirectory, actualOutputDirectory)) {
+    throw new Error("Refusing to create a private key inside the repository.");
+  }
+  await chmod(actualOutputDirectory, 0o700);
+
+  const outputPath = resolve(actualOutputDirectory, filename);
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const jwk = privateKey.export({ format: "jwk" });
+
+  assert.equal(jwk.kty, "OKP");
+  assert.equal(jwk.crv, "Ed25519");
+  assert.match(jwk.x, /^[A-Za-z0-9_-]+$/);
+  assert.match(jwk.d, /^[A-Za-z0-9_-]+$/);
+
+  try {
+    await writeFile(outputPath, `${JSON.stringify(jwk)}\n`, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      throw new Error(
+        `Refusing to overwrite the existing key at ${outputPath}.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  await chmod(outputPath, 0o600);
+
+  console.log(`Created ${outputPath}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/apps/server/scripts/generate-peated-bot-key.mjs
+++ b/apps/server/scripts/generate-peated-bot-key.mjs
@@ -1,4 +1,3 @@
-import assert from "node:assert/strict";
 import { generateKeyPairSync } from "node:crypto";
 import { chmod, mkdir, realpath, stat, writeFile } from "node:fs/promises";
 import {
@@ -15,6 +14,7 @@ import { fileURLToPath } from "node:url";
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const repositoryDirectory = resolve(scriptDirectory, "../../..");
 const filename = "peated-bot-private.jwk";
+const encodedKeyPattern = /^[A-Za-z0-9_-]{43}$/;
 
 function isWithin(parent, candidate) {
   const pathFromParent = relative(parent, candidate);
@@ -89,10 +89,14 @@ async function main() {
   const { privateKey } = generateKeyPairSync("ed25519");
   const jwk = privateKey.export({ format: "jwk" });
 
-  assert.equal(jwk.kty, "OKP");
-  assert.equal(jwk.crv, "Ed25519");
-  assert.match(jwk.x, /^[A-Za-z0-9_-]+$/);
-  assert.match(jwk.d, /^[A-Za-z0-9_-]+$/);
+  if (
+    jwk.kty !== "OKP" ||
+    jwk.crv !== "Ed25519" ||
+    !encodedKeyPattern.test(jwk.x ?? "") ||
+    !encodedKeyPattern.test(jwk.d ?? "")
+  ) {
+    throw new Error("Node.js did not generate a valid Ed25519 private key.");
+  }
 
   try {
     await writeFile(outputPath, `${JSON.stringify(jwk)}\n`, {

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -77,6 +77,7 @@ export default {
   FIRECRAWL_API_KEY: process.env.FIRECRAWL_API_KEY || null,
   SCRAPER_FIRECRAWL_API_KEY:
     process.env.SCRAPER_FIRECRAWL_API_KEY?.trim() || null,
+  PEATED_BOT_PRIVATE_JWK: process.env.PEATED_BOT_PRIVATE_JWK?.trim() || null,
   FIRECRAWL_API_URL: process.env.FIRECRAWL_API_URL || null,
   BOTTLE_CLASSIFIER_MAX_SEARCH_QUERIES: Number(
     process.env.BOTTLE_CLASSIFIER_MAX_SEARCH_QUERIES ||

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -265,3 +265,7 @@ still stopping work that cannot make progress.
 Outbound requests identify as `PeatedBot/1.0 (+https://peated.com/bot)`. The
 public page explains Peated's purpose, request controls, and contact path. Do
 not replace it with a browser identity or add credential/cookie forwarding.
+When `PEATED_BOT_PRIVATE_JWK` is configured, the shared HTTP transport signs
+each request with Cloudflare Web Bot Auth. Follow the
+[PeatedBot request signing runbook](../../../../docs/operations/peated-bot.md)
+for deployment, registration, checks, and key rotation.

--- a/apps/server/src/scraper/generateSigningKey.test.ts
+++ b/apps/server/src/scraper/generateSigningKey.test.ts
@@ -1,0 +1,67 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, realpath, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = fileURLToPath(
+  new URL("../../scripts/generate-peated-bot-key.mjs", import.meta.url),
+);
+
+describe("generate-peated-bot-key", () => {
+  let temporaryDirectory: string;
+
+  beforeEach(async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "peated-bot-key-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  it("creates a private Ed25519 JWK with restrictive permissions", async () => {
+    const outputDirectory = join(temporaryDirectory, "private");
+    const outputPath = join(outputDirectory, "peated-bot-private.jwk");
+
+    const { stdout } = await execFileAsync(process.execPath, [
+      scriptPath,
+      outputDirectory,
+    ]);
+
+    expect(stdout).toBe(
+      `Created ${join(await realpath(outputDirectory), "peated-bot-private.jwk")}\n`,
+    );
+    const key = JSON.parse(await readFile(outputPath, "utf8"));
+    expect(key).toMatchObject({ kty: "OKP", crv: "Ed25519" });
+    expect(key.x).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(key.d).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect((await stat(outputDirectory)).mode & 0o777).toBe(0o700);
+    expect((await stat(outputPath)).mode & 0o777).toBe(0o600);
+  });
+
+  it("does not overwrite an existing key", async () => {
+    const outputDirectory = join(temporaryDirectory, "private");
+    await execFileAsync(process.execPath, [scriptPath, outputDirectory]);
+
+    await expect(
+      execFileAsync(process.execPath, [scriptPath, outputDirectory]),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("Refusing to overwrite the existing key"),
+    });
+  });
+
+  it("rejects relative and repository paths", async () => {
+    await expect(
+      execFileAsync(process.execPath, [scriptPath, "private"]),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("must be an absolute path"),
+    });
+    await expect(
+      execFileAsync(process.execPath, [scriptPath, dirname(scriptPath)]),
+    ).rejects.toMatchObject({
+      stderr: expect.stringContaining("inside the repository"),
+    });
+  });
+});

--- a/apps/server/src/scraper/generateSigningKey.test.ts
+++ b/apps/server/src/scraper/generateSigningKey.test.ts
@@ -34,9 +34,10 @@ describe("generate-peated-bot-key", () => {
       `Created ${join(await realpath(outputDirectory), "peated-bot-private.jwk")}\n`,
     );
     const key = JSON.parse(await readFile(outputPath, "utf8"));
-    expect(key).toMatchObject({ kty: "OKP", crv: "Ed25519" });
-    expect(key.x).toMatch(/^[A-Za-z0-9_-]+$/);
-    expect(key.d).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(key.kty).toBe("OKP");
+    expect(key.crv).toBe("Ed25519");
+    expect(/^[A-Za-z0-9_-]{43}$/.test(key.x ?? "")).toBe(true);
+    expect(/^[A-Za-z0-9_-]{43}$/.test(key.d ?? "")).toBe(true);
     expect((await stat(outputDirectory)).mode & 0o777).toBe(0o700);
     expect((await stat(outputPath)).mode & 0o777).toBe(0o600);
   });

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -1,3 +1,4 @@
+import config from "@peated/server/config";
 import { BOT_USER_AGENT } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import {
@@ -7,7 +8,10 @@ import {
 } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { eq } from "drizzle-orm";
+import { generateKeyPairSync } from "node:crypto";
 import { vi } from "vitest";
+import { verify } from "web-bot-auth";
+import { verifierFromJWK } from "web-bot-auth/crypto";
 import { z } from "zod";
 import {
   createScraperRegistry,
@@ -180,6 +184,7 @@ test("sends an identified bounded GET and exposes only safe response headers", a
         expect(new Headers(init?.headers).get("user-agent")).toBe(
           BOT_USER_AGENT,
         );
+        expect(new Headers(init?.headers).get("signature")).toBeNull();
         expect(init).toMatchObject({ method: "GET", redirect: "manual" });
         return new Response("catalog", {
           headers: {
@@ -215,6 +220,49 @@ test("sends an identified bounded GET and exposes only safe response headers", a
     .where(eq(externalSiteRuns.id, run.id));
   expect(runState).toMatchObject({ requestCount: 1, retryCount: 0 });
   expect((await db.select().from(scrapeTargets))[0]?.leaseToken).toBeNull();
+});
+
+test("signs requests when the PeatedBot private key is configured", async () => {
+  const { privateKey } = generateKeyPairSync("ed25519");
+  const privateJwk = privateKey.export({ format: "jwk" });
+  const originalKey = config.PEATED_BOT_PRIVATE_JWK;
+  config.PEATED_BOT_PRIVATE_JWK = JSON.stringify(privateJwk);
+  try {
+    const { registry, run } = await setupRuntime();
+    const verifier = await verifierFromJWK(privateJwk);
+    const now = new Date("2026-08-18T12:00:00Z");
+    const fetchImpl = vi.fn<typeof fetch>(async (url, init) => {
+      const signedRequest = new Request(url, init);
+      expect(signedRequest.headers.get("signature-agent")).toBe(
+        '"https://peated.com"',
+      );
+      const verified = await verify(signedRequest, {
+        resolver: () => verifier,
+        now,
+      });
+      expect(verified).toMatchObject({
+        keyid: verifier.keyid,
+        tag: "web-bot-auth",
+      });
+      return new Response("catalog");
+    });
+
+    await requestScraperUrl({
+      runId: run.id,
+      sourceKey: "finedrams",
+      request: {
+        target: "operator",
+        url: new URL("https://example.com/catalog"),
+      },
+      registry,
+      fetchImpl,
+      clock: clockAt(now.toISOString()),
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  } finally {
+    config.PEATED_BOT_PRIVATE_JWK = originalKey;
+  }
 });
 
 test("sends code-authorized POST queries without implicit retries", async () => {

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -265,6 +265,36 @@ test("signs requests when the PeatedBot private key is configured", async () => 
   }
 });
 
+test("does not send a request when the PeatedBot key is invalid", async () => {
+  const originalKey = config.PEATED_BOT_PRIVATE_JWK;
+  config.PEATED_BOT_PRIVATE_JWK = '{"kty":"OKP","crv":"Ed25519"}';
+  try {
+    const { registry, run } = await setupRuntime();
+    const fetchImpl = vi.fn<typeof fetch>();
+
+    await expect(
+      requestScraperUrl({
+        runId: run.id,
+        sourceKey: "finedrams",
+        request: {
+          target: "operator",
+          url: new URL("https://example.com/catalog"),
+        },
+        registry,
+        fetchImpl,
+        clock: clockAt(),
+      }),
+    ).rejects.toThrow(
+      "PEATED_BOT_PRIVATE_JWK must contain a private Ed25519 JWK.",
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect((await db.select().from(scrapeTargets))[0]?.leaseToken).toBeNull();
+  } finally {
+    config.PEATED_BOT_PRIVATE_JWK = originalKey;
+  }
+});
+
 test("sends code-authorized POST queries without implicit retries", async () => {
   const { registry, run } = await setupRuntime({
     allowedRequestHeaders: ["x-catalog-key"],

--- a/apps/server/src/scraper/http.ts
+++ b/apps/server/src/scraper/http.ts
@@ -7,6 +7,7 @@ import {
   releaseScrapePermit,
 } from "./coordinator";
 import { resolveScraperOrigin } from "./definitions";
+import { signScraperRequest } from "./signing";
 import type { ScraperRegistry, ScraperRequest, ScraperResponse } from "./types";
 
 const MAX_REDIRECTS = 5;
@@ -314,12 +315,27 @@ export async function requestScraperUrl({
         canResumeLater: request.canResumeLater ?? false,
         clock,
       });
+      let requestHeaders: Headers;
+      try {
+        requestHeaders = await signScraperRequest(
+          currentUrl,
+          headers,
+          clock.now(),
+        );
+      } catch (error) {
+        await releaseScrapePermit({
+          targetKey: request.target,
+          token: permit.token,
+          now: clock.now(),
+        });
+        throw error;
+      }
       let response: Response;
       try {
         response = await fetchImpl(currentUrl, {
           method,
           body: request.body,
-          headers,
+          headers: requestHeaders,
           redirect: "manual",
           signal: AbortSignal.timeout(permit.timeoutMs),
         });

--- a/apps/server/src/scraper/signing.ts
+++ b/apps/server/src/scraper/signing.ts
@@ -1,0 +1,71 @@
+import config from "@peated/server/config";
+import { generateNonce, sign, type WebBotSigner } from "web-bot-auth";
+import { signerFromJWK } from "web-bot-auth/crypto";
+import { z } from "zod";
+
+const SIGNATURE_AGENT = '"https://peated.com"';
+const SIGNATURE_LIFETIME_MS = 60_000;
+
+let cachedSigner:
+  | { configuredKey: string; signer: Promise<WebBotSigner> }
+  | undefined;
+
+const PrivateJwkSchema = z
+  .object({
+    kty: z.literal("OKP"),
+    crv: z.literal("Ed25519"),
+    alg: z.literal("EdDSA").optional(),
+    x: z.string().min(1),
+    d: z.string().min(1),
+  })
+  .passthrough();
+
+function parsePrivateJwk(configuredKey: string) {
+  let value: unknown;
+  try {
+    value = JSON.parse(configuredKey);
+  } catch {
+    throw new Error("PEATED_BOT_PRIVATE_JWK must be valid JSON.");
+  }
+
+  const parsed = PrivateJwkSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(
+      "PEATED_BOT_PRIVATE_JWK must contain a private Ed25519 JWK.",
+    );
+  }
+
+  return parsed.data;
+}
+
+function getSigner(configuredKey: string) {
+  if (cachedSigner?.configuredKey !== configuredKey) {
+    cachedSigner = {
+      configuredKey,
+      signer: signerFromJWK(parsePrivateJwk(configuredKey)),
+    };
+  }
+  return cachedSigner.signer;
+}
+
+export async function signScraperRequest(
+  url: URL,
+  headers: Readonly<Record<string, string>>,
+  created: Date,
+) {
+  const configuredKey = config.PEATED_BOT_PRIVATE_JWK;
+  if (!configuredKey) return new Headers(headers);
+
+  const signer = await getSigner(configuredKey);
+  const signedHeaders = new Headers(headers);
+  signedHeaders.set("Signature-Agent", SIGNATURE_AGENT);
+  const fields = await sign(new Request(url, { headers: signedHeaders }), {
+    signer,
+    created,
+    expires: new Date(created.getTime() + SIGNATURE_LIFETIME_MS),
+    nonce: generateNonce(),
+  });
+  signedHeaders.set("Signature", fields.signature);
+  signedHeaders.set("Signature-Input", fields.signatureInput);
+  return signedHeaders;
+}

--- a/apps/server/src/scraper/signing.ts
+++ b/apps/server/src/scraper/signing.ts
@@ -15,16 +15,18 @@ const PrivateJwkSchema = z
     kty: z.literal("OKP"),
     crv: z.literal("Ed25519"),
     alg: z.literal("EdDSA").optional(),
-    x: z.string().min(1),
-    d: z.string().min(1),
+    x: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+    d: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
   })
-  .passthrough();
+  .strip();
 
 function parsePrivateJwk(configuredKey: string) {
   let value: unknown;
   try {
     value = JSON.parse(configuredKey);
   } catch {
+    // Sensitive-data policy: JSON parse errors can quote the private key, so do
+    // not preserve the parser error as the cause.
     throw new Error("PEATED_BOT_PRIVATE_JWK must be valid JSON.");
   }
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -49,6 +49,7 @@
     "autoprefixer": "^10.4.27",
     "dayjs": "^1.11.19",
     "fathom-client": "^3.7.2",
+    "http-message-sig": "0.3.0",
     "iron-session": "^8.0.4",
     "isomorphic-dompurify": "^2.12.0",
     "lucide-react": "^1.35.0",
@@ -62,6 +63,7 @@
     "react-qr-code": "^2.0.18",
     "schema-dts": "^1.1.5",
     "usehooks-ts": "^3.1.1",
+    "web-bot-auth": "0.2.0",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/web/src/app/(app)/bot/page.tsx
+++ b/apps/web/src/app/(app)/bot/page.tsx
@@ -12,27 +12,50 @@ export const dynamic = "force-static";
 
 export const metadata: Metadata = {
   title: "PeatedBot",
-  description: "How PeatedBot accesses public whisky information.",
+  description:
+    "What PeatedBot reads, how it limits requests, and how site owners can control access.",
 };
 
 export default function BotPage() {
   return (
     <ContentPage
-      intro="PeatedBot collects public whisky catalog, availability, and review metadata."
+      intro="PeatedBot reads public whisky information so Peated can keep an accurate, freely available catalog."
       title="PeatedBot"
     >
+      <ContentSection title="What it reads">
+        <ContentText>
+          PeatedBot reads public catalog and product pages for bottle names,
+          producers, release facts, images, prices, and availability. It reads
+          public review pages for titles, writers, dates, scores, Bottle names,
+          and review text.
+        </ContentText>
+        <ContentText>
+          Peated stores normalized facts, source links, and attribution. Full
+          review text may be kept privately so Peated can update parsing without
+          fetching the page again. Peated does not publish that full text.
+        </ContentText>
+      </ContentSection>
       <ContentSection title="How it behaves">
         <ContentList>
-          <li>It identifies requests as PeatedBot and links to this page.</li>
-          <li>It honors robots.txt and source-specific access approval.</li>
-          <li>It limits concurrent requests and obeys 429 backoff.</li>
+          <li>
+            It identifies requests as PeatedBot/1.0 and links to this page.
+          </li>
+          <li>It follows robots.txt for the PeatedBot product token.</li>
+          <li>
+            Each source has its own request rate. Requests are spaced through
+            the hour.
+          </li>
+          <li>It obeys 429 responses and the Retry-After header.</li>
           <li>It uses bounded runs, timeouts, retries, and response sizes.</li>
           <li>It does not bypass authentication or access controls.</li>
         </ContentList>
+      </ContentSection>
+      <ContentSection title="Control access">
         <ContentText>
-          Peated stores normalized facts and links, not fetched page bodies.
-          External reviews keep their attribution and link back to the original
-          publisher.
+          Site owners can block all PeatedBot requests by adding a robots.txt
+          group for <code>PeatedBot</code> with <code>Disallow: /</code>. A more
+          specific rule can allow or block individual paths. After 24 hours,
+          Peated checks robots.txt again before making another request.
         </ContentText>
       </ContentSection>
       <ContentSection title="Contact">
@@ -43,7 +66,8 @@ export default function BotPage() {
           </ContentLink>{" "}
           or the{" "}
           <ContentLink href={config.DISCORD_LINK}>Peated Discord</ContentLink>.
-          Include the hostname and request times.
+          Include the hostname and request times. We will pause a source while
+          investigating an access or rate problem.
         </ContentText>
       </ContentSection>
     </ContentPage>

--- a/apps/web/src/app/(app)/bot/page.tsx
+++ b/apps/web/src/app/(app)/bot/page.tsx
@@ -25,14 +25,15 @@ export default function BotPage() {
       <ContentSection title="What it reads">
         <ContentText>
           PeatedBot reads public catalog and product pages for bottle names,
-          producers, release facts, images, prices, and availability. It reads
-          public review pages for titles, writers, dates, scores, Bottle names,
-          and review text.
+          producers, ages, strengths, release years, images, prices, and
+          availability. It reads public review pages for titles, writers, dates,
+          scores, bottle names, and review text.
         </ContentText>
         <ContentText>
-          Peated stores normalized facts, source links, and attribution. Full
-          review text may be kept privately so Peated can update parsing without
-          fetching the page again. Peated does not publish that full text.
+          Peated stores bottle facts, source links, and credit to the original
+          website. Full review text may be stored privately so Peated can
+          improve how it reads pages without requesting them again. Peated does
+          not publish that full text.
         </ContentText>
       </ContentSection>
       <ContentSection title="How it behaves">
@@ -40,13 +41,16 @@ export default function BotPage() {
           <li>
             It identifies requests as PeatedBot/1.0 and links to this page.
           </li>
-          <li>It follows robots.txt for the PeatedBot product token.</li>
+          <li>It follows robots.txt rules written for PeatedBot.</li>
           <li>
-            Each source has its own request rate. Requests are spaced through
-            the hour.
+            Each website has its own request limit. PeatedBot spreads those
+            requests across the hour.
           </li>
-          <li>It obeys 429 responses and the Retry-After header.</li>
-          <li>It uses bounded runs, timeouts, retries, and response sizes.</li>
+          <li>
+            It obeys HTTP 429 responses and waits for the time named in
+            Retry-After.
+          </li>
+          <li>It limits each run, request, retry, and download.</li>
           <li>It does not bypass authentication or access controls.</li>
         </ContentList>
       </ContentSection>

--- a/apps/web/src/app/.well-known/http-message-signatures-directory/route.test.ts
+++ b/apps/web/src/app/.well-known/http-message-signatures-directory/route.test.ts
@@ -26,6 +26,18 @@ describe("HTTP message signature directory", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
   });
 
+  it("reports invalid configuration without repeating the configured value", async () => {
+    vi.stubEnv("PEATED_BOT_PRIVATE_JWK", "private-value-that-must-stay-hidden");
+
+    await expect(
+      GET(
+        new Request(
+          "https://peated.com/.well-known/http-message-signatures-directory",
+        ),
+      ),
+    ).rejects.toThrow("PEATED_BOT_PRIVATE_JWK must be valid JSON.");
+  });
+
   it("publishes only the public key in a signed directory", async () => {
     const { privateKey } = generateKeyPairSync("ed25519");
     const privateJwk = privateKey.export({ format: "jwk" });
@@ -40,16 +52,11 @@ describe("HTTP message signature directory", () => {
     expect(response.headers.get("content-type")).toBe(
       "application/http-message-signatures-directory+json",
     );
-    expect(directory).toEqual({
-      keys: [
-        {
-          kty: "OKP",
-          crv: "Ed25519",
-          x: privateJwk.x,
-        },
-      ],
-    });
-    expect(directory.keys[0]).not.toHaveProperty("d");
+    const publishedKey = directory.keys[0];
+    expect(publishedKey.kty).toBe("OKP");
+    expect(publishedKey.crv).toBe("Ed25519");
+    expect(publishedKey.x).toBe(privateJwk.x);
+    expect(Object.keys(publishedKey).sort()).toEqual(["crv", "kty", "x"]);
 
     const verifier = await verifierFromJWK(privateJwk);
     const descriptor: ResponseDescriptor = {

--- a/apps/web/src/app/.well-known/http-message-signatures-directory/route.test.ts
+++ b/apps/web/src/app/.well-known/http-message-signatures-directory/route.test.ts
@@ -1,0 +1,86 @@
+import {
+  component,
+  verifySignature,
+  type ResponseDescriptor,
+} from "http-message-sig";
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { verifierFromJWK } from "web-bot-auth/crypto";
+import { GET } from "./route";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("HTTP message signature directory", () => {
+  it("does not publish a directory without a configured private key", async () => {
+    vi.stubEnv("PEATED_BOT_PRIVATE_JWK", "");
+
+    const response = await GET(
+      new Request(
+        "https://peated.com/.well-known/http-message-signatures-directory",
+      ),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("publishes only the public key in a signed directory", async () => {
+    const { privateKey } = generateKeyPairSync("ed25519");
+    const privateJwk = privateKey.export({ format: "jwk" });
+    vi.stubEnv("PEATED_BOT_PRIVATE_JWK", JSON.stringify(privateJwk));
+    const request = new Request(
+      "https://peated.com/.well-known/http-message-signatures-directory",
+    );
+    const response = await GET(request);
+    const directory = await response.clone().json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "application/http-message-signatures-directory+json",
+    );
+    expect(directory).toEqual({
+      keys: [
+        {
+          kty: "OKP",
+          crv: "Ed25519",
+          x: privateJwk.x,
+        },
+      ],
+    });
+    expect(directory.keys[0]).not.toHaveProperty("d");
+
+    const verifier = await verifierFromJWK(privateJwk);
+    const descriptor: ResponseDescriptor = {
+      kind: "response",
+      status: response.status,
+      fields: Array.from(response.headers, ([name, value]) => ({
+        name,
+        value,
+      })),
+      request,
+    };
+    const verified = await verifySignature(descriptor, {
+      policy: {
+        algorithms: ["ed25519"],
+        requiredComponents: [component("@authority", { req: true })],
+        requiredParameters: [
+          "alg",
+          "keyid",
+          "nonce",
+          "tag",
+          "created",
+          "expires",
+        ],
+      },
+      resolveVerifier: () => verifier,
+    });
+
+    expect(verified.parameters).toMatchObject({
+      alg: "ed25519",
+      keyid: verifier.keyid,
+      tag: "http-message-signatures-directory",
+    });
+  });
+});

--- a/apps/web/src/app/.well-known/http-message-signatures-directory/route.ts
+++ b/apps/web/src/app/.well-known/http-message-signatures-directory/route.ts
@@ -1,0 +1,95 @@
+import {
+  component,
+  createSignature,
+  type FieldOccurrence,
+  type ResponseDescriptor,
+} from "http-message-sig";
+import { generateNonce } from "web-bot-auth";
+import { signerFromJWK } from "web-bot-auth/crypto";
+import { z } from "zod";
+
+const CACHE_CONTROL = "public, max-age=86400";
+const CONTENT_TYPE = "application/http-message-signatures-directory+json";
+const DIRECTORY_SIGNATURE_TAG = "http-message-signatures-directory";
+const SIGNATURE_LIFETIME_SECONDS = 60;
+
+export const runtime = "nodejs";
+
+const PrivateJwkSchema = z
+  .object({
+    kty: z.literal("OKP"),
+    crv: z.literal("Ed25519"),
+    alg: z.literal("EdDSA").optional(),
+    x: z.string().min(1),
+    d: z.string().min(1),
+  })
+  .passthrough();
+
+function parsePrivateJwk(configuredKey: string) {
+  let value: unknown;
+  try {
+    value = JSON.parse(configuredKey);
+  } catch {
+    throw new Error("PEATED_BOT_PRIVATE_JWK must be valid JSON.");
+  }
+
+  const parsed = PrivateJwkSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(
+      "PEATED_BOT_PRIVATE_JWK must contain a private Ed25519 JWK.",
+    );
+  }
+
+  return parsed.data;
+}
+
+function responseFields(headers: Headers): FieldOccurrence[] {
+  return Array.from(headers, ([name, value]) => ({ name, value }));
+}
+
+export async function GET(request: Request) {
+  const configuredKey = process.env.PEATED_BOT_PRIVATE_JWK?.trim();
+  if (!configuredKey) {
+    return new Response("PeatedBot signing is not configured.", {
+      status: 503,
+      headers: { "Cache-Control": "no-store" },
+    });
+  }
+
+  const privateJwk = parsePrivateJwk(configuredKey);
+  const publicJwk = {
+    kty: "OKP",
+    crv: "Ed25519",
+    x: privateJwk.x,
+  };
+  const body = JSON.stringify({ keys: [publicJwk] });
+  const headers = new Headers({
+    "Cache-Control": CACHE_CONTROL,
+    "Content-Type": CONTENT_TYPE,
+  });
+  const signer = await signerFromJWK(privateJwk);
+  const created = Math.floor(Date.now() / 1_000);
+  const response: ResponseDescriptor = {
+    kind: "response",
+    status: 200,
+    fields: responseFields(headers),
+    request,
+  };
+  const signature = await createSignature(response, {
+    label: "sig1",
+    components: [component("@authority", { req: true })],
+    parameters: {
+      alg: "ed25519",
+      keyid: signer.keyid,
+      nonce: generateNonce(),
+      tag: DIRECTORY_SIGNATURE_TAG,
+      created,
+      expires: created + SIGNATURE_LIFETIME_SECONDS,
+    },
+    signer,
+  });
+  headers.set("Signature", signature.signature);
+  headers.set("Signature-Input", signature.signatureInput);
+
+  return new Response(body, { headers });
+}

--- a/apps/web/src/app/.well-known/http-message-signatures-directory/route.ts
+++ b/apps/web/src/app/.well-known/http-message-signatures-directory/route.ts
@@ -20,16 +20,18 @@ const PrivateJwkSchema = z
     kty: z.literal("OKP"),
     crv: z.literal("Ed25519"),
     alg: z.literal("EdDSA").optional(),
-    x: z.string().min(1),
-    d: z.string().min(1),
+    x: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+    d: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
   })
-  .passthrough();
+  .strip();
 
 function parsePrivateJwk(configuredKey: string) {
   let value: unknown;
   try {
     value = JSON.parse(configuredKey);
   } catch {
+    // Sensitive-data policy: JSON parse errors can quote the private key, so do
+    // not preserve the parser error as the cause.
     throw new Error("PEATED_BOT_PRIVATE_JWK must be valid JSON.");
   }
 
@@ -57,6 +59,8 @@ export async function GET(request: Request) {
   }
 
   const privateJwk = parsePrivateJwk(configuredKey);
+  // Cloudflare directory contract: publish only public JWK fields. The `d`
+  // field is the private key and must never leave the deployment secret.
   const publicJwk = {
     kty: "OKP",
     crv: "Ed25519",

--- a/apps/web/src/app/sitemaps/static.xml/route.ts
+++ b/apps/web/src/app/sitemaps/static.xml/route.ts
@@ -15,6 +15,7 @@ export async function GET() {
     { url: "/companies" },
     { url: "/about" },
     { url: "/about/tasting-wheel" },
+    { url: "/bot" },
     { url: "/bottlers/4263/codes" },
     { url: "/activity" },
     { url: "/events" },

--- a/docs/operations/peated-bot.md
+++ b/docs/operations/peated-bot.md
@@ -1,0 +1,118 @@
+# PeatedBot Request Signing
+
+PeatedBot identifies scraper traffic with
+`PeatedBot/1.0 (+https://peated.com/bot)` and signs requests using Cloudflare Web
+Bot Auth. The private signing key is a deployment secret. The public key is
+served from
+`https://peated.com/.well-known/http-message-signatures-directory`.
+
+Cloudflare registration and a production source check are operational steps.
+They cannot be completed by merging code alone.
+
+## Create the key
+
+Create a dedicated Ed25519 key on a trusted workstation. Do not create it in
+the repository or a shared temporary directory. Replace the example directory
+below with a private local path. The repository script creates the directory,
+sets restrictive permissions, validates the generated JWK, and refuses to
+overwrite an existing key. It uses Peated's supported Node.js version, so this
+does not depend on the system OpenSSL build:
+
+```bash
+PEATED_BOT_KEY_DIR="/path/to/private/peated-bot-key"
+pnpm --filter @peated/server generate:peated-bot-key -- "$PEATED_BOT_KEY_DIR"
+```
+
+The key is written to `$PEATED_BOT_KEY_DIR/peated-bot-private.jwk`. The script
+prints only that path, never the key contents.
+
+On macOS, copy the JWK without printing it:
+
+```bash
+pbcopy < "$PEATED_BOT_KEY_DIR/peated-bot-private.jwk"
+```
+
+Store the complete contents of `peated-bot-private.jwk` as the
+`PEATED_BOT_PRIVATE_JWK` secret in:
+
+- the Vercel production environment for `peated-web`;
+- the Render `worker` service; and
+- every Render API environment that runs scraper previews or setup.
+
+Use the same JWK in each environment. Never put it in `.env.example`, source
+control, logs, an issue, or a pull request. Store a recovery copy in the
+approved secret manager. After the deployment secrets and recovery copy are
+confirmed, remove the local files and their now-empty directory:
+
+```bash
+rm "$PEATED_BOT_KEY_DIR/peated-bot-private.jwk"
+rmdir "$PEATED_BOT_KEY_DIR"
+unset PEATED_BOT_KEY_DIR
+```
+
+Without the secret, scraper requests remain unsigned and the public key route
+returns HTTP 503. This keeps local development and existing unsigned targets
+working.
+
+## Verify the deployment
+
+Deploy the web and scraper services before registration.
+
+1. Request the public directory and confirm it returns HTTP 200,
+   `Content-Type: application/http-message-signatures-directory+json`,
+   `Signature-Input`, and `Signature`.
+2. Confirm every published key contains only `kty`, `crv`, and `x`. A `d`
+   property is a private key leak. Remove the secret and deployment immediately
+   if it appears.
+3. From a server environment with the secret, run the crawl check:
+
+   ```bash
+   pnpm --filter @peated/server check:peated-bot-signature
+   ```
+
+   This uses the same signing function as the shared scraper transport and does
+   not print request headers. Before registration, HTTP 401 is expected when the
+   format is valid but the key is unknown. After registration, require HTTP 200;
+   HTTP 401 can also mean that a known key failed verification. HTTP 400 means
+   the request format is invalid.
+
+4. Confirm an ordinary unsigned-compatible source still completes through
+   Admin → Scrapers.
+
+Do not print request headers while checking a signed request. The signature is
+short-lived, but it is still authentication material.
+
+## Register with Cloudflare
+
+In the Cloudflare dashboard, open Manage Account → Configurations → Bot
+Submission Form. Choose **Request Signature** as the verification method. Use
+the public directory URL as the validation instruction and list
+`PeatedBot/1.0 (+https://peated.com/bot)` as the user agent.
+
+After Cloudflare accepts the submission:
+
+1. Repeat the crawl test and require HTTP 200.
+2. Run one bounded catalog request against a Cloudflare-backed source.
+3. Record the UTC time, source, HTTP status, and scraper run ID in the issue or
+   deployment record. Do not record request headers or the fetched body.
+4. If Springbank still returns its Cloudflare block page, record that the site
+   owner must allow PeatedBot. Do not add browser impersonation, proxies, or
+   challenge bypasses.
+
+## Rotate or recover the key
+
+Cloudflare accepts several Ed25519 keys in one directory, but the current route
+publishes one key. Rotate during a short scraper pause:
+
+1. Create a new dedicated key while the old key remains active.
+2. Pause scheduled scraper work.
+3. Change the web deployment to publish the new key.
+4. Submit or update the new public key with Cloudflare and wait for acceptance.
+5. Change the worker and API secrets to the new key, then resume scraper work.
+6. Require HTTP 200 from the crawl test and verify a Cloudflare-backed source.
+7. Remove the old key from every deployment and the recovery store.
+
+If the private key is lost, create and register a new key. If it may have been
+exposed, remove it from scraper services first, contact Cloudflare to revoke the
+registration, and then follow the rotation steps. Never reconstruct a key from
+logs or copy a key from an untrusted machine.

--- a/docs/operations/peated-bot.md
+++ b/docs/operations/peated-bot.md
@@ -1,22 +1,22 @@
-# PeatedBot Request Signing
+# PeatedBot request signing
 
-PeatedBot identifies scraper traffic with
-`PeatedBot/1.0 (+https://peated.com/bot)` and signs requests using Cloudflare Web
-Bot Auth. The private signing key is a deployment secret. The public key is
-served from
+PeatedBot identifies its requests with
+`PeatedBot/1.0 (+https://peated.com/bot)`. It uses Cloudflare Web Bot Auth to
+prove that those requests came from Peated. The private signing key is a
+deployment secret. Peated serves the matching public key from
 `https://peated.com/.well-known/http-message-signatures-directory`.
 
-Cloudflare registration and a production source check are operational steps.
+Cloudflare registration and a production website check are operational steps.
 They cannot be completed by merging code alone.
 
 ## Create the key
 
-Create a dedicated Ed25519 key on a trusted workstation. Do not create it in
-the repository or a shared temporary directory. Replace the example directory
-below with a private local path. The repository script creates the directory,
-sets restrictive permissions, validates the generated JWK, and refuses to
-overwrite an existing key. It uses Peated's supported Node.js version, so this
-does not depend on the system OpenSSL build:
+Create a dedicated Ed25519 key on a trusted workstation. The script stores it
+in JSON Web Key (JWK) format. Do not create it in the repository or a shared
+temporary directory. Replace the example directory below with a private local
+path. The repository script creates the directory, limits access to it, checks
+the generated key, and refuses to overwrite an existing key. It uses Peated's
+supported Node.js version, so it does not depend on the system OpenSSL build:
 
 ```bash
 PEATED_BOT_KEY_DIR="/path/to/private/peated-bot-key"
@@ -61,38 +61,39 @@ Deploy the web and scraper services before registration.
 1. Request the public directory and confirm it returns HTTP 200,
    `Content-Type: application/http-message-signatures-directory+json`,
    `Signature-Input`, and `Signature`.
-2. Confirm every published key contains only `kty`, `crv`, and `x`. A `d`
-   property is a private key leak. Remove the secret and deployment immediately
-   if it appears.
-3. From a server environment with the secret, run the crawl check:
+2. Confirm every published key contains only `kty`, `crv`, and `x`. The `d`
+   field contains the private key. Remove the secret and deployment immediately
+   if it appears in the response.
+3. From a server environment with the secret, run Cloudflare's request check:
 
    ```bash
    pnpm --filter @peated/server check:peated-bot-signature
    ```
 
-   This uses the same signing function as the shared scraper transport and does
-   not print request headers. Before registration, HTTP 401 is expected when the
-   format is valid but the key is unknown. After registration, require HTTP 200;
-   HTTP 401 can also mean that a known key failed verification. HTTP 400 means
-   the request format is invalid.
+   This uses the same signing function as the shared scraper request code and
+   does not print request headers. Before registration, HTTP 401 is expected
+   when the format is valid but the key is unknown. After registration, require
+   HTTP 200; HTTP 401 can also mean that a known key failed verification. HTTP
+   400 means the request format is invalid.
 
-4. Confirm an ordinary unsigned-compatible source still completes through
+4. Confirm a source that does not require a signature still completes through
    Admin → Scrapers.
 
-Do not print request headers while checking a signed request. The signature is
-short-lived, but it is still authentication material.
+Do not print request headers while checking a signed request. Someone could
+reuse the signature before it expires.
 
 ## Register with Cloudflare
 
 In the Cloudflare dashboard, open Manage Account → Configurations → Bot
 Submission Form. Choose **Request Signature** as the verification method. Use
-the public directory URL as the validation instruction and list
+the public key directory URL for **Validation Instructions** and list
 `PeatedBot/1.0 (+https://peated.com/bot)` as the user agent.
 
 After Cloudflare accepts the submission:
 
 1. Repeat the crawl test and require HTTP 200.
-2. Run one bounded catalog request against a Cloudflare-backed source.
+2. Run one catalog request, with the usual limits, against a site protected by
+   Cloudflare.
 3. Record the UTC time, source, HTTP status, and scraper run ID in the issue or
    deployment record. Do not record request headers or the fetched body.
 4. If Springbank still returns its Cloudflare block page, record that the site
@@ -109,8 +110,9 @@ publishes one key. Rotate during a short scraper pause:
 3. Change the web deployment to publish the new key.
 4. Submit or update the new public key with Cloudflare and wait for acceptance.
 5. Change the worker and API secrets to the new key, then resume scraper work.
-6. Require HTTP 200 from the crawl test and verify a Cloudflare-backed source.
-7. Remove the old key from every deployment and the recovery store.
+6. Require HTTP 200 from the crawl test and verify a site protected by
+   Cloudflare.
+7. Remove the old key from every deployment and the secret manager.
 
 If the private key is lost, create and register a new key. If it may have been
 exposed, remove it from scraper services first, contact Cloudflare to revoke the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      web-bot-auth:
+        specifier: 0.2.0
+        version: 0.2.0
       wkx:
         specifier: ^0.5.0
         version: 0.5.0
@@ -502,6 +505,9 @@ importers:
       fathom-client:
         specifier: ^3.7.2
         version: 3.7.2
+      http-message-sig:
+        specifier: 0.3.0
+        version: 0.3.0
       iron-session:
         specifier: ^8.0.4
         version: 8.0.4
@@ -541,6 +547,9 @@ importers:
       usehooks-ts:
         specifier: ^3.1.1
         version: 3.1.1(react@19.2.7)
+      web-bot-auth:
+        specifier: 0.2.0
+        version: 0.2.0
       zod:
         specifier: 'catalog:'
         version: 4.5.4
@@ -7418,6 +7427,9 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-message-sig@0.3.0:
+    resolution: {integrity: sha512-ossX5ZDDCRD+YtMzryp3gCg+5wqLFes1RVChEFmEE9Bzbd49Ts2IIIvFnTst/mYWx0ivrxrTTPsIIKKJ07s7+w==}
+
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -7852,6 +7864,9 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonwebkey-thumbprint@0.1.0:
+    resolution: {integrity: sha512-4m/gJEUQH8N2NfvZFjCL8/E+vlt0FlrmHoR4T93CEXQRkC64qwRi6oQri4/eqLVXqEqXYCss0+Q7pLx6vJBqzw==}
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -9815,6 +9830,10 @@ packages:
   strnum@2.2.0:
     resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
 
+  structured-headers@2.0.3:
+    resolution: {integrity: sha512-4g5yxhlDMClRwCcfKfLeS7Z8yAVdOWGDADwm80Poh1iReU2KVKLGBlqwpHWJ2qovq0+ZIf1atAEO1eua2o9Rgg==}
+    engines: {node: '>=18', npm: '>=6'}
+
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
@@ -10576,6 +10595,9 @@ packages:
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
+
+  web-bot-auth@0.2.0:
+    resolution: {integrity: sha512-3DJ72ZhWK4a3yCHCClF6q32g03X37DJlpyASYeBroGTRj/qFkHNcPwkESc3FLigjW6NOWF6MR+Hat9AfOqqtAQ==}
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
@@ -17783,6 +17805,10 @@ snapshots:
       toidentifier: 1.0.1
     optional: true
 
+  http-message-sig@0.3.0:
+    dependencies:
+      structured-headers: 2.0.3
+
   http-proxy-agent@5.0.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -18237,6 +18263,8 @@ snapshots:
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
+
+  jsonwebkey-thumbprint@0.1.0: {}
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -20823,6 +20851,8 @@ snapshots:
 
   strnum@2.2.0: {}
 
+  structured-headers@2.0.3: {}
+
   stubs@3.0.0: {}
 
   style-to-object@1.0.8:
@@ -21670,6 +21700,12 @@ snapshots:
   watchpack@2.5.2:
     dependencies:
       graceful-fs: 4.2.11
+
+  web-bot-auth@0.2.0:
+    dependencies:
+      http-message-sig: 0.3.0
+      jsonwebkey-thumbprint: 0.1.0
+      structured-headers: 2.0.3
 
   web-namespaces@2.0.1: {}
 


### PR DESCRIPTION
PeatedBot now attaches short-lived Ed25519 Web Bot Auth signatures to requests made through the shared scraper transport when `PEATED_BOT_PRIVATE_JWK` is configured. Deployments without the secret keep the existing unsigned behavior.

Peated.com also publishes the signed public-key directory required by Cloudflare without exposing the private `d` value. The public bot page now documents what Peated reads, its request controls, robots handling, and the contact path. An operations runbook and guarded key-generation and crawl-check scripts cover initial setup, verification, rotation, and recovery.

The same JWK is already configured in Vercel and Render. Cloudflare's crawl test returned the expected pre-registration HTTP 401, confirming that the request format is valid while the key remains unknown. After deployment, the remaining rollout steps are to submit the public directory through Cloudflare's Bot Submission Form, require HTTP 200 from the crawl test, and test one Cloudflare-backed catalog.

Refs #1184
