### PR TITLE
fix(classifier): double reference turn budget

### DIFF
--- a/packages/bottle-classifier/src/classifierOutputBoundary.test.ts
+++ b/packages/bottle-classifier/src/classifierOutputBoundary.test.ts
@@ -322,7 +322,7 @@ describe("classifier output boundary", () => {
     });
   });
 
-  test("returns a decision after eight research turns", async () => {
+  test("returns a decision after 17 research turns", async () => {
     const prepared = await prepareBottleClassifierAgentRun(classifierOptions, {
       reference: { name: "Example Single Malt" },
       extractedIdentity: null,
@@ -343,10 +343,10 @@ describe("classifier output boundary", () => {
         matchedBottleId: null,
         proposedBottle: null,
       },
-      { researchTurns: 8, runOptions: prepared.runOptions },
+      { researchTurns: 17, runOptions: prepared.runOptions },
     );
 
-    expect(turn).toBe(9);
+    expect(turn).toBe(18);
     expect(prepared.runOptions.maxTurns).toBe(turn);
     expect(prepared.getAgentResult(result).decision).toMatchObject({
       action: "no_match",

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -111,8 +111,8 @@ export type {
   BottleClassifierToolEvent,
 } from "./runtime/bottleCheckRuntime";
 
-// A reference run can use eight turns for research and one to return its decision.
-const REFERENCE_CLASSIFIER_MAX_TURNS = 9;
+// A reference run can use 17 turns for research and one to return its decision.
+const REFERENCE_CLASSIFIER_MAX_TURNS = 18;
 const AUDIT_CLASSIFIER_MAX_TURNS = 8;
 // Tool calls run one at a time, so an audit keeps its last turn for the result.
 const CLASSIFIER_MAX_PROPOSED_OPERATIONS = AUDIT_CLASSIFIER_MAX_TURNS - 1;


### PR DESCRIPTION
Reference Classification can now spend up to 17 turns gathering evidence before using its final turn for a decision, doubling the complete run budget from 9 to 18 turns. Audit runs keep their existing independent eight-turn limit.

The deterministic output-boundary test now proves that a reference run can still return a valid decision on turn 18.

Fixes PEATED-4BK
