### PR TITLE
fix(scraper): enforce robots rules on redirects

### DIFF
--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -263,6 +263,7 @@ test("follows declared redirects and rejects an undeclared redirect before conta
       }),
     )
     .mockResolvedValueOnce(new Response("ok"));
+  const checkRedirect = vi.fn<(url: URL) => Promise<void>>(async () => {});
 
   const response = await requestScraperUrl({
     runId: run.id,
@@ -272,11 +273,15 @@ test("follows declared redirects and rejects an undeclared redirect before conta
       url: new URL("https://example.com/start"),
     },
     registry,
+    checkRedirect,
     fetchImpl,
     clock: clockAt(),
   });
   expect(response.url.origin).toBe("https://static.example.com");
   expect(fetchImpl).toHaveBeenCalledTimes(2);
+  expect(checkRedirect).toHaveBeenCalledExactlyOnceWith(
+    new URL("https://static.example.com/catalog"),
+  );
 
   const [secondRun] = await db
     .update(externalSiteRuns)

--- a/apps/server/src/scraper/http.ts
+++ b/apps/server/src/scraper/http.ts
@@ -256,6 +256,7 @@ export async function requestScraperUrl({
   sourceKey,
   request,
   registry,
+  checkRedirect,
   fetchImpl = fetch,
   clock = scraperSystemClock,
 }: {
@@ -264,6 +265,7 @@ export async function requestScraperUrl({
   sourceKey: string;
   request: ScraperRequest;
   registry: ScraperRegistry;
+  checkRedirect?: (url: URL) => Promise<void>;
   fetchImpl?: typeof fetch;
   clock?: ScraperHttpClock;
 }): Promise<ScraperResponse> {
@@ -303,6 +305,7 @@ export async function requestScraperUrl({
     ) {
       throw new ScraperRequestError("invalid_request");
     }
+    if (redirect > 0) await checkRedirect?.(currentUrl);
     let retry = 0;
 
     while (true) {

--- a/apps/server/src/scraper/robots.test.ts
+++ b/apps/server/src/scraper/robots.test.ts
@@ -19,6 +19,7 @@ import {
   robotsAllowsUrl,
   ScraperRobotsDeniedError,
 } from "./robots";
+import { createScraperSession } from "./session";
 import { syncScraperDefinitions } from "./syncDefinitions";
 
 const adapter = async () => {};
@@ -150,6 +151,43 @@ test("uses a fresh SQL cache and refuses a disallowed path without contact", asy
     }),
   ).rejects.toBeInstanceOf(ScraperRobotsDeniedError);
   expect(fetchImpl).not.toHaveBeenCalled();
+});
+
+test("checks cached robots rules before following a redirect", async () => {
+  const { registry, run } = await setupRobotsRuntime();
+  const now = new Date("2026-08-18T12:00:00Z");
+  await db
+    .update(scrapeOrigins)
+    .set({
+      robotsState: parseRobotsRules("User-agent: *\nDisallow: /private"),
+      robotsFetchedAt: now,
+      robotsExpiresAt: new Date("2026-08-19T12:00:00Z"),
+    })
+    .where(eq(scrapeOrigins.origin, "https://example.com"));
+  const source = registry.sources.get("finedrams");
+  if (!source) throw new Error("Expected source.");
+  const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
+    new Response(null, {
+      status: 302,
+      headers: { location: "/private/article" },
+    }),
+  );
+  const session = createScraperSession({
+    run,
+    source,
+    registry,
+    executionToken: EXECUTION_TOKEN,
+    fetchImpl,
+    clock: fixedClock(),
+  });
+
+  await expect(
+    session.request({
+      target: "operator",
+      url: new URL("https://example.com/public/article"),
+    }),
+  ).rejects.toBeInstanceOf(ScraperRobotsDeniedError);
+  expect(fetchImpl).toHaveBeenCalledOnce();
 });
 
 test("caches a missing robots document as allowed for the bounded period", async () => {

--- a/apps/server/src/scraper/session.ts
+++ b/apps/server/src/scraper/session.ts
@@ -82,23 +82,27 @@ export function createScraperSession<TCursor, TObservation>({
   return {
     async request(request: ScraperRequest) {
       try {
-        await ensureRobotsAllowed({
-          runId: run.id,
-          executionToken,
-          sourceKey: source.key,
-          targetKey: request.target,
-          url: request.url,
-          canResumeLater: request.canResumeLater,
-          registry,
-          fetchImpl,
-          clock,
-        });
+        const checkRobots = async (url: URL) => {
+          await ensureRobotsAllowed({
+            runId: run.id,
+            executionToken,
+            sourceKey: source.key,
+            targetKey: request.target,
+            url,
+            canResumeLater: request.canResumeLater,
+            registry,
+            fetchImpl,
+            clock,
+          });
+        };
+        await checkRobots(request.url);
         return await requestScraperUrl({
           runId: run.id,
           executionToken,
           sourceKey: source.key,
           request,
           registry,
+          checkRedirect: checkRobots,
           fetchImpl,
           clock,
         });


### PR DESCRIPTION
Crawler redirects now run the destination URL through the session's robots check before the next request is sent. Existing origin, header, request-budget, and redirect limits remain unchanged, and the integration test proves a redirect to a disallowed path is stopped before contact.

Fixes #1193.
