### PR TITLE
fix(web): handle invalid countries as not found

### DIFF
--- a/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPage.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPage.tsx
@@ -1,5 +1,6 @@
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { resolveCountryOrNotFound } from "@peated/web/lib/orpc/notFound.server";
 
 import {
   EntityCatalogPageClient,
@@ -17,14 +18,17 @@ export async function EntityCatalogPage({
     numericFields: ["cursor", "limit"],
   });
   const { client } = await getPublicPageServerClient();
-  const entityList =
+  const entityListPromise =
     kind === "distillery"
-      ? await client.distilleries.list(queryParams)
+      ? client.distilleries.list(queryParams)
       : kind === "brand"
-        ? await client.brands.list(queryParams)
+        ? client.brands.list(queryParams)
         : kind === "bottler"
-          ? await client.bottlers.list(queryParams)
-          : await client.companies.list(queryParams);
+          ? client.bottlers.list(queryParams)
+          : client.companies.list(queryParams);
+  const entityList = queryParams.country
+    ? await resolveCountryOrNotFound(entityListPromise, "query")
+    : await entityListPromise;
 
   return <EntityCatalogPageClient initialEntityList={entityList} kind={kind} />;
 }

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/bottles/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/bottles/page.tsx
@@ -33,24 +33,22 @@ export default async function CountryBottlesPage(props: {
     props.params,
     props.searchParams,
   ]);
+  const country = await getCountryPage(countrySlug);
   const queryParams = normalizeBottleCatalogQueryParams(
     getApiQueryParams(searchParams, {
       defaults: { sort: LOCATION_BOTTLE_DEFAULT_SORT },
       allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
       fields: LOCATION_BOTTLE_QUERY_FIELDS,
       numericFields: ["cursor"],
-      overrides: { country: countrySlug, limit: 25 },
+      overrides: { country: country.slug, limit: 25 },
     }),
   );
   const { client } = await getPublicPageServerClient();
-  const [country, bottleList] = await Promise.all([
-    getCountryPage(countrySlug),
-    client.bottles.list(queryParams),
-  ]);
+  const bottleList = await client.bottles.list(queryParams);
 
   return (
     <LocationBottleListClient
-      country={countrySlug}
+      country={country.slug}
       initialBottleList={bottleList}
       locationName={country.name}
     />

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/distillers/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/distillers/page.tsx
@@ -29,17 +29,15 @@ export default async function CountryDistillersPage(props: {
     props.params,
     props.searchParams,
   ]);
+  const country = await getCountryPage(countrySlug);
   const queryParams = getApiQueryParams(searchParams, {
     defaults: { sort: "-bottles" },
     numericFields: ["cursor", "limit"],
-    overrides: { country: countrySlug, limit: 50 },
+    overrides: { country: country.slug, limit: 50 },
   });
   const { client } = await getPublicPageServerClient();
-  const [country, distillerList] = await Promise.all([
-    getCountryPage(countrySlug),
-    client.distilleries.list(queryParams),
-  ]);
-  const pathname = `/locations/${countrySlug}/distillers`;
+  const distillerList = await client.distilleries.list(queryParams);
+  const pathname = `/locations/${country.slug}/distillers`;
   const page = Number(queryParams.cursor ?? 1) || 1;
 
   return (

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/regions/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/regions/page.tsx
@@ -35,23 +35,24 @@ export default async function CountryRegionsPage(props: {
     props.params,
     props.searchParams,
   ]);
+  const country = await getCountryPage(countrySlug);
   const queryParams = getApiQueryParams(searchParams, {
     defaults: { sort: "-bottles" },
     allowedValues: { sort: REGION_LIST_SORT_OPTIONS },
     fields: REGION_QUERY_FIELDS,
     numericFields: ["cursor", "limit"],
-    overrides: { country: countrySlug, limit: 100 },
+    overrides: { country: country.slug, limit: 100 },
   });
   const { client } = await getPublicPageServerClient();
   const regionList = await client.regions.list(queryParams);
-  const pathname = `/locations/${countrySlug}/regions`;
+  const pathname = `/locations/${country.slug}/regions`;
   const page = Number(queryParams.cursor ?? 1) || 1;
 
   return (
     <>
       {regionList.results.length ? (
         <LocationTable
-          caption={`Whisky regions in ${countrySlug.replaceAll("-", " ")}`}
+          caption={`Whisky regions in ${country.name}`}
           getHref={(region) => `${pathname}/${region.slug}`}
           items={regionList.results}
         />

--- a/apps/web/src/lib/locationPage.server.ts
+++ b/apps/web/src/lib/locationPage.server.ts
@@ -3,12 +3,16 @@
 import { cache } from "react";
 
 import { getAnonymousServerClient } from "./orpc/client.server";
-import { resolveOrNotFound } from "./orpc/notFound.server";
+import {
+  resolveCountryOrNotFound,
+  resolveOrNotFound,
+} from "./orpc/notFound.server";
 
 export const getCountryPage = cache(async (countrySlug: string) => {
   const { client } = await getAnonymousServerClient();
-  return await resolveOrNotFound(
+  return await resolveCountryOrNotFound(
     client.countries.details({ country: countrySlug }),
+    "path",
   );
 });
 

--- a/apps/web/src/lib/orpc/notFound.server.test.ts
+++ b/apps/web/src/lib/orpc/notFound.server.test.ts
@@ -1,0 +1,56 @@
+import { ORPCError } from "@orpc/client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createCountryNotFoundResolver } from "./notFound.server";
+
+const logInfo = vi.fn();
+const notFound = vi.fn(() => {
+  throw Object.assign(new Error("Not found"), {
+    digest: "NEXT_HTTP_ERROR_FALLBACK;404",
+  });
+});
+const resolveCountryOrNotFound = createCountryNotFoundResolver({
+  logInfo,
+  notFound,
+});
+
+describe("resolveCountryOrNotFound", () => {
+  beforeEach(() => {
+    logInfo.mockReset();
+    notFound.mockClear();
+  });
+
+  it("returns successful country requests without logging", async () => {
+    await expect(
+      resolveCountryOrNotFound(Promise.resolve("Scotland"), "path"),
+    ).resolves.toBe("Scotland");
+    expect(logInfo).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    new ORPCError("NOT_FOUND", { defined: true }),
+    new ORPCError("BAD_REQUEST", {
+      defined: true,
+      message: "Invalid country.",
+    }),
+  ])("logs expected invalid countries and returns a 404", async (error) => {
+    await expect(
+      resolveCountryOrNotFound(Promise.reject(error), "query"),
+    ).rejects.toMatchObject({ digest: "NEXT_HTTP_ERROR_FALLBACK;404" });
+    expect(logInfo).toHaveBeenCalledWith("Country did not match the catalog", {
+      extra: { "peated.catalog.country.source": "query" },
+    });
+  });
+
+  it("passes unexpected client errors to the route handler", async () => {
+    const error = new ORPCError("BAD_REQUEST", {
+      defined: true,
+      message: "Invalid region.",
+    });
+
+    await expect(
+      resolveCountryOrNotFound(Promise.reject(error), "path"),
+    ).rejects.toBe(error);
+    expect(logInfo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/orpc/notFound.server.ts
+++ b/apps/web/src/lib/orpc/notFound.server.ts
@@ -1,7 +1,18 @@
 "server only";
 
-import { isORPCNotFoundError } from "@peated/orpc/client/errors";
+import {
+  isORPCClientError,
+  isORPCNotFoundError,
+} from "@peated/orpc/client/errors";
+import { logInfo } from "@peated/web/lib/log";
 import { notFound } from "next/navigation";
+
+type CountrySource = "path" | "query";
+
+interface CountryNotFoundDependencies {
+  logInfo: typeof logInfo;
+  notFound: typeof notFound;
+}
 
 export async function resolveOrNotFound<T>(promise: Promise<T>): Promise<T> {
   try {
@@ -14,3 +25,37 @@ export async function resolveOrNotFound<T>(promise: Promise<T>): Promise<T> {
     throw error;
   }
 }
+
+export function createCountryNotFoundResolver({
+  logInfo: writeLog,
+  notFound: renderNotFound,
+}: CountryNotFoundDependencies) {
+  /** Turn an expected invalid country request into a logged public 404. */
+  return async function resolveCountryOrNotFound<T>(
+    promise: Promise<T>,
+    source: CountrySource,
+  ): Promise<T> {
+    try {
+      return await promise;
+    } catch (error) {
+      const invalidCountry =
+        isORPCClientError(error) &&
+        error.status === 400 &&
+        error.message === "Invalid country.";
+
+      if (isORPCNotFoundError(error) || invalidCountry) {
+        writeLog("Country did not match the catalog", {
+          extra: { "peated.catalog.country.source": source },
+        });
+        renderNotFound();
+      }
+
+      throw error;
+    }
+  };
+}
+
+export const resolveCountryOrNotFound = createCountryNotFoundResolver({
+  logInfo,
+  notFound,
+});


### PR DESCRIPTION
Malformed country paths and catalog filters now return the public 404 page and emit a structured informational log instead of escaping as application errors. Country subpages validate the country before issuing dependent list requests, so concurrent API validation can no longer win the race with the page's not-found handling.

The log records only whether the rejected country came from a path or query; it does not retain the attacker-controlled value. API validation behavior is unchanged.

Fixes PEATED-4EM
Fixes PEATED-4HC
Fixes PEATED-4GS
