### PR TITLE
perf(entities): use role indexes for catalog summaries

### DIFF
--- a/apps/server/src/orpc/routes/entities/catalog.ts
+++ b/apps/server/src/orpc/routes/entities/catalog.ts
@@ -7,22 +7,33 @@ import {
 } from "@peated/server/db/schema";
 import { implement } from "@peated/server/orpc";
 import entityCatalogContract from "@peated/server/orpc/contracts/entities/catalog";
-import { and, asc, desc, eq, isNotNull, ne, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, ne, sql } from "drizzle-orm";
+import { union } from "drizzle-orm/pg-core";
 
-const activeBottleWhere = (entityId: number) =>
-  and(
+const activeBottleWhere = (entityId: number) => {
+  // Catalog reads use the role indexes independently instead of scanning every
+  // Bottle through one OR expression. The UNION also removes role overlaps.
+  const associatedBottleIds = union(
+    db
+      .select({ id: bottles.id })
+      .from(bottles)
+      .where(eq(bottles.brandId, entityId)),
+    db
+      .select({ id: bottles.id })
+      .from(bottles)
+      .where(eq(bottles.bottlerId, entityId)),
+    db
+      .select({ id: bottlesToDistillers.bottleId })
+      .from(bottlesToDistillers)
+      .where(eq(bottlesToDistillers.distillerId, entityId)),
+  );
+
+  return and(
     isNotNull(bottles.groupId),
     sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
-    or(
-      eq(bottles.brandId, entityId),
-      eq(bottles.bottlerId, entityId),
-      sql`EXISTS(
-        SELECT FROM ${bottlesToDistillers}
-        WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
-          AND ${bottlesToDistillers.distillerId} = ${entityId}
-      )`,
-    ),
+    inArray(bottles.id, associatedBottleIds),
   );
+};
 
 export default implement(entityCatalogContract).handler(async function ({
   input,


### PR DESCRIPTION
Entity catalog summaries now build their Bottle set through three indexed role lookups—Brand, bottler, and distillery—and combine them with `UNION`. This replaces the repeated full Bottle scan with an `OR` and correlated distillery lookup that Sentry was still reporting at roughly 0.8–1.5 seconds per aggregate query.

The union preserves the existing response contract and removes duplicate Bottle IDs when one Entity fills several roles. The existing integration coverage exercises that overlap together with categories, relationship counts, related Entities, and notable Bottles.

Fixes PEATED-4FN
Fixes PEATED-4FW
Fixes PEATED-4FX
Fixes PEATED-4FZ
Fixes PEATED-4G0
Fixes PEATED-4G2
