### PR TITLE
fix(web): keep PeatedBot directory signatures fresh

### DIFF
--- a/apps/web/src/app/.well-known/http-message-signatures-directory/route.test.ts
+++ b/apps/web/src/app/.well-known/http-message-signatures-directory/route.test.ts
@@ -52,6 +52,7 @@ describe("HTTP message signature directory", () => {
     expect(response.headers.get("content-type")).toBe(
       "application/http-message-signatures-directory+json",
     );
+    expect(response.headers.get("cache-control")).toBe("no-store");
     const publishedKey = directory.keys[0];
     expect(publishedKey.kty).toBe("OKP");
     expect(publishedKey.crv).toBe("Ed25519");

--- a/apps/web/src/app/.well-known/http-message-signatures-directory/route.ts
+++ b/apps/web/src/app/.well-known/http-message-signatures-directory/route.ts
@@ -8,7 +8,7 @@ import { generateNonce } from "web-bot-auth";
 import { signerFromJWK } from "web-bot-auth/crypto";
 import { z } from "zod";
 
-const CACHE_CONTROL = "public, max-age=86400";
+const CACHE_CONTROL = "no-store";
 const CONTENT_TYPE = "application/http-message-signatures-directory+json";
 const DIRECTORY_SIGNATURE_TAG = "http-message-signatures-directory";
 const SIGNATURE_LIFETIME_SECONDS = 60;

--- a/docs/operations/peated-bot.md
+++ b/docs/operations/peated-bot.md
@@ -60,7 +60,8 @@ Deploy the web and scraper services before registration.
 
 1. Request the public directory and confirm it returns HTTP 200,
    `Content-Type: application/http-message-signatures-directory+json`,
-   `Signature-Input`, and `Signature`.
+   `Cache-Control: no-store`, `Signature-Input`, and `Signature`. The response
+   must not be cached because its signature expires after 60 seconds.
 2. Confirm every published key contains only `kty`, `crv`, and `x`. The `d`
    field contains the private key. Remove the secret and deployment immediately
    if it appears in the response.


### PR DESCRIPTION
The PeatedBot public-key directory now sends `Cache-Control: no-store`, preventing Vercel from serving a response after its 60-second ownership signature has expired. Production verification found that the previous 24-hour cache lifetime could return an already-expired signature to Cloudflare.

This keeps the short signature lifetime while ensuring every directory check receives a fresh signed response. The route test and operations check now enforce the no-store boundary.

Refs #1184
