### PR TITLE
fix(catalog): distinguish releases by bottling year

### DIFF
--- a/apps/server/src/lib/createBottle.test.ts
+++ b/apps/server/src/lib/createBottle.test.ts
@@ -498,7 +498,7 @@ describe("Bottle creation", () => {
     });
   });
 
-  test("allows one marketed title to have distinct structured releases", async ({
+  test("allows one marketed title to have distinct bottling years", async ({
     defaults,
     fixtures,
   }) => {
@@ -509,7 +509,8 @@ describe("Bottle creation", () => {
       input: {
         name: "Annual Selection",
         brand: brand.id,
-        releaseYear: 2025,
+        vintageYear: 1990,
+        bottlingYear: 2025,
         abv: 46,
       },
     });
@@ -518,14 +519,15 @@ describe("Bottle creation", () => {
       input: {
         name: "Annual Selection",
         brand: brand.id,
-        releaseYear: 2026,
-        abv: 48,
+        vintageYear: 1990,
+        bottlingYear: 2026,
+        abv: 46,
       },
     });
 
     expect(second.bottle.id).not.toBe(first.bottle.id);
     expect(second.bottle.fullName).toBe(first.bottle.fullName);
-    expect([first.bottle.releaseYear, second.bottle.releaseYear]).toEqual([
+    expect([first.bottle.bottlingYear, second.bottle.bottlingYear]).toEqual([
       2025, 2026,
     ]);
   });

--- a/apps/server/src/lib/createBottle.ts
+++ b/apps/server/src/lib/createBottle.ts
@@ -390,8 +390,9 @@ async function findExactBottleIdentityInTransaction(
   tx: AnyTransaction,
   bottle: NewBottle,
 ) {
-  // Names are marketed titles, not unique ids. Serialize same-title creates and
-  // compare the structured identity that can safely prove an exact duplicate.
+  // BottleGroup relates releases of one expression; it does not collapse their
+  // Bottle-owned exact fields. Serialize same-title creates and compare the
+  // structured identity that can safely prove an exact duplicate.
   await tx.execute(
     sql`SELECT pg_advisory_xact_lock(hashtext(${`bottle:identity:${bottle.fullName.toLowerCase()}`}))`,
   );
@@ -406,6 +407,7 @@ async function findExactBottleIdentityInTransaction(
         sql`${bottles.statedAge} IS NOT DISTINCT FROM ${bottle.statedAge ?? null}`,
         sql`${bottles.noAgeStatement} IS NOT DISTINCT FROM ${bottle.noAgeStatement ?? null}`,
         sql`${bottles.vintageYear} IS NOT DISTINCT FROM ${bottle.vintageYear ?? null}`,
+        sql`${bottles.bottlingYear} IS NOT DISTINCT FROM ${bottle.bottlingYear ?? null}`,
         sql`${bottles.releaseYear} IS NOT DISTINCT FROM ${bottle.releaseYear ?? null}`,
         sql`${bottles.releaseMonth} IS NOT DISTINCT FROM ${bottle.releaseMonth ?? null}`,
         sql`${bottles.releaseDay} IS NOT DISTINCT FROM ${bottle.releaseDay ?? null}`,
@@ -602,6 +604,8 @@ export async function createBottleInTransaction(
     });
   }
 
+  // TODO(catalog): Add a reviewed regrouping operation so verified releases of
+  // one expression can share a BottleGroup without guessing from their names.
   const group = await createIndependentGroupPrefix(tx, {
     actorId: createdByActorId,
     fields: groupFields,

--- a/docs/architecture/whisky-identity-model.md
+++ b/docs/architecture/whisky-identity-model.md
@@ -202,6 +202,8 @@ BottleSeries means “related products in the same range.”
   BottleGroup.
 - Macallan 18 annual releases can be separate Bottles in one BottleGroup when
   they are marketed as annual versions of the same expression.
+- One vintage bottled in different years can be separate Bottles in one
+  BottleGroup because the additional time in cask can change the whisky.
 - Octomore 13.1 and 13.3 are distinct expressions in separate BottleGroups,
   even if they share a BottleSeries.
 
@@ -234,10 +236,10 @@ Entity.
   when the producer sells one ongoing product without batch-specific
   marketing.
 - Bottle names combine the stable expression with an explicit marketed
-  edition. Age, vintage year, release year, ABV, cask strength, cask number, and
-  outturn remain structured facts. Do not generate name suffixes from those
-  fields to make a Bottle look unique. Wording already marketed in the
-  expression remains there.
+  edition. Age, vintage year, bottling year, release year, ABV, cask strength,
+  cask number, and outturn remain structured facts. Do not generate name
+  suffixes from those fields to make a Bottle look unique. Wording already
+  marketed in the expression remains there.
 - For a uniform multi-distillery label with no separate expression name, use
   the featured distillery as the Bottle name. For example, use `Glenury Royal`
   as the Rare Series Bottle name. Store its 55-year age, 1970 vintage, 2026
@@ -247,9 +249,10 @@ Entity.
   available. Store `releaseMonth` and `releaseDay` only when the source gives
   them. A month requires a year, and a day requires a month. Do not make up a
   month or day. A bare year is ambiguous until the source explains it.
-- A different `bottlingYear` does not prove that it is a different Bottle.
-  Create a separate Bottle for that year only when the producer markets the
-  bottling as a separate release.
+- A different `bottlingYear` means two structured identities are not exact
+  duplicates because the time spent maturing can differ. It does not by itself
+  prove that two source records describe separate marketed releases. Create a
+  separate Bottle only when release evidence supports that distinction.
 - Do not infer `statedAge` from year fields unless the source states the age.
 
 When one uniform consumer label markets whiskies from multiple named

--- a/docs/research/catalog/2026-09-07-brora.md
+++ b/docs/research/catalog/2026-09-07-brora.md
@@ -1,0 +1,658 @@
+# Brora — September 7, 2026
+
+This production review began with official Brora single malts marketed by the
+distillery or Diageo from the first Rare Malts Selection releases in 1995
+through the current range checked on September 7, 2026, then expanded to
+independent bottlings that name Brora as their distillery. The latest marketed
+official release found was from 2024. The official inventory included the 16
+annual Special Releases, Rare Malts Selection, Prima & Ultima, Triptych,
+Distillery Collection, Casks of Distinction, and documented one-offs. Blends
+that contain Brora, cask samples, whole-cask sales, miniatures of an otherwise
+identical release, and packaging-only variants are not separate Brora Bottle
+identities. Pre-1969 bottles marketed as Clynelish remain Clynelish identities
+even though the original site was later renamed Brora.
+
+- Whisky Auctioneer's [distillery history](https://whiskyauctioneer.com/learn/explore-whisky/distilleries/brora)
+  established the 1995 Rare Malts debut, the 2002 official Brora brand launch,
+  the annual Special Releases through 2017, and the later named collections.
+  Christie's [complete 16-bottle set](https://www.christies.com/en/lot/lot-6405825)
+  supplied the release year, age, strength, and outturn for every annual
+  Special Release. Exact producer, auction, and contemporary review pages were
+  still needed for vintages, maturation, color, and filtration claims. The
+  broad [Whiskyfun Brora index](https://www.whiskyfun.com/Brora-Index.html) is
+  useful for inventory, but its 2010 and 2011 outturn summaries conflict with
+  exact bottle labels and Christie's. The exact evidence supports 3,000 and
+  1,500 bottles respectively.
+- The Rare Malts inventory was checked against the [Buxrud release list](https://www.buxrud.se/raremalt.htm),
+  exact auction records, and label images. The [Fine Spirits compilation](https://blog.finespirits.auction/img/news/RARE%20MALTS%20SELECTION%20-%20EN.pdf)
+  is a useful lead but contains shifted or unsupported Brora rows, including
+  1972/22-year/54.9% and 1974/20-year/57.5% combinations that could not be
+  found on an exact label or release record. Do not create releases from that
+  table without exact corroboration.
+- Diageo's Prima & Ultima release documents establish the
+  [Second Release](https://mma.prnewswire.com/media/1561023/Diageo.pdf),
+  [Third Release](https://cms-diageocms.diageoplatform.com/media/2lgfjmeu/prima-and-ultima-3rd-release-faq.pdf),
+  and [Fourth Release](https://media.diageocms.com/media/b5parkgi/prima-ultima-fourth-release-faq.pdf)
+  ages, vintages, strengths, bottle counts, bottling dates, and cask makeups.
+  The producer's [Fourth Release page](https://www.malts.com/en-gb/products/brora-1977-single-malt-scotch-whisky-prima-and-ultima-fourth-release)
+  supplied exact marketed wording.
+- The exact [Triptych set record](https://www.scotchwhiskyauctions.com/auctions/215-the-166th-auction/807434-brora-triptych---1972-elusive-legacy-1977-age-of-peat--1982-timeless-original-3-x-50cl/)
+  identifies Elusive Legacy, Age of Peat, and Timeless Original as three
+  distinct 2021 Bottles. Exact records also established the
+  [World of Whiskies exclusive](https://www.whisky-online.com/collections/40-49-year-old-whisky/products/brora-1972-40-year-old-world-of-whiskies-exclusive-single-cask),
+  200th Anniversary release, and the one-of-one
+  [2018 charity bottle](https://whisky.auction/auctions/lot/46364/brora-35-year-old-bottle-1-of-1).
+- Distillery Collection evidence came from the exact
+  [Hidden Beneath](https://whiskyauctioneer.com/whisky-lot/5254340/brora-1982-distillery-collection-39-year-old-hidden-beneath)
+  record, the [producer page](https://www.diageorareandexceptional.com/us/brora-39-year-old)
+  confirming its 150-bottle outturn and natural strength, and a contemporary
+  [Untold Depths review](https://www.whiskyfun.com/archivejune24-2-Brora-Macduff.html).
+  The current-release audit also checked the exact
+  [Untold Depths record](https://www.whiskybase.com/whiskies/whisky/256948)
+  and repaired B55102 with its stated natural color, no chill filtration, and
+  cask strength; its existing 1977 vintage, 44-year age, 2024 release, 49.1%
+  strength, refill-hogshead maturation, cask 2637, 150-bottle outturn, and
+  single-cask status were retained and verified.
+  Diageo's current [Brora distillery page](https://www.diageorareandexceptional.com/ww/brora-distillery)
+  and a [June 2026 distillery overview](https://www.thewhiskyexchange.com/inspiration/article/19289/lost-distilleries-a-closer-look-at-brora)
+  show no later marketed Brora Bottle: the reopened distillery is laying down
+  new spirit, while released Bottles still come from pre-1983 stocks. The
+  three-year-old reopened spirit offered during the visitor experience is a
+  tasting, not evidence of a retail Bottle identity.
+  Casks of Distinction was inventoried from its [Series page](https://whiskyauctioneer.com/learn/explore-whisky/series/diageo-casks-distinction),
+  exact bottle records, and Diageo's announcement for the
+  [1972 cask 4817 bottle](https://www.diageo.com/en/news-and-media/press-releases/2017/one-of-the-worlds-rarest-whiskies-sells-at-auction-oldest-official-bottling-of-1972-brora-sold).
+  An exact [Sotheby's lot record](https://www.lot-art.com/auction-lots/Brora-40-Year-Old-Cask-of-Distinction-438-522-abv/6118-brora_40-18.3.26-sotheby)
+  and [Whiskybase record](https://www.whiskybase.com/whiskies/whisky/258350/brora-1982)
+  established the 1982/40-year cask 438 bottling for Hong Kong Whisky Fellows:
+  52.2% ABV, refill American oak, and an outturn of 150 bottles. A separate
+  2022 Sotheby's whole-cask listing quoted 52.8% before bottling and should not
+  replace the finished Bottle facts.
+  A 1978/43-year cask 2704 lead appears to describe a cask sample or a path
+  toward the Triptych rather than a separate marketed bottle, so it remains
+  unresolved. Whole-cask offers were not counted as Bottles.
+- Diageo's [current Brora page](https://www.diageorareandexceptional.com/us/brora-distillery)
+  displayed Triptych and Hidden Beneath. It says spirit made after the 2021
+  reopening became whisky in 2024, but no marketed Bottle from that new spirit
+  or any 2025 or 2026 release was found. New-make samples, a three-year cask
+  sample, and whole-cask offers were excluded from the Bottle inventory.
+- A broader distillery-scope check found 298 Brora-linked entries on
+  [Whiskybase](https://www.whiskybase.com/whiskies/distillery/106/whiskies),
+  compared with 50 production records carrying the Brora distillery
+  relationship before one additional repair. The larger list includes
+  independent single malts, blends containing Brora, advanced samples,
+  miniatures, and packaging variants, so 298 is an inventory lead rather than
+  a safe Bottle count. Its independent groups include Cadenhead's, Douglas
+  Laing, Gordon & MacPhail, Ian Macleod, Lombard, Signatory Vintage, the Scotch
+  Malt Whisky Society, and many smaller bottlers. Whiskybase's interactive page
+  rejected a headless browser at its security check, but its indexed table and
+  exact Bottle pages remained readable. A full distillery-wide independent
+  bottling review is materially larger than the official-release subset and
+  must verify every row rather than bulk-create the specialist list.
+- The wider name search exposed an existing Lombard record whose import wording
+  exactly matched a [Whisky Advocate review](https://whiskyadvocate.com/Lombard-Jewels-of-Scotland-distilled-at-Brora-1982-vintage-50).
+  That source and the exact [Whiskybase record](https://www.whiskybase.com/whiskies/whisky/261323/brora-1982-lb?language=en)
+  established a 1982 Brora bottled in 2004 at 22 years old and 50% ABV. The
+  Bottle was repaired with Lombard as Brand and bottler, Brora as distiller,
+  and a new Jewels of Scotland Series. Its unsupported generated tasting notes
+  were cleared. The different 2014 Lombard release from cask 876 is 32 years
+  old and 46.1% ABV; it is now separately stored as B55740.
+- The Bottlers released two distinct 19-year-old Brora single casks distilled
+  in June 1981 and bottled in July 2000. The exact
+  [cask 1076 retailer page](https://www.thewhiskyexchange.com/p/1278/brora-1981-19-year-old-the-bottlers)
+  and [cask 1077 auction record](https://whiskyauctioneer.com/learn/explore-whisky/bottles/brora-1981-19-year-old-1)
+  establish refill sherry butt 1076 at 61% ABV and refill sherry butt 1077 at
+  60.4% ABV. Whiskybase's exact
+  [1076](https://www.whiskybase.com/whiskies/whisky/2388/brora-1981-tb)
+  and [1077](https://www.whiskybase.com/whiskies/whisky/2389/brora-1981-tb)
+  records corroborate the dates, age, cask strength, natural color, and lack of
+  chill filtration. Both Bottles were created under The Bottlers as Brand and
+  bottler with Brora as distiller. The older generic production record says
+  only “Brora 1981 TB,” incorrectly records 18 years, and has no activity,
+  image, or cask-specific reference. After a fresh consumer and reference
+  check, that unsupported placeholder B1229 was deleted rather than being
+  guessed as either cask; its import text remains unassigned.
+- William Cadenhead's released five supported 1982 Brora identities: four in
+  the existing Authentic Collection Series and one separate Cadenhead
+  bottling. Its
+  [bottler inventory](https://www.whiskybase.com/whiskies/bottler/77375/cadenhead)
+  separates the 13-year-old 56.6% January 1996 bottling from Authentic
+  Collection releases at 60.4% and 59.2% in 1995, 59.9% in 1996, and 60.6% in 1997. Exact pages establish the
+  [56.6% release](https://www.whiskybase.com/whiskies/whisky/20149/brora-1982-ca),
+  while exact auction records corroborate the
+  [59.2%](https://whiskyauctioneer.com/learn/explore-whisky/bottles/brora-1982-cadenheads-authentic-collection-13-year-old-1),
+  [59.9%](https://whisky.auction/auctions/lot/103805/brora-1982-13-year-old),
+  and
+  [60.6%](https://www.thewhiskyexchange.com/p/23054/brora-1982-14-year-old-bot1997-cadenheads)
+  identities. The 50-millilitre version of the 59.2% release was treated as a
+  packaging variant, not a sixth Bottle. Production now has all five under
+  William Cadenhead's as Brand and bottler with Brora as distiller; the four
+  named releases use the existing Authentic Collection Series. Unknown cask
+  numbers, outturns, and production claims were left unknown.
+- Blackadder's exact
+  [Distillery Selection record](https://www.whiskybase.com/whiskies/whisky/18233/brora-1982-ba)
+  and the corroborating
+  [retailer page](https://www.masterofmalt.com/whiskies/brora/brora-13-year-old-1982-cask-430-blackadder-whisky/)
+  establish one 13-year-old Brora distilled on March 18, 1982 and bottled in
+  November 1995 from cask 430 at 43% ABV. The label record also supports single
+  cask, natural color, and non-chill filtration. Production now has that exact
+  Bottle under Blackadder as Brand and bottler with Brora as distiller, plus a
+  Blackadder-owned Distillery Selection Series. Cask strength and maturation
+  remain unknown because the exact sources do not establish them.
+- Acredyke Whisky Ltd.'s exact
+  [A Single Old Malt Cask record](https://www.whiskybase.com/whiskies/whisky/12429/brora-1982-awl)
+  establishes one no-age-statement Brora distilled in 1982 and bottled in 2004
+  for the Japanese market at cask strength, 59.8% ABV. The indexed label record
+  supports natural color but does not establish a cask number, outturn, single
+  cask status, or chill-filtration claim, so those facts remain unknown.
+  Production now has this exact Bottle under Acredyke Whisky Ltd. as Brand and
+  bottler with Brora as distiller, plus the Acredyke-owned A Single Old Malt
+  Cask Series.
+- Daily Dram's exact
+  [The Nectar of the Daily Drams record](https://www.whiskybase.com/whiskies/whisky/19220/brora-1982-dd)
+  and corroborating
+  [auction record](https://whiskyauctioneer.com/learn/explore-whisky/bottles/brora-1982-nectar-daily-drams-28-year-old)
+  establish one 28-year-old Brora distilled in 1982 and bottled in 2010 from
+  cask 877 at cask strength, 52.3% ABV. The exact label record supports single
+  cask, natural color, non-chill filtration, and an outturn of 100 bottles.
+  Production now has B55627 in the existing The Nectar of the Daily Drams
+  Series, using the same stored relationship as its existing member: Daily Dram
+  as Brand, The Nectar as bottler, and Brora as distiller.
+- That Boutique-y Whisky Company's
+  [producer archive](https://www.thatboutiqueywhiskycompany.com/whiskies/brora)
+  and exact auction records establish two no-age-statement Brora batches. Batch
+  1 was bottled in 2013 at 47.1% ABV with an outturn of 24 bottles; its
+  [exact record](https://www.whiskybase.com/whiskies/whisky/40180/brora-batch-1-tbwc?language=en)
+  supports cask strength, natural color, and non-chill filtration. Batch 2 was
+  [released in September 2014](https://whiskyauctioneer.com/learn/explore-whisky/bottles/brora-boutique-y-whisky-company-batch-2)
+  at 52.1% ABV with an outturn of 42 bottles; its
+  [exact label record](https://www.whiskybase.com/whiskies/whisky/58392/brora-batch-2-tbwc)
+  supports single cask, natural color, and non-chill filtration. Production now
+  has B55635 and B55639 under That Boutique-y Whisky Company as Brand and
+  bottler with Brora as distiller. Claims not shown for the respective batch
+  remain unknown.
+- The Dalriada Whisky Company's exact
+  [Modern Masters of Scotland record](https://www.whiskybase.com/whiskies/whisky/13133/brora-1981-daw)
+  and a contemporary
+  [review](https://www.whiskyfun.com/archivejuly25-2-Highland-Park-Brora.html)
+  establish one no-age-statement Brora distilled in 1981 and bottled in 2004
+  from a butt at 58.2% ABV for the Japanese market, with an outturn of 239
+  bottles. Production now has B55640 under The Dalriada Whisky Company as Brand
+  and bottler with Brora as distiller, plus the Dalriada-owned The Modern
+  Masters of Scotland Series. The sources do not explicitly establish a cask
+  number, single-cask status, cask strength, natural color, or chill filtration,
+  so those facts remain unknown.
+- The 30-year-old, 52.9% Brora shown under Speciality Drinks Ltd and The Whisky
+  Exchange in specialist indexes is one Whisky Show 2011 release, not two
+  Bottle identities. The Whisky Exchange's
+  [exact product page](https://www.thewhiskyexchange.com/p/15213/brora-30-year-old-twe-whisky-show)
+  and [October 2011 archive](https://www.thewhiskyexchange.com/new-products/october-2011)
+  identify it as an exclusive 2011 show bottling, matured for 30 years in oak,
+  with no added color or chill filtration. The exact
+  [label record](https://www.whiskybase.com/whiskies/whisky/26296/brora-30-year-old-sms)
+  supports cask strength and names Speciality Drinks Ltd as the bottler. The
+  later [Whisky Exchange index entry](https://www.whiskybase.com/whiskies/whisky/53962/brora-30-year-old-twex)
+  is another catalog version of the same age, strength, maturation, and event
+  release. Production now has one Bottle, B55641, under The Whisky Exchange as
+  Brand, Speciality Drinks Ltd as bottler, and Brora as distiller. Its verified
+  alternate public name, `Brora - Fine Old Rare`, is stored as alias 269 rather
+  than as a duplicate Bottle. Vintage, bottling year, cask number, outturn, and
+  single-cask status remain unknown.
+- Single Malts Direct's exact
+  [Whiskies of Scotland record](https://www.whiskybase.com/whiskies/whisky/28216/brora-1981-smd)
+  establishes one no-age-statement Brora distilled in 1981 and bottled at cask
+  strength, 57.1% ABV, with no added color or chill filtration. Its
+  500-millilitre presentation is the standard size used by other releases in
+  the range, not a miniature or sample. Production now has B55642 under Single
+  Malts Direct as Brand and bottler with Brora as distiller, plus the
+  Single-Malts-Direct-owned Whiskies of Scotland Series. Bottling and release
+  dates, cask number, maturation, outturn, and single-cask status remain
+  unknown.
+- The Whisky Agency released two distinct 28-year-old Brora bottlings from
+  1982 in 2010. The exact
+  [Perfect Dram record](https://www.whiskybase.com/whiskies/whisky/19725/brora-1982-twa)
+  and Whisky Auctioneer's
+  [range history](https://whiskyauctioneer.com/learn/explore-whisky/brands/perfect-dram)
+  establish a joint bottling with Daily Dram from an ex-bourbon hogshead at
+  cask strength, 52.3% ABV, with natural color, no chill filtration, and an
+  outturn of 222 bottles. It is a different marketed Bottle from Daily Dram's
+  cask 877 release, which had an outturn of 100 bottles. The exact
+  [Private Stock record](https://www.whiskybase.com/whiskies/whisky/18718/brora-1982-twa),
+  Whisky Auctioneer's
+  [Series inventory](https://whiskyauctioneer.com/learn/explore-whisky/series/whisky-agency-private-stock),
+  and a corroborating
+  [Fine Spirits account](https://blog.finespirits.auction/en/news/the-view-from-the-golden-promise-25-2-188)
+  establish the separate La Maison du Whisky bottling from a bourbon hogshead
+  at 51.6% ABV, with an outturn of 222 bottles. Production now has B55643 in
+  the existing The Whisky Agency Perfect Dram Series and B55644 in the new
+  The Whisky Agency Private Stock Series S0791. Both use The Whisky Agency as
+  Brand and bottler and Brora as distiller. Unsupported Private Stock color,
+  filtration, cask-strength, single-cask, and cask-number claims remain
+  unknown.
+- Wilson & Morgan's exact
+  [Barrel Selection record](https://www.whiskybase.com/whiskies/whisky/10359/brora-1974-wm?language=en),
+  corroborating
+  [retailer page](https://www.thewhiskyexchange.com/p/27552/brora-1974-27-year-old-bot2002-wilson-morgan),
+  and
+  [auction record](https://whiskyauctioneer.com/learn/explore-whisky/bottles/brora-1974-wilson-morgan-barrel-selection-27-year-old-anniversary)
+  establish one 27-year-old Brora distilled in 1974 and bottled in 2002 for
+  the Anniversary Selection at 46% ABV. Production now has B55645 in the
+  existing Wilson & Morgan Barrel Selection Series, using Wilson & Morgan as
+  Brand and bottler and Brora as distiller. Maturation, cask number, outturn,
+  and color, filtration, cask-strength, and single-cask claims remain unknown.
+- The Scottish Independent Distillers Co. Ltd.'s exact
+  [Original-Label Selection record](https://www.whiskybase.com/whiskies/whisky/298301/brora-1980-tsid)
+  establishes one no-age-statement Brora distilled in 1980 and bottled at 46%
+  ABV for Main Bar Tudor at the Miyako Hotel Tokyo in Japan. Production now
+  has B55646 in the new Original-Label Selection Series S0795, using The
+  Scottish Independent Distillers Co. Ltd. as Brand and bottler and Brora as
+  distiller. Bottling and release dates, maturation, cask number, outturn, and
+  color, filtration, cask-strength, and single-cask claims remain unknown.
+- Edition Spirits' exact
+  [The First Editions record](https://www.whiskybase.com/whiskies/whisky/271955/brora-1982-ed)
+  establishes one 37-year-old Brora distilled in 1982 and bottled in 2020 from
+  refill hogshead HL 17675 at cask strength, 43.8% ABV, with natural color and
+  no chill filtration. Production now has B55647 under Hunter Laing as Brand
+  and owner of the existing The First Editions Series, Edition Spirits as
+  bottler, and Brora as distiller. The stored Entity relationship confirms
+  Edition Spirits is owned by Hunter Laing. The outturn and release date remain
+  unknown.
+- Hunter Laing's exact
+  [Old & Rare record](https://www.whiskybase.com/whiskies/whisky/245220/brora-1982-hl),
+  corroborating
+  [retailer page](https://www.thewhiskyexchange.com/p/79534/brora-1982-40-year-old-old-and-rare),
+  [single-cask listing](https://www.whiskyshop.com/old-rare-brora-1982-40-year-old),
+  and [contemporary review](https://www.whiskyfun.com/2024/A-trio-of-Brora-to-celebrate-the-New-Year.html)
+  establish one 40-year-old Brora distilled in 1982 and bottled in 2022 from
+  refill cask HL19390 at cask strength, 47.4% ABV, with natural color, no chill
+  filtration, and an outturn of 50 decanters. Production now has B55648 under
+  Hunter Laing as Brand and bottler, Brora as distiller, and the new Hunter
+  Laing Old & Rare Series S0797.
+- First Cask's
+  [bottler inventory](https://www.whiskybase.com/whiskies/bottler/77399/whiskies)
+  establishes eleven distinct Brora single casks at 46% ABV: 1981 casks
+  [1556](https://www.whiskybase.com/whiskies/whisky/40305/brora-1981-fc)
+  and
+  [1558](https://www.whiskybase.com/whiskies/whisky/37242/brora-1981-fc),
+  both stated as 23 years old, and 1982 casks
+  [274](https://www.whiskybase.com/whiskies/whisky/64898/brora-1982-fc),
+  [275](https://www.whiskybase.com/whiskies/whisky/21227/brora-1982-fc),
+  [276](https://www.whiskybase.com/whiskies/whisky/67306/brora-1982-fc),
+  [277](https://www.whiskybase.com/whiskies/whisky/297520/brora-1982-fc),
+  [278](https://www.whiskybase.com/whiskies/whisky/260663/brora-1982-fc),
+  [279](https://www.whiskybase.com/whiskies/whisky/20148/brora-1982-fc),
+  [280](https://www.whiskybase.com/whiskies/whisky/75013/brora-1982-fc),
+  [281](https://www.whiskybase.com/whiskies/whisky/102708/brora-1982-fc),
+  and
+  [282](https://www.whiskybase.com/whiskies/whisky/75014/brora-1982-fc),
+  all stated as 21 years old. Exact pages give December 8, 1981 and February
+  25, 1982 distillation dates. Cask 1556 was bottled in April 2005; casks 275,
+  276, 277, and 279 were bottled in January 2003; cask 278 was bottled in 2003.
+  The remaining bottling dates are unknown. Exact label records support natural
+  color and no chill filtration for casks 276, 277, 281, and 282; those claims
+  remain unknown for the other casks. Production now has B55649 through B55659
+  under First Cask as Brand, Direct Wines as bottler, and Brora as distiller.
+  The production relationship follows the stored First Cask model. Maturation,
+  outturn, and cask-strength claims remain unknown for all eleven.
+- Dun Eideann's exact
+  [cask 1562 record](https://www.whiskybase.com/whiskies/whisky/52613/brora-1981-de),
+  corroborating
+  [retailer page](https://www.thewhiskyexchange.com/p/66445/brora-1981-cask-1562-dun-eideann),
+  and [auction lot](https://www.mctears.co.uk/auction/lot/lot-358---brora-1981-dun-eideann-cask-1562/?au=1319&ef=&et=&g=1&ic=False&lot=241803&pn=4&pp=96&sd=1&so=0&st=&sto=0)
+  establish one 23-year-old Brora distilled in 1981 and bottled in 2004 for
+  Divo SA Suisse from cask 1562 at cask strength, 58.4% ABV, with natural
+  color, no chill filtration, and an outturn of 667 bottles. Production now
+  has B55660 under Dun Eideann as Brand and bottler and Brora as distiller.
+  Maturation and release date remain unknown.
+- Scotch Malt Sales' exact records establish three no-age-statement Brora
+  bottlings for the Japanese market: a
+  [1980 Celtic Cross](https://www.whiskybase.com/whiskies/whisky/64872/brora-1980-scms)
+  at 46% ABV with natural color and no chill filtration, a
+  [1981 Celtic Cross](https://www.whiskybase.com/whiskies/whisky/130858/brora-1981-scms)
+  at 46% ABV, and a
+  [1981 Tir Nan Og](https://www.whiskybase.com/whiskies/whisky/175030/brora-1981-scms)
+  at cask strength, 55.1% ABV. Production now has B55671, B55672, and B55673
+  under Scotch Malt Sales as Brand and bottler and Brora as distiller, plus
+  the Scotch Malt Sales-owned Celtic Cross S0798 and Tir Nan Og S0799 Series.
+  Bottling and release dates, maturation, cask numbers, outturns, and all other
+  unsupported production claims remain unknown.
+- Duncan Taylor's
+  [bottler inventory](https://www.whiskybase.com/whiskies/bottler/77362/whiskies)
+  establishes six full-size Brora releases in its Rare Auld Series, all
+  distilled in November 1981 and bottled as natural-color, non-chill-filtered
+  single casks at cask strength. The exact records cover casks
+  [1426](https://www.whiskybase.com/whiskies/whisky/1373/brora-1981-dt),
+  [1425](https://www.whiskybase.com/whiskies/whisky/2745/brora-1981-dt),
+  [1423](https://www.whiskybase.com/whiskies/whisky/1099/brora-1981-dt),
+  [1424](https://www.whiskybase.com/whiskies/whisky/2746/brora-1981-dt),
+  [1427](https://www.whiskybase.com/whiskies/whisky/5611/brora-1981-dt),
+  and
+  [291](https://www.whiskybase.com/whiskies/whisky/10374/brora-1981-dt).
+  Their ages, strengths, bottling months and years, cask numbers, and outturns
+  are stored on production Bottles B55691 through B55696, using Duncan Taylor
+  as Brand and bottler, Brora as distiller, and the existing Duncan Taylor Rare
+  Auld Series S0475. Oak-cask maturation is stated only for casks 1426 and 1423. For cask 1426, photographed auction bottles numbered 114 and 115 of 251
+  and an exact
+  [auction record](https://www.whiskyshop.com/auctions/a125624-brora-1981-22-year-old-single-cask-1426-duncan-taylor-rare-auld)
+  support an outturn of 251 over one conflicting secondary index's 261. The
+  separate 50 ml entry was excluded as a miniature format rather than a new
+  liquid identity; the separate 750 ml cask 1424 entry was likewise excluded
+  as a packaging variant of the same cask release.
+- Ian Macleod's
+  [bottler inventory](https://www.whiskybase.com/whiskies/bottler/77364/whiskies)
+  establishes 16 full-size Brora releases under two producer-owned Brands.
+  Dun Bheagan covers the 1980 cask
+  [824](https://www.whiskybase.com/whiskies/whisky/20147/brora-1980-im)
+  and 1981 casks
+  [1513](https://www.whiskybase.com/whiskies/whisky/6137/brora-1981-im),
+  [1512](https://www.whiskybase.com/whiskies/whisky/2917/brora-1981-im),
+  [1524](https://www.whiskybase.com/whiskies/whisky/2729/brora-1981-im),
+  and
+  [1526](https://www.whiskybase.com/whiskies/whisky/5306/brora-1981-im).
+  Chieftain's Choice covers 1981 casks
+  [1511](https://www.whiskybase.com/whiskies/whisky/10361/brora-1981-im),
+  [1510](https://www.whiskybase.com/whiskies/whisky/6139/brora-1981-im),
+  [1514](https://www.whiskybase.com/whiskies/whisky/2387/brora-1981-im),
+  [1522](https://www.whiskybase.com/whiskies/whisky/2682/brora-1981-im),
+  [1521](https://www.whiskybase.com/whiskies/whisky/5980/brora-1981-im),
+  [1523](https://www.whiskybase.com/whiskies/whisky/32730/brora-1981-im),
+  and
+  [1525](https://www.whiskybase.com/whiskies/whisky/32371/brora-1981-im),
+  plus the 1982 releases from casks
+  [1189 and 1192](https://www.whiskybase.com/whiskies/whisky/6140/brora-1982-im),
+  [1197](https://www.whiskybase.com/whiskies/whisky/14351/brora-1982-im),
+  [1191](https://www.whiskybase.com/whiskies/whisky/31665/brora-1982-im),
+  and
+  [1195](https://www.whiskybase.com/whiskies/whisky/10373/brora-1982-im).
+  Production now has Dun Bheagan Bottles B55705 through B55711 and Chieftain's
+  Choice Bottles B55712 through B55728, with concurrent ID gaps. Both existing
+  Brands are owned by Ian Macleod Distillers, which is stored as bottler, while
+  Brora is stored as distiller. Exact ages, strengths, vintages, bottling years,
+  maturation types, cask numbers, outturns, natural color, and lack of chill
+  filtration were retained. The 1982 release from casks 1189 and 1192 is
+  correctly not marked single-cask; all other releases use one cask. Only exact
+  records that state cask strength carry that claim.
+- Lombard's
+  [bottler inventory](https://www.whiskybase.com/whiskies/bottler/77374/whiskies)
+  establishes six full-size Brora releases. The existing 1982/22-year/2004
+  Jewels of Scotland Bottle B17700 was preserved after its earlier repair.
+  Production now also has the 1981/1999
+  [Jewels of the Highlands](https://www.whiskybase.com/whiskies/whisky/9724/brora-1981-lb)
+  as B55736, the 1982/1997
+  [Jewels of the Highlands](https://www.whiskybase.com/whiskies/whisky/126080/brora-1982-lb)
+  as B55737, the 1982/2002
+  [Jewels of Scotland](https://www.whiskybase.com/whiskies/whisky/8049/brora-1982-lb)
+  as B55738, the 1982/21-year/2003
+  [Jewels of the Highlands](https://www.whiskybase.com/whiskies/whisky/8048/brora-1982-lb)
+  as B55739, and the 1982/32-year/2014 single cask
+  [Jewels of Scotland](https://www.whiskybase.com/whiskies/whisky/81210/brora-1982-lb)
+  as B55740. All use Lombard as Brand and bottler and Brora as distiller. The
+  earlier range is now represented by the new Lombard-owned Jewels of the
+  Highlands Series S0800; later releases reuse Jewels of Scotland S0781. Exact
+  label records support natural color and no chill filtration except for the
+  1997 Bottle, where those claims remain unknown. Cask 876 is stored at cask
+  strength with its 69-bottle outturn and oak-cask maturation. The other
+  releases retain unknown cask details where the sources do not supply them.
+- The [Brora distillery inventory](https://www.whiskybase.com/whiskies/distillery/106/whiskies),
+  its [1981 vintage table](https://www.whiskybase.com/whiskies/vintage?direction=asc&page=10&sort=whisky.name&vintage_year%5B0%5D=1981),
+  and exact records for the two 1982 casks
+  [273](https://www.whiskybase.com/whiskies/whisky/10368/brora-1982-sv)
+  and [416](https://www.whiskybase.com/whiskies/whisky/10367/brora-1982-sv)
+  and the three 1983 casks
+  [495](https://www.whiskybase.com/whiskies/whisky/160414/brora-1983-sv),
+  [40](https://www.whiskybase.com/whiskies/whisky/6189/brora-1983-sv),
+  and [39](https://www.whiskybase.com/whiskies/whisky/10371/brora-1983-sv)
+  establish 38 full-size Signatory-associated Brora releases: 33 distilled in
+  1981, two in 1982, and three in 1983. Production now has 37 under Signatory
+  Vintage as Brand and bottler, B55753 and B55759 through B55789 plus B55791
+  through B55795. The Prestonfield release from cask 1083 is B55790, with
+  Prestonfield as Brand and Signatory Vintage as bottler. All 38 use Brora as
+  distiller. The operation created the Signatory Vintage-owned Vintage
+  Collection S0801, Millennium Edition S0802, Straight From The Cask S0803,
+  Unfiltered Hand Bottled S0804, and Single Cask Selection S0805 Series. The
+  producer's dumpy-bottle wording was treated as packaging within Vintage
+  Collection, and the merchant named on one Straight From The Cask release did
+  not become a separate Bottle identity. Exact ages, strengths, vintages,
+  bottling years, cask numbers, outturns, maturation descriptions, and stated
+  production claims were retained. Casks 573 and 574 are one vatting rather
+  than a single-cask release. Unsupported bottling dates, color, filtration,
+  and cask-strength claims remain unknown. A duplicate 50 ml cask 1081 listing
+  was excluded as a packaging variant, and useful images did not state reusable
+  rights, so no Bottle images were copied.
+- Gordon & MacPhail's rows in the same
+  [Brora distillery inventory](https://www.whiskybase.com/whiskies/distillery/106/whiskies)
+  and exact records establish 18 liquid identities. The 1972 releases are six
+  Connoisseurs Choice bottlings from
+  [1992](https://www.whiskybase.com/whiskies/whisky/10356/brora-1972-gm),
+  [1993](https://www.whiskybase.com/whiskies/whisky/7211/brora-1972-gm),
+  [1994](https://www.whiskybase.com/whiskies/whisky/120990/brora-1972-gm),
+  [1995](https://www.whiskybase.com/whiskies/whisky/8624/brora-1972-gm),
+  [1996](https://www.whiskybase.com/whiskies/whisky/3926/brora-1972-gm),
+  and [1997](https://www.whiskybase.com/whiskies/whisky/10357/brora-1972-gm),
+  plus an undated
+  [Spirit of Scotland](https://www.whiskybase.com/whiskies/whisky/39317/brora-1972-gm)
+  and a 1997
+  [Rare Old](https://www.whiskybase.com/whiskies/whisky/17448/brora-1972-gm).
+  The inventory also contains the 1978
+  [Rare Old cask RO/13/05](https://www.whiskybase.com/whiskies/whisky/54111/brora-1978-gm)
+  and nine 1982 releases: Spirit of Scotland from
+  [1997](https://www.whiskybase.com/whiskies/whisky/1380/brora-1982-gm)
+  and [1999](https://www.whiskybase.com/whiskies/whisky/18824/brora-1982-gm),
+  Connoisseurs Choice from
+  [1997](https://www.whiskybase.com/whiskies/whisky/6305/brora-1982-gm),
+  [2000](https://www.whiskybase.com/whiskies/whisky/18812/brora-1982-gm),
+  [2002](https://www.whiskybase.com/whiskies/whisky/9167/brora-1982-gm),
+  [2006](https://www.whiskybase.com/whiskies/whisky/2217/brora-1982-gm),
+  and [2008](https://www.whiskybase.com/whiskies/whisky/9259/brora-1982-gm),
+  the 2002 [Reserve cask 43](https://www.whiskybase.com/whiskies/whisky/1379/brora-1982-gm),
+  and the 2015
+  [Rare Old cask RO/15/01](https://www.whiskybase.com/whiskies/whisky/70325/brora-1982-gm).
+  The 2000 Connoisseurs Choice B52288 was repaired with its stated coloring and
+  chill-filtration facts. Production now also has B55805, B55809, B55810,
+  B55812, B55813, and B55814, all with Gordon & MacPhail as Brand and bottler
+  and Brora as distiller. Rare Old S0807 and Reserve S0808 were created; the
+  existing Connoisseurs Choice S0097 and Spirit of Scotland S0299 were reused.
+  The 2006 Connoisseurs Choice is a distinct liquid release even though the
+  main inventory hides it as a version. A
+  [50 ml compilation](https://www.whiskybase.com/whiskies/whisky/158447/brora-1972-gm),
+  the merchant-labelled 1972 records from
+  [1993](https://www.whiskybase.com/whiskies/whisky/192094/brora-1972-gm)
+  and [1995](https://www.whiskybase.com/whiskies/whisky/192093/brora-1972-gm),
+  and the [750 ml version](https://www.whiskybase.com/whiskies/whisky/125947/brora-1978-gm)
+  of the same RO/13/05 cask were excluded because package size or market label
+  alone does not establish a different liquid. Eleven of the 18 supported
+  identities remain unwritten: five 1972 Connoisseurs Choice bottling years,
+  the 1972 Spirit of Scotland and Rare Old releases, both 1982 Spirit of
+  Scotland years, and the 1997 and 2002 1982 Connoisseurs Choice releases. The
+  deployed production duplicate guard at the time of the audit omitted Bottle
+  Series and bottling year from its comparison, so those correct identities
+  returned conflicts. The local guard now compares bottling year; Series still
+  needs separate handling, and production behavior will not change until the
+  guard is deployed. No invented edition or release date was used to bypass
+  that limit. A second
+  exact-label audit checked auction records and the
+  [Brora bottling index](https://www.whiskyfun.com/Brora-Index.html). It found
+  no stated cask numbers or release dates for the eleven blocked identities.
+  Codes such as `IG/ABC`, `JJ/BFI`, `II/BJF`, and `JF/CD` are bottle or label
+  codes, not cask numbers, so they were not repurposed as identity fields.
+  Distillation and bottling months on later labels likewise do not establish a
+  marketed release date. Calculated ages were not stored as stated ages,
+  unsupported claims remain unknown, and source images did not state reusable
+  rights.
+- Douglas McGibbon's
+  [bottler inventory](https://www.whiskybase.com/whiskies/bottler/77445/whiskies)
+  and exact records establish three full-size McGibbon's Provenance releases:
+  the 25-year-old [1974](https://www.whiskybase.com/whiskies/whisky/20783/brora-1974-mcg)
+  bottled in 2002 with a sherry-wood finish, the 25-year-old
+  [1975](https://www.whiskybase.com/whiskies/whisky/3334/brora-1975-mcg)
+  bottled in 2001, and the 26-year-old
+  [1976 cask DMG 742](https://www.whiskybase.com/whiskies/whisky/4716/brora-1976-mcg)
+  bottled in 2002. Production now has them as B55818, B55819, and B55820. All
+  three use Douglas Laing as Brand, its existing Provenance Series S0101,
+  Douglas McGibbon as the historical bottler, and Brora as distiller. This
+  follows the stored owner relationship without creating a duplicate Series
+  under the subsidiary. The exact records support their ages, strengths,
+  vintages, bottling years, natural color, and no chill filtration; only cask
+  DMG 742 is stated to be a single cask. Seasonal vintage and bottling wording
+  was not converted to unsupported months, and unknown cask-strength claims
+  remain unknown. Source images did not state reusable rights.
+- Douglas Laing's rows in the
+  [Brora distillery inventory](https://www.whiskybase.com/whiskies/distillery/106/whiskies)
+  establish 44 full-size release identities: 12 Old & Rare Platinum Selection,
+  30 The Old Malt Cask, one Selected by The Whisky Shop, and one Premier Barrel
+  Selection. Production now has all 12 Old & Rare releases as B55828 through
+  B55839, using the existing Old & Rare Brand E366645 and Platinum Selection
+  S0488 with Douglas Laing as historical bottler. It has 26 representable Old
+  Malt Cask releases as B55844 through B55858, B55861 through B55865, B55867,
+  and B55868 through B55872, using The Old Malt Cask Brand E366649 and Douglas
+  Laing as bottler. The existing Douglas Laing-owned Old Malt Cask Series S0357
+  was not used because the stored Brand already represents that product line.
+  Brorageddon is the edition on B55849, and the two Final Vintage releases are
+  editions B55869 and B55870. The one-off 1972 Selected by The Whisky Shop is
+  B55873, and the yearless 23-year-old Premier Barrel is B55874 under S0105.
+  Exact pages for the [1970/32-year](https://www.whiskybase.com/whiskies/whisky/4233/brora-1970-dl),
+  [1971/29-year sherry cask](https://www.whiskybase.com/whiskies/whisky/3925/brora-1971-dl),
+  [Brorageddon](https://www.whiskybase.com/whiskies/whisky/5622/brora-1972-dl-brorageddon),
+  [cask DL 387](https://www.whiskybase.com/whiskies/whisky/10366/brora-1982-dl),
+  [cask DL 1186](https://www.whiskybase.com/whiskies/whisky/2390/brora-1982-dl),
+  [cask DL 313](https://www.whiskybase.com/whiskies/whisky/6118/brora-1982-dl),
+  [cask DL 2294](https://www.whiskybase.com/whiskies/whisky/2920/brora-1982-dl),
+  [cask DL 435](https://www.whiskybase.com/whiskies/whisky/121876/brora-1982-dl),
+  [Final Vintage at 50%](https://www.whiskybase.com/whiskies/whisky/778/brora-1983-dl),
+  [Final Vintage at 52.7%](https://www.whiskybase.com/whiskies/whisky/11291/brora-1983-dl),
+  and [Premier Barrel](https://www.whiskybase.com/whiskies/whisky/29032/brora-23-year-old-dl)
+  supplied exact cask, outturn, maturation, and production claims where stated.
+  Three 200 ml advance samples and one 50 ml miniature were excluded. Four
+  supported full-size Old Malt Cask identities remain unwritten because the
+  deployed production duplicate guard at the time of the audit ignored
+  bottling year and outturn. The local guard now compares bottling year, but
+  production behavior will not change until the guard is deployed, and outturn
+  remains outside exact identity comparison. The blocked releases are the
+  [1971/29-year/285-bottle release](https://www.whiskybase.com/whiskies/whisky/207823/brora-1971-dl),
+  the [1981/18-year/732-bottle release](https://www.thewhiskyexchange.com/p/1284/brora-1981-18-year-old-sherry-cask-old-malt-cask),
+  the [1981/18-year/291-bottle release](https://www.whiskybase.com/whiskies/whisky/46227/brora-1981-dl),
+  and the [1982/19-year/732-bottle release](https://www.whiskybase.com/whiskies/whisky/13710/brora-1982-dl).
+  A second audit of exact auction and retailer records confirmed bottling
+  months for these releases—March 2000 for the 1971 release, July 2000 and July
+  1999 for the two 1981 releases, and April 2001 for the 1982 release—but found
+  no genuine cask number or marketed release date that distinguishes them
+  under the current identity comparison. Distillation/bottling codes such as
+  `D11/'82 B11/'01` describe dates, not casks. No false edition, release date,
+  or cask number was added to bypass the conflicts. Useful source images did
+  not state reusable rights, so none were copied.
+- Silver Seal's three rows in the
+  [Brora distillery inventory](https://www.whiskybase.com/whiskies/distillery/106/whiskies)
+  and exact records establish three full-size releases: the 1982 19-year-old
+  [First Bottling](https://www.whiskybase.com/whiskies/whisky/11308/brora-1982-ss),
+  the distinct 1982 19-year-old
+  [Single Barrel](https://www.whiskybase.com/whiskies/whisky/9258/brora-1982-ss),
+  and the 1982 24-year-old
+  [2006 decanter](https://www.whiskybase.com/whiskies/whisky/11309/brora-1982-ss).
+  Production now has B55875, B55876, and B55877 with Silver Seal as Brand and
+  bottler and Brora as distiller. The two 2001 liquids use their exact marketed
+  labels as editions because they otherwise share vintage, age, strength, and
+  bottling year. The decanter wording describes packaging, so it was not stored
+  as an edition. Only source-confirmed maturation, outturn, natural-color, and
+  single-cask facts were written; unsupported filtration and cask-strength
+  claims remain unknown. Source images did not state reusable rights.
+- The Scotch Malt Whisky Society's 23 rows in the
+  [Brora distillery inventory](https://www.whiskybase.com/whiskies/distillery/106/whiskies)
+  establish the complete historical Society set: numbered casks 61.1 through
+  61.22 plus the separate 1977 Whisky Magazine Editors' Choice cask 529. Exact
+  records for [61.1](https://www.whiskybase.com/whiskies/whisky/24055/brora-1976-smws-611),
+  [61.12](https://www.whiskybase.com/whiskies/whisky/24252/brora-1977-smws-6112),
+  [61.13](https://www.whiskybase.com/whiskies/whisky/24251/brora-1978-smws-6113),
+  [61.20](https://www.whiskybase.com/whiskies/whisky/178106/brora-1978-smws-6120),
+  [61.8](https://www.whiskybase.com/whiskies/whisky/23165/brora-1981-smws-618),
+  and [61.19](https://www.whiskybase.com/whiskies/whisky/24248/brora-1982-smws-6119)
+  supply precise dates, titles, cask numbers, strengths, maturation, and
+  outturns where stated. The Society's
+  [range guide](https://unfiltered.smws.com/uk/welcome-magazine/the-smws-range.html)
+  confirms that its signature numbered releases are single-cask, natural-color,
+  non-chill-filtered, and cask-strength whiskies. Production now has B55884
+  through B55906 with The Scotch Malt Whisky Society as Brand and bottler and
+  Brora as distiller. Names follow the existing catalog convention of Society
+  code plus tasting-panel title, and the same codes are stored as cask numbers.
+  The Editors' Choice Bottle B55885 stores only the separately supported
+  single-cask claim, hogshead maturation, and 187-bottle outturn; the numbered
+  range rules were not assumed for that special label. Calculated ages on 61.1
+  and 61.2 were not stored as stated ages. Conflicting 61.12 outturn reports and
+  package-specific 61.14 and 61.16 counts remain unknown. Source images did not
+  state reusable rights.
+- The official [Distillers One of One catalogue](https://www.distillersoneofone.com/assets/2023-catalogue.pdf)
+  and [producer page](https://www.diageorareandexceptional.com/us/brora-iris)
+  establish Brora Iris as one 1.5-litre 1972/50-year decanter at 42% ABV. The
+  official strength was retained over conflicting secondary records.
+- Exact review URLs preserved by Peated helped resolve generic legacy imports:
+  their age, release wording, and URL strength match the 2008, 2009, 2010,
+  2012, 2013, and 2016 annual releases. Exact 2009 and 2012 references and
+  their consumers were reassigned to the canonical annual Bottles. The
+  remaining generic 30-year/55.7% review could describe the 2003, 2006, or
+  2007 release and remains on an unresolved yearless record. The 2015 annual
+  release is a multi-vintage
+  vatting; the exact [WhiskyNotes account](https://www.whiskynotes.be/2016/brora/brora-37-years-2015/)
+  records confirmation from Diageo archivist Nick Morgan, so a secondary claim
+  that the complete Bottle was distilled in 1977 was not stored. Sources also
+  conflict on a single vintage for the 2008 release, so that vintage remains
+  unknown.
+- Approved duplicate cleanup merged B4581 into B49847 (2011), B4426 into B49848
+  (2012), B3701 into B16115 (2015), B3426 and B15905 into B49856 (2016), B4978
+  and B17723 into B49839 (2008), and B17410 into B4749 (2010). Each retired ID
+  resolves to its chosen survivor; exact Bottle facts stayed intact, and saved
+  reviews and import references moved to that survivor. Fresh checks also
+  confirmed that B16753, B49738, B49740, and B1229 had no tastings, reviews,
+  scores, images, or public aliases. They were deleted, and their import text
+  remains unassigned rather than lost or attached to a guess. B49738 combined
+  the 1972/22-year identity with the 54.9% strength of the evidenced 1975/20-year
+  release; B49740's 1974/20-year/57.5% combination likewise has no exact Brora
+  release evidence. B17620 has a generic 30-year review that could belong to
+  the 2003, 2006, or 2007 55.7% annual release and remains unresolved.
+- The final production inventory query returns 225 Bottles linked to Brora as
+  distiller across 33 Brands. A three-page verification found 225 unique Bottle
+  IDs: every result is a single malt, has a Brand, retains Brora as distiller,
+  and has no repeated identity across the exact fields compared by the
+  production duplicate guard. Every null bottler belongs to a Diageo-owned
+  official Brand, so no independent release is missing its historical bottler
+  relationship. A separate Brora Brand query returns ten records: nine are
+  correctly linked official releases, and B17620 is the one unresolved legacy
+  record retained because its activity cannot safely identify an annual
+  release.
+- The research inventory contains 47 supported official release identities
+  before any approved duplicate cleanup. Sixteen new Bottles, two Bottle
+  Series, and the Casks of Distinction Brand were created; 22 existing Bottles
+  were repaired in the official set, and one ambiguous legacy record had its
+  unsupported year cleared. One independently bottled Lombard release was
+  repaired and its Bottle Series was created separately during the broader
+  scope check. Two independently bottled The Bottlers releases, five William
+  Cadenhead's releases, one Blackadder release, one Acredyke Whisky Ltd.
+  release, one Daily Dram release, both That Boutique-y Whisky Company batches,
+  one The Dalriada Whisky Company release, the Whisky Show 2011 release, and one
+  Single Malts Direct release were also created. Two The Whisky Agency releases
+  and its Private Stock Series and one Wilson & Morgan release were created
+  separately. One The Scottish Independent Distillers Co. Ltd. release and its
+  Original-Label Selection Series, one Edition Spirits release, and one Hunter
+  Laing release with its Old & Rare Series were also created. Eleven First Cask
+  releases and one Dun Eideann release were created separately; The Bottlers'
+  unsupported ambiguous legacy record was deleted. Three Scotch Malt Sales releases
+  and their two Series were created separately. Six Duncan Taylor Rare Auld
+  releases were created separately using its existing Series. Sixteen Ian
+  Macleod releases were created separately under the existing Dun Bheagan and
+  Chieftain's Choice Brands. Five additional Lombard releases and the Jewels of
+  the Highlands Series were created, completing its six-release Brora family.
+  Thirty-eight Signatory-associated releases and five Signatory Vintage Series
+  were created separately, including one Prestonfield-branded release. One
+  existing Gordon & MacPhail release was repaired, six were created with two
+  new Series, and eleven more researched identities remain blocked by the
+  production duplicate guard. Three McGibbon's Provenance releases were
+  created using the existing Douglas Laing-owned Series and the historical
+  Douglas McGibbon bottler relationship. Forty additional Douglas
+  Laing-associated releases were created across Old & Rare, The Old Malt Cask,
+  Selected by The Whisky Shop, and Premier Barrel; four more remain blocked by
+  the same duplicate-guard limitation. Three Silver Seal releases and all 23
+  historical Scotch Malt Whisky Society releases were created. The Whisky
+  Exchange Fine Old Rare name was added as an alias to the existing Whisky Show
+  2011 Bottle instead of creating a duplicate.
+  The Brora Entity already had a licensed Wikimedia Commons image and complete
+  ownership, location, and history fields. Existing Bottle images have no
+  stored source or license, and useful producer, retailer, review, and auction
+  images did not state reusable rights, so no Bottle images were copied.


### PR DESCRIPTION
Bottle creation now treats `bottlingYear` as part of exact Bottle identity. Releases with the same marketed title and vintage but different bottling years can coexist instead of producing a false duplicate conflict; the focused regression keeps every other compared field unchanged.

The identity guide clarifies that these releases remain separate Bottles and may belong to one BottleGroup because additional time in cask can change the whisky. Creation still starts with singleton groups until Peated has a reviewed, evidence-backed regrouping operation, now recorded as an owned TODO. Series- or outturn-only distinctions remain outside this fix.

The accompanying research record captures the verified Brora catalog inventory, evidence, production repairs, duplicate cleanup, unresolved records, and the releases that remain blocked until this guard is deployed or their remaining identity rules are addressed.
