### PR TITLE
feat(distilleries): add series and recent activity

### DIFF
--- a/apps/server/src/orpc/routes/bottleSeries/list.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/list.test.ts
@@ -1,8 +1,11 @@
+import { db } from "@peated/server/db";
+import { bottleTombstones } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { describe, expect, it } from "vitest";
 
 describe("GET /bottle-series", () => {
-  it("lists series for a brand", async function ({ fixtures, defaults }) {
+  it("lists series for a brand", async function ({ fixtures }) {
     const brand = await fixtures.Entity({ name: "Ardbeg" });
 
     const series1 = await fixtures.BottleSeries({
@@ -17,7 +20,6 @@ describe("GET /bottle-series", () => {
       brandId: brand.id,
     });
 
-    // Create a series for another brand to ensure filtering works
     const otherBrand = await fixtures.Entity({ name: "Macallan" });
     await fixtures.BottleSeries({
       name: "Edition No.",
@@ -36,6 +38,7 @@ describe("GET /bottle-series", () => {
           id: series1.id,
           name: series1.name,
           description: series1.description,
+          brand: expect.objectContaining({ id: brand.id, name: brand.name }),
         }),
         expect.objectContaining({
           id: series2.id,
@@ -46,7 +49,100 @@ describe("GET /bottle-series", () => {
     );
   });
 
-  it("filters series by query", async function ({ fixtures, defaults }) {
+  it("lists a distillery's series by matching bottle count", async function ({
+    fixtures,
+  }) {
+    const distillery = await fixtures.Entity({
+      kind: "distillery",
+      name: "Port Ellen",
+    });
+    const otherDistillery = await fixtures.Entity({
+      kind: "distillery",
+      name: "Brora",
+    });
+    const brand = await fixtures.Entity({ kind: "brand", name: "Rare Malts" });
+    const seriesWithTwoBottles = await fixtures.BottleSeries({
+      brandId: brand.id,
+      name: "Rare Series",
+    });
+    const seriesWithOneBottle = await fixtures.BottleSeries({
+      brandId: brand.id,
+      name: "Special Releases",
+    });
+    const unrelatedSeries = await fixtures.BottleSeries({
+      brandId: brand.id,
+      name: "Other Distillery",
+    });
+
+    await fixtures.Bottle({
+      brandId: brand.id,
+      distillerIds: [distillery.id],
+      seriesId: seriesWithTwoBottles.id,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      distillerIds: [distillery.id],
+      seriesId: seriesWithTwoBottles.id,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      distillerIds: [distillery.id],
+      seriesId: seriesWithOneBottle.id,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      distillerIds: [otherDistillery.id],
+      seriesId: unrelatedSeries.id,
+    });
+    await fixtures.LegacyBottle({
+      brandId: brand.id,
+      distillerIds: [distillery.id],
+      seriesId: seriesWithTwoBottles.id,
+    });
+    const retiredBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      distillerIds: [distillery.id],
+      seriesId: seriesWithTwoBottles.id,
+    });
+    const replacementBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      distillerIds: [otherDistillery.id],
+    });
+    await db.insert(bottleTombstones).values({
+      bottleId: retiredBottle.id,
+      newBottleId: replacementBottle.id,
+    });
+
+    const result = await routerClient.bottleSeries.list({
+      distillery: distillery.id,
+      sort: "-bottles",
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.results).toMatchObject([
+      {
+        id: seriesWithTwoBottles.id,
+        brand: { id: brand.id, name: brand.name },
+        numBottles: 2,
+      },
+      {
+        id: seriesWithOneBottle.id,
+        brand: { id: brand.id, name: brand.name },
+        numBottles: 1,
+      },
+    ]);
+  });
+
+  it("rejects an unsupported sort", async function () {
+    // SAFETY: This test sends an unsupported value through the public input boundary.
+    const error = await waitError(() =>
+      routerClient.bottleSeries.list({ sort: "popular" as "name" }),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Input validation failed]`);
+  });
+
+  it("filters series by query", async function ({ fixtures }) {
     const brand = await fixtures.Entity({ name: "Ardbeg" });
 
     const series1 = await fixtures.BottleSeries({
@@ -72,10 +168,7 @@ describe("GET /bottle-series", () => {
     });
   });
 
-  it("returns empty list for non-existent brand", async function ({
-    fixtures,
-    defaults,
-  }) {
+  it("returns empty list for non-existent brand", async function () {
     const { results } = await routerClient.bottleSeries.list({
       brand: 12345,
     });

--- a/apps/server/src/orpc/routes/bottleSeries/list.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/list.ts
@@ -1,12 +1,31 @@
 import { db } from "@peated/server/db";
-import { bottleSeries } from "@peated/server/db/schema";
+import {
+  bottles,
+  bottleSeries,
+  bottlesToDistillers,
+  bottleTombstones,
+  entities,
+} from "@peated/server/db/schema";
+import { formatPeatedId } from "@peated/server/lib/peatedId";
 import { plainTextSearchQuery } from "@peated/server/lib/search";
 import { procedure } from "@peated/server/orpc";
-import { BottleSeriesSchema, CursorSchema } from "@peated/server/schemas";
+import {
+  BottleSeriesListItemSchema,
+  CursorSchema,
+} from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { BottleSeriesSerializer } from "@peated/server/serializers/bottleSeries";
 import type { SQL } from "drizzle-orm";
-import { and, asc, eq, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  getTableColumns,
+  isNotNull,
+  isNull,
+  sql,
+} from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -14,8 +33,7 @@ export default procedure
     method: "GET",
     path: "/bottle-series",
     summary: "List bottle series",
-    description:
-      "List bottle series, with optional brand filtering, search, and pagination.",
+    description: "Find bottle series by name, brand, or distillery.",
     spec: (spec) => ({ ...spec, operationId: "listBottleSeries" }),
   })
   .input(
@@ -24,20 +42,39 @@ export default procedure
         .string()
         .default("")
         .describe("Search text only. Search operators are not supported."),
-      brand: z.coerce.number().optional().describe("Filter by brand ID."),
+      brand: z.coerce
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Filter by brand ID."),
+      distillery: z.coerce
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "Filter to bottle series with active bottles from this distillery ID.",
+        ),
       cursor: z.coerce.number().gte(1).default(1),
       limit: z.coerce.number().gte(1).lte(100).default(25),
+      sort: z
+        .enum(["name", "-bottles"])
+        .default("name")
+        .describe(
+          "Use `name` for A–Z or `-bottles` for the most matching bottles first.",
+        ),
     }),
   )
   .output(
     z.object({
-      results: z.array(BottleSeriesSchema),
+      results: z.array(BottleSeriesListItemSchema),
       total: z.number(),
       rel: CursorSchema,
     }),
   )
-  .handler(async function ({ input, context, errors }) {
-    const { query, brand, cursor, limit } = input;
+  .handler(async function ({ input, context }) {
+    const { query, brand, distillery, cursor, limit, sort } = input;
     const offset = (cursor - 1) * limit;
 
     const where: (SQL<unknown> | undefined)[] = [];
@@ -50,12 +87,50 @@ export default procedure
       );
     }
 
+    const matchingBottleCount = distillery
+      ? sql<number>`(
+          SELECT COUNT(DISTINCT ${bottles.id})::int
+          FROM ${bottles}
+          INNER JOIN ${bottlesToDistillers}
+            ON ${bottlesToDistillers.bottleId} = ${bottles.id}
+          LEFT JOIN ${bottleTombstones}
+            ON ${bottleTombstones.bottleId} = ${bottles.id}
+          WHERE ${bottles.seriesId} = ${bottleSeries.id}
+            AND ${bottlesToDistillers.distillerId} = ${distillery}
+            AND ${isNotNull(bottles.groupId)}
+            AND ${isNull(bottleTombstones.bottleId)}
+        )`
+      : bottleSeries.numReleases;
+
+    if (distillery) {
+      where.push(sql`${matchingBottleCount} > 0`);
+    }
+
+    const orderBy =
+      sort === "-bottles"
+        ? [
+            desc(matchingBottleCount),
+            asc(bottleSeries.name),
+            asc(bottleSeries.id),
+          ]
+        : [asc(bottleSeries.name), asc(bottleSeries.id)];
+
     const [results, total] = await Promise.all([
       db
-        .select()
+        .select({
+          series: getTableColumns(bottleSeries),
+          brand: {
+            id: entities.id,
+            name: entities.name,
+            shortName: entities.shortName,
+            kind: entities.kind,
+          },
+          numBottles: matchingBottleCount,
+        })
         .from(bottleSeries)
+        .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
         .where(where ? and(...where) : undefined)
-        .orderBy(asc(bottleSeries.name))
+        .orderBy(...orderBy)
         .limit(limit + 1)
         .offset(offset),
       db
@@ -64,12 +139,22 @@ export default procedure
         .where(where ? and(...where) : undefined),
     ]);
 
+    const page = results.slice(0, limit);
+    const serializedSeries = await serialize(
+      BottleSeriesSerializer,
+      page.map(({ series }) => series),
+      context.user,
+    );
+
     return {
-      results: await serialize(
-        BottleSeriesSerializer,
-        results.slice(0, limit),
-        context.user,
-      ),
+      results: serializedSeries.map((series, index) => ({
+        ...series,
+        brand: {
+          ...page[index].brand,
+          peatedId: formatPeatedId("entity", page[index].brand.id),
+        },
+        numBottles: Number(page[index].numBottles),
+      })),
       total: Number(total[0].count),
       rel: {
         nextCursor: results.length > limit ? cursor + 1 : null,

--- a/apps/server/src/schemas/bottleSeries.ts
+++ b/apps/server/src/schemas/bottleSeries.ts
@@ -43,14 +43,26 @@ export const BottleSeriesSchema = z.object({
     .describe("Timestamp when the series was last updated"),
 });
 
+const BottleSeriesBrandSchema = EntitySchema.pick({
+  id: true,
+  peatedId: true,
+  name: true,
+  shortName: true,
+  kind: true,
+});
+
+export const BottleSeriesListItemSchema = BottleSeriesSchema.extend({
+  brand: BottleSeriesBrandSchema.describe("Brand that owns this bottle series"),
+  numBottles: z
+    .number()
+    .int()
+    .nonnegative()
+    .readonly()
+    .describe("Number of active bottles matching the list filters"),
+});
+
 export const BottleSeriesDetailsSchema = BottleSeriesSchema.extend({
-  brand: EntitySchema.pick({
-    id: true,
-    peatedId: true,
-    name: true,
-    shortName: true,
-    kind: true,
-  }).describe("Brand that owns this bottle series"),
+  brand: BottleSeriesBrandSchema.describe("Brand that owns this bottle series"),
   distillers: z
     .array(
       EntitySchema.pick({

--- a/apps/web/src/app/(app)/entities/[entityId]/(overview)/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/(overview)/page.tsx
@@ -54,6 +54,17 @@ export default async function EntityPage(props: {
     );
   }
 
+  if (entity.kind === "distillery") {
+    prefetches.push(
+      queryClient.prefetchQuery(
+        entityOverviewQueries.seriesByBottleCount(orpc, entity),
+      ),
+      queryClient.prefetchQuery(
+        entityOverviewQueries.recentReviewsAndTastings(orpc, entity),
+      ),
+    );
+  }
+
   if (entity.kind === "company") {
     prefetches.push(
       queryClient.prefetchQuery(

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -22,6 +22,8 @@ import { EntityOverviewLayout } from "./entityOverviewLayout.stylex";
 import { entityOverviewQueries } from "./entityOverviewQueries";
 import { useEntityPage } from "./entityPageFrameClient.stylex";
 import { EntityReleaseOverview } from "./entityReleaseOverview";
+import { EntityReviewsAndTastingsOverview } from "./entityReviewsAndTastingsOverview";
+import { EntitySeriesOverview } from "./entitySeriesOverview";
 import { EntitySiblingOverview } from "./entitySiblingOverview";
 
 export function EntityOverviewClient() {
@@ -33,6 +35,12 @@ export function EntityOverviewClient() {
   const eventListQuery = useQuery(entityOverviewQueries.events(orpc, entity));
   const bottleListQuery = useQuery(
     entityOverviewQueries.popularBottles(orpc, entity),
+  );
+  const seriesListQuery = useQuery(
+    entityOverviewQueries.seriesByBottleCount(orpc, entity),
+  );
+  const recentReviewsAndTastingsQuery = useQuery(
+    entityOverviewQueries.recentReviewsAndTastings(orpc, entity),
   );
   const releaseListQuery = useQuery(
     entityOverviewQueries.releases(orpc, entity),
@@ -102,6 +110,13 @@ export function EntityOverviewClient() {
             releaseList={releaseListQuery.data}
             retry={() => void releaseListQuery.refetch()}
           />
+          <EntitySeriesOverview
+            entity={entity}
+            error={Boolean(seriesListQuery.error)}
+            pending={seriesListQuery.isPending}
+            retry={() => void seriesListQuery.refetch()}
+            seriesList={seriesListQuery.data}
+          />
           <EntityBottleOverview
             bottleList={bottleListQuery.data}
             createBottleHref={getEntityBottleCreateHref(entity)}
@@ -110,6 +125,13 @@ export function EntityOverviewClient() {
             pending={bottleListQuery.isPending}
             retry={() => void bottleListQuery.refetch()}
             totalBottles={entity.totalBottles}
+          />
+          <EntityReviewsAndTastingsOverview
+            entity={entity}
+            error={Boolean(recentReviewsAndTastingsQuery.error)}
+            pending={recentReviewsAndTastingsQuery.isPending}
+            retry={() => void recentReviewsAndTastingsQuery.refetch()}
+            reviewsAndTastings={recentReviewsAndTastingsQuery.data}
           />
           <EntityHistoryOverview
             entityName={entity.name}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewQueries.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewQueries.ts
@@ -38,6 +38,22 @@ export const entityOverviewQueries = {
     }),
     enabled: entityHasBottleCatalog(entity),
   }),
+  seriesByBottleCount: (orpc: ORPCQueryUtils, entity: Entity) => ({
+    ...orpc.bottleSeries.list.queryOptions({
+      input: {
+        distillery: entity.id,
+        limit: 4,
+        sort: "-bottles",
+      },
+    }),
+    enabled: entity.kind === "distillery",
+  }),
+  recentReviewsAndTastings: (orpc: ORPCQueryUtils, entity: Entity) => ({
+    ...orpc.activity.reviewsAndTastings.queryOptions({
+      input: { entity: entity.id, limit: 3 },
+    }),
+    enabled: entity.kind === "distillery",
+  }),
   releases: (orpc: ORPCQueryUtils, entity: Entity) => ({
     ...orpc.bottles.list.queryOptions({
       input: {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -120,6 +120,35 @@ describe("getEntityTabs", () => {
       },
     ]);
   });
+
+  it("adds a Series tab for distilleries", () => {
+    expect(
+      getEntityTabs({
+        id: 321,
+        kind: "distillery",
+        name: "Port Ellen",
+        shortName: null,
+        totalBottles: 42,
+        publicReviewAndTastingCount: 8,
+      }),
+    ).toEqual([
+      { href: "/distillers/321-port-ellen", label: "Overview" },
+      {
+        count: 42,
+        href: "/distillers/321-port-ellen/bottles",
+        label: "Bottles",
+      },
+      {
+        href: "/distillers/321-port-ellen/series",
+        label: "Series",
+      },
+      {
+        count: 8,
+        href: "/distillers/321-port-ellen/tastings",
+        label: "Reviews & tastings",
+      },
+    ]);
+  });
 });
 
 describe("getEntityCurrentHref", () => {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -102,6 +102,13 @@ export function getEntityTabs(
     });
   }
 
+  if (entity.kind === "distillery") {
+    tabs.push({
+      href: `${baseUrl}/series`,
+      label: "Series",
+    });
+  }
+
   if (entityHasBottleCatalog(entity)) {
     tabs.push({
       count: entity.publicReviewAndTastingCount,

--- a/apps/web/src/app/(app)/entities/[entityId]/entityReviewsAndTastingsOverview.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityReviewsAndTastingsOverview.test.tsx
@@ -1,0 +1,85 @@
+import {
+  mockEntity,
+  mockExternalReview,
+  mockMemberReview,
+  mockTasting,
+} from "@peated/server/orpc/mock/fixtures";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import type { Entity } from "./entityPageData";
+import { EntityReviewsAndTastingsOverview } from "./entityReviewsAndTastingsOverview";
+
+const distillery = {
+  ...mockEntity,
+  id: 321,
+  images: [],
+  kind: "distillery",
+  name: "Port Ellen",
+  peatedId: "E0321",
+  publicReviewAndTastingCount: 18,
+} satisfies Entity;
+
+describe("EntityReviewsAndTastingsOverview", () => {
+  test("shows the three newest related reviews and tastings", () => {
+    const html = renderToStaticMarkup(
+      <EntityReviewsAndTastingsOverview
+        reviewsAndTastings={{
+          rel: { nextCursor: null },
+          results: [
+            { type: "tasting", tasting: mockTasting },
+            { type: "member_review", review: mockMemberReview },
+            { type: "critic_review", review: mockExternalReview },
+            {
+              type: "tasting",
+              tasting: {
+                ...mockTasting,
+                id: mockTasting.id + 100,
+                createdBy: {
+                  ...mockTasting.createdBy,
+                  username: "hidden-fourth-member",
+                },
+              },
+            },
+          ],
+        }}
+        entity={distillery}
+        error={false}
+        pending={false}
+        retry={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("Recent activity");
+    expect(html).toContain("View all activity");
+    expect(html).not.toContain("hidden-fourth-member");
+    expect(html).toContain('href="/distillers/321-port-ellen/tastings"');
+  });
+
+  test("omits an empty activity preview", () => {
+    const html = renderToStaticMarkup(
+      <EntityReviewsAndTastingsOverview
+        entity={distillery}
+        error={false}
+        pending={false}
+        retry={() => undefined}
+        reviewsAndTastings={{ rel: { nextCursor: null }, results: [] }}
+      />,
+    );
+
+    expect(html).toBe("");
+  });
+
+  test("does not add the distillery preview to other entity pages", () => {
+    const html = renderToStaticMarkup(
+      <EntityReviewsAndTastingsOverview
+        entity={{ ...distillery, kind: "brand" }}
+        error={false}
+        pending={true}
+        retry={() => undefined}
+      />,
+    );
+
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityReviewsAndTastingsOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityReviewsAndTastingsOverview.tsx
@@ -1,0 +1,67 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+import { LoadingList, SectionError, TextLink } from "@peated/web/components";
+import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
+import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { getReviewAndTastingFeedItems } from "@peated/web/lib/communityFeed";
+import { getEntityUrl } from "@peated/web/lib/urls";
+
+import type { Entity } from "./entityPageData";
+
+type ReviewsAndTastings = Outputs["activity"]["reviewsAndTastings"];
+
+export function EntityReviewsAndTastingsOverview({
+  entity,
+  error,
+  pending,
+  retry,
+  reviewsAndTastings,
+}: {
+  entity: Entity;
+  error: boolean;
+  pending: boolean;
+  retry: () => void;
+  reviewsAndTastings?: ReviewsAndTastings;
+}) {
+  if (entity.kind !== "distillery") return null;
+
+  if (pending) {
+    return (
+      <PageSection heading="Recent activity">
+        <LoadingList
+          label={`Loading recent ${entity.name} activity`}
+          rows={3}
+        />
+      </PageSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageSection heading="Recent activity">
+        <SectionError heading="Recent activity is unavailable" onRetry={retry}>
+          The rest of this page still works. Try loading this activity again.
+        </SectionError>
+      </PageSection>
+    );
+  }
+
+  if (!reviewsAndTastings?.results.length) return null;
+
+  return (
+    <PageSection
+      heading="Recent activity"
+      intro={
+        <TextLink href={`${getEntityUrl(entity)}/tastings`}>
+          View all activity
+        </TextLink>
+      }
+    >
+      <CommunityFeed
+        ariaLabel={`Recent ${entity.name} activity`}
+        items={getReviewAndTastingFeedItems(reviewsAndTastings.results)}
+        limit={3}
+      />
+    </PageSection>
+  );
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySeriesOverview.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySeriesOverview.test.tsx
@@ -1,0 +1,76 @@
+import { mockEntity } from "@peated/server/orpc/mock/fixtures";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import type { Entity } from "./entityPageData";
+import { EntitySeriesOverview } from "./entitySeriesOverview";
+
+const distillery = {
+  ...mockEntity,
+  id: 321,
+  images: [],
+  kind: "distillery",
+  name: "Port Ellen",
+  peatedId: "E0321",
+} satisfies Entity;
+
+describe("EntitySeriesOverview", () => {
+  test("shows the Series with the most bottles and a full-list link", () => {
+    const html = renderToStaticMarkup(
+      <EntitySeriesOverview
+        entity={distillery}
+        error={false}
+        pending={false}
+        retry={() => undefined}
+        seriesList={{
+          rel: { nextCursor: null, prevCursor: null },
+          results: [
+            {
+              brand: {
+                id: 10,
+                kind: "brand",
+                name: "Rare Malts",
+                peatedId: "E0010",
+                shortName: null,
+              },
+              createdAt: "2026-01-01T00:00:00.000Z",
+              description: null,
+              fullName: "Rare Malts Rare Series",
+              id: 20,
+              name: "Rare Series",
+              numBottles: 3,
+              numReleases: 4,
+              peatedId: "S0020",
+              updatedAt: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+          total: 6,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Rare Series");
+    expect(html).toContain("Rare Malts");
+    expect(html).toContain("3 bottles");
+    expect(html).toContain("View all 6 series");
+    expect(html).toContain('href="/distillers/321-port-ellen/series"');
+  });
+
+  test("omits an empty Series preview", () => {
+    const html = renderToStaticMarkup(
+      <EntitySeriesOverview
+        entity={distillery}
+        error={false}
+        pending={false}
+        retry={() => undefined}
+        seriesList={{
+          rel: { nextCursor: null, prevCursor: null },
+          results: [],
+          total: 0,
+        }}
+      />,
+    );
+
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySeriesOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySeriesOverview.tsx
@@ -1,0 +1,85 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+import {
+  ItemList,
+  ItemListItem,
+  LoadingList,
+  SectionError,
+  SeriesIdentityRow,
+  TextLink,
+} from "@peated/web/components";
+import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { getBottleSeriesUrl, getEntityUrl } from "@peated/web/lib/urls";
+
+import type { Entity } from "./entityPageData";
+
+type BottleSeriesList = Outputs["bottleSeries"]["list"];
+
+export function EntitySeriesOverview({
+  entity,
+  error,
+  pending,
+  retry,
+  seriesList,
+}: {
+  entity: Entity;
+  error: boolean;
+  pending: boolean;
+  retry: () => void;
+  seriesList?: BottleSeriesList;
+}) {
+  if (entity.kind !== "distillery") return null;
+
+  if (pending) {
+    return (
+      <PageSection heading="Series">
+        <LoadingList label={`Loading ${entity.name} series`} rows={4} />
+      </PageSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageSection heading="Series">
+        <SectionError heading="Series are unavailable" onRetry={retry}>
+          The rest of this page still works. Try loading the series again.
+        </SectionError>
+      </PageSection>
+    );
+  }
+
+  if (!seriesList?.results.length) return null;
+
+  const viewAllLabel =
+    seriesList.total === 1
+      ? "View 1 series"
+      : `View all ${seriesList.total.toLocaleString("en-US")} series`;
+
+  return (
+    <PageSection
+      heading="Series"
+      intro={
+        <TextLink href={`${getEntityUrl(entity)}/series`}>
+          {viewAllLabel}
+        </TextLink>
+      }
+    >
+      <ItemList ariaLabel={`${entity.name} series`}>
+        {seriesList.results.map((series) => (
+          <ItemListItem key={series.id}>
+            <SeriesIdentityRow
+              brand={series.brand.name}
+              end={formatBottleCount(series.numBottles)}
+              href={getBottleSeriesUrl(series)}
+              name={series.name}
+            />
+          </ItemListItem>
+        ))}
+      </ItemList>
+    </PageSection>
+  );
+}
+
+function formatBottleCount(count: number) {
+  return `${count.toLocaleString("en-US")} ${count === 1 ? "bottle" : "bottles"}`;
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/series/entitySeriesListClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/series/entitySeriesListClient.stylex.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import * as stylex from "@stylexjs/stylex";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useOptimistic, useTransition } from "react";
+
+import {
+  CursorPager,
+  EmptyState,
+  ItemList,
+  ItemListItem,
+  ListToolbar,
+  SeriesIdentityRow,
+} from "@peated/web/components";
+import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { getBottleSeriesUrl } from "@peated/web/lib/urls";
+import { space } from "../../../../../styles/tokens.stylex";
+
+import { getEntitySeriesInput } from "./entitySeriesParams";
+
+type BottleSeriesList = Outputs["bottleSeries"]["list"];
+
+const sortOptions = [
+  { label: "Most bottles", value: "-bottles" },
+  { label: "Name", value: "name" },
+] as const;
+
+export function EntitySeriesListClient({
+  distilleryId,
+  distilleryName,
+  initialSeriesList,
+}: {
+  distilleryId: number;
+  distilleryName: string;
+  initialSeriesList: BottleSeriesList;
+}) {
+  const orpc = useORPC();
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryInput = getEntitySeriesInput(distilleryId, searchParams);
+  const { data: seriesList, isFetching } = useSuspenseQuery({
+    ...orpc.bottleSeries.list.queryOptions({ input: queryInput }),
+    initialData: initialSeriesList,
+  });
+  const [isNavigating, startTransition] = useTransition();
+  const [sort, setSort] = useOptimistic(queryInput.sort ?? "-bottles");
+  const page = Number(queryInput.cursor ?? 1);
+
+  function updateSort(value: string) {
+    const nextSort = value === "name" ? "name" : "-bottles";
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("sort", nextSort);
+    nextParams.delete("cursor");
+    startTransition(() => {
+      setSort(nextSort);
+      router.push(buildSearchHref(pathname, nextParams), { scroll: false });
+    });
+  }
+
+  return (
+    <section
+      aria-label={`Series featuring whisky from ${distilleryName}`}
+      {...stylex.props(styles.content)}
+    >
+      <ListToolbar
+        count={seriesList.results.length}
+        noun="series"
+        onSortChange={updateSort}
+        pending={isNavigating || isFetching}
+        pluralNoun="series"
+        sort={sort}
+        sortOptions={sortOptions}
+        total={seriesList.total}
+      />
+      {seriesList.results.length ? (
+        <ItemList ariaLabel={`${distilleryName} series`}>
+          {seriesList.results.map((series) => (
+            <ItemListItem key={series.id}>
+              <SeriesIdentityRow
+                brand={series.brand.name}
+                end={formatBottleCount(series.numBottles)}
+                href={getBottleSeriesUrl(series)}
+                name={series.name}
+              />
+            </ItemListItem>
+          ))}
+        </ItemList>
+      ) : (
+        <EmptyState heading="No series yet">
+          No series with bottles from {distilleryName} have been added yet.
+        </EmptyState>
+      )}
+      <CursorPager
+        ariaLabel={`${distilleryName} series pages`}
+        nextHref={getCursorHref(
+          pathname,
+          searchParams,
+          seriesList.rel.nextCursor,
+        )}
+        page={page}
+        previousHref={getCursorHref(
+          pathname,
+          searchParams,
+          seriesList.rel.prevCursor,
+        )}
+      />
+    </section>
+  );
+}
+
+function formatBottleCount(count: number) {
+  return `${count.toLocaleString("en-US")} ${count === 1 ? "bottle" : "bottles"}`;
+}
+
+const styles = stylex.create({
+  content: {
+    minWidth: 0,
+    paddingTop: space.x6,
+  },
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/series/entitySeriesParams.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/series/entitySeriesParams.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { getEntitySeriesInput } from "./entitySeriesParams";
+
+describe("getEntitySeriesInput", () => {
+  it("defaults to the most populated Series", () => {
+    expect(getEntitySeriesInput(321, {})).toEqual({
+      cursor: 1,
+      distillery: 321,
+      limit: 25,
+      sort: "-bottles",
+    });
+  });
+
+  it("keeps valid pagination and name sorting", () => {
+    expect(getEntitySeriesInput(321, { cursor: "3", sort: "name" })).toEqual({
+      cursor: 3,
+      distillery: 321,
+      limit: 25,
+      sort: "name",
+    });
+  });
+
+  it("drops unsupported query values", () => {
+    expect(
+      getEntitySeriesInput(321, { cursor: "nope", sort: "newest" }),
+    ).toEqual({
+      cursor: 1,
+      distillery: 321,
+      limit: 25,
+      sort: "-bottles",
+    });
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/series/entitySeriesParams.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/series/entitySeriesParams.ts
@@ -1,0 +1,26 @@
+import type { Inputs } from "@peated/server/orpc/router";
+import {
+  getApiQueryParams,
+  type SearchParamSource,
+} from "@peated/web/lib/apiQueryParams";
+
+export const entitySeriesSorts = ["-bottles", "name"] as const;
+
+export function getEntitySeriesInput(
+  distillery: number,
+  searchParams: SearchParamSource,
+): Inputs["bottleSeries"]["list"] {
+  const params = getApiQueryParams(searchParams, {
+    allowedValues: { sort: entitySeriesSorts },
+    defaults: { cursor: 1, sort: "-bottles" },
+    fields: ["cursor", "sort"],
+    numericFields: ["cursor"],
+  });
+
+  return {
+    cursor: Number(params.cursor),
+    distillery,
+    limit: 25,
+    sort: params.sort,
+  };
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/series/loading.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/series/loading.tsx
@@ -1,0 +1,5 @@
+import { EntityTabLoading } from "../entityTabLoading.stylex";
+
+export default function EntitySeriesLoading() {
+  return <EntityTabLoading label="Loading series" />;
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/series/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/series/page.tsx
@@ -1,0 +1,31 @@
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+import { getEntityPage } from "@peated/web/lib/entityPage.server";
+import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getEntityUrl } from "@peated/web/lib/urls";
+import { redirect } from "next/navigation";
+
+import { EntitySeriesListClient } from "./entitySeriesListClient.stylex";
+import { getEntitySeriesInput } from "./entitySeriesParams";
+
+export default async function EntitySeriesPage(props: {
+  params: Promise<{ entityId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { entityId } = await props.params;
+  const searchParams = await props.searchParams;
+  const entity = await getEntityPage(parseCatalogRouteId(entityId));
+  if (entity.kind !== "distillery") redirect(getEntityUrl(entity));
+
+  const { client } = await getPublicPageServerClient();
+  const seriesList = await client.bottleSeries.list(
+    getEntitySeriesInput(entity.id, searchParams),
+  );
+
+  return (
+    <EntitySeriesListClient
+      distilleryId={entity.id}
+      distilleryName={entity.name}
+      initialSeriesList={seriesList}
+    />
+  );
+}

--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -25,6 +25,7 @@ export type ListSortOption = {
 export type ListToolbarProps = {
   count: number;
   noun: string;
+  pluralNoun?: string;
   onExport?: () => void;
   onSortChange: (value: string) => void;
   pending?: boolean;
@@ -37,6 +38,7 @@ export type ListToolbarProps = {
 export function ListToolbar({
   count,
   noun,
+  pluralNoun = `${noun}s`,
   onExport,
   onSortChange,
   pending = false,
@@ -48,7 +50,7 @@ export function ListToolbar({
     <div {...stylex.props(styles.toolbar)}>
       <p aria-live="polite" {...stylex.props(styles.count)}>
         <strong {...stylex.props(styles.countValue)}>
-          {count.toLocaleString("en-US")} {count === 1 ? noun : `${noun}s`}
+          {count.toLocaleString("en-US")} {count === 1 ? noun : pluralNoun}
         </strong>
         {total !== undefined ? (
           <span
@@ -68,7 +70,7 @@ export function ListToolbar({
         <label {...stylex.props(foundationStyles.fieldLabel, styles.sortLabel)}>
           <span>Sort</span>
           <CompactSelect
-            aria-label={`Sort ${noun}s`}
+            aria-label={`Sort ${pluralNoun}`}
             onChange={(event) => onSortChange(event.currentTarget.value)}
             value={sort}
           >

--- a/apps/web/src/components/lists.test.tsx
+++ b/apps/web/src/components/lists.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { CursorPager } from "./lists.stylex";
+import { CursorPager, ListToolbar } from "./lists.stylex";
 
 describe("CursorPager", () => {
   it("places page context before the navigation actions", () => {
@@ -15,5 +15,24 @@ describe("CursorPager", () => {
 
     expect(html.indexOf("Page 3")).toBeLessThan(html.indexOf("← Previous"));
     expect(html.indexOf("← Previous")).toBeLessThan(html.indexOf("Next →"));
+  });
+});
+
+describe("ListToolbar", () => {
+  it("supports a noun whose plural does not add s", () => {
+    const html = renderToStaticMarkup(
+      <ListToolbar
+        count={4}
+        noun="series"
+        onSortChange={() => undefined}
+        pluralNoun="series"
+        sort="-bottles"
+        sortOptions={[{ label: "Most bottles", value: "-bottles" }]}
+      />,
+    );
+
+    expect(html).toContain("4 series");
+    expect(html).toContain('aria-label="Sort series"');
+    expect(html).not.toContain("serieses");
   });
 });


### PR DESCRIPTION
Distillery pages now show the four Series with the most bottles and the three latest related activity items on the overview. A dedicated Series tab lets people browse every matching Series and sort by bottle count or name; empty previews stay hidden, and other entity kinds are unchanged.

The bottle-series list API now supports distillery filtering and bottle-count sorting, and returns the owning brand plus the number of active matching bottles. Counts exclude legacy and tombstoned bottles so both distillery surfaces reflect the public catalog.
