### PR TITLE
feat(web): publish PeatedBot request identity

### DIFF
--- a/apps/web/src/app/(app)/bot/botPage.stylex.tsx
+++ b/apps/web/src/app/(app)/bot/botPage.stylex.tsx
@@ -1,0 +1,31 @@
+import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
+import { foundationStyles } from "../../../styles/foundations.stylex";
+import { space } from "../../../styles/tokens.stylex";
+
+export function BotCode({ children }: { children: ReactNode }) {
+  return (
+    <code {...stylex.props(foundationStyles.code, styles.code)}>
+      {children}
+    </code>
+  );
+}
+
+export function BotSectionGrid({ children }: { children: ReactNode }) {
+  return <div {...stylex.props(styles.sectionGrid)}>{children}</div>;
+}
+
+const styles = stylex.create({
+  code: {
+    overflowWrap: "anywhere",
+  },
+  sectionGrid: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "repeat(2, minmax(0, 1fr))",
+      "@media (max-width: 759px)": "minmax(0, 1fr)",
+    },
+    columnGap: space.x12,
+    rowGap: space.x8,
+  },
+});

--- a/apps/web/src/app/(app)/bot/page.test.tsx
+++ b/apps/web/src/app/(app)/bot/page.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import BotPage from "./page";
+
+describe("PeatedBot page", () => {
+  it("publishes the information needed to identify and verify requests", () => {
+    const html = renderToStaticMarkup(<BotPage />);
+
+    expect(html).toContain("PeatedBot/1.0 (+https://peated.com/bot)");
+    expect(html).toContain(
+      'href="https://peated.com/.well-known/http-message-signatures-directory"',
+    );
+    expect(html).toContain("Ed25519");
+    expect(html).toContain("It never includes the private key.");
+  });
+});

--- a/apps/web/src/app/(app)/bot/page.tsx
+++ b/apps/web/src/app/(app)/bot/page.tsx
@@ -1,4 +1,5 @@
 import { BOT_USER_AGENT } from "@peated/server/constants";
+import { FactList } from "@peated/web/components";
 import {
   ContentLink,
   ContentList,
@@ -8,6 +9,7 @@ import {
 } from "@peated/web/components/pages/contentPage.stylex";
 import config from "@peated/web/config";
 import type { Metadata } from "next";
+import { BotCode, BotSectionGrid } from "./botPage.stylex";
 
 export const dynamic = "force-static";
 
@@ -28,100 +30,108 @@ export default function BotPage() {
       intro="PeatedBot reads public whisky information so Peated can keep an accurate, freely available catalog."
       title="PeatedBot"
     >
-      <ContentSection title="What it reads">
-        <ContentText>
-          PeatedBot reads public catalog and product pages for bottle names,
-          producers, ages, strengths, release years, images, prices, and
-          availability. It reads public review pages for titles, writers, dates,
-          scores, bottle names, and review text.
-        </ContentText>
-        <ContentText>
-          Peated stores bottle facts, source links, and credit to the original
-          website. Full review text may be stored privately so Peated can
-          improve how it reads pages without requesting them again. Peated does
-          not publish that full text.
-        </ContentText>
+      <ContentSection title="Request identity">
+        <FactList
+          facts={[
+            {
+              label: "User agent",
+              value: <BotCode>{BOT_USER_AGENT}</BotCode>,
+            },
+            {
+              label: "robots.txt",
+              value: <BotCode>PeatedBot</BotCode>,
+            },
+            {
+              label: "Signature agent",
+              value: <BotCode>&quot;https://peated.com&quot;</BotCode>,
+            },
+            {
+              label: "Key directory",
+              value: (
+                <BotCode>
+                  <ContentLink href={KEY_DIRECTORY_URL}>
+                    {KEY_DIRECTORY_URL}
+                  </ContentLink>
+                </BotCode>
+              ),
+            },
+            {
+              label: "Algorithm",
+              value: <BotCode>Ed25519</BotCode>,
+            },
+          ]}
+        />
       </ContentSection>
-      <ContentSection title="How it behaves">
-        <ContentList>
-          <li>It identifies every request with the user agent below.</li>
-          <li>It follows robots.txt rules written for PeatedBot.</li>
-          <li>
-            Each website has its own request limit. PeatedBot spreads those
-            requests across the hour.
-          </li>
-          <li>
-            It obeys HTTP 429 responses and waits for the time named in
-            Retry-After.
-          </li>
-          <li>It limits each run, request, retry, and download.</li>
-          <li>It does not bypass authentication or access controls.</li>
-        </ContentList>
-      </ContentSection>
-      <ContentSection title="Identify a request">
-        <ContentList>
-          <li>
-            User agent: <code>{BOT_USER_AGENT}</code>
-          </li>
-          <li>
-            robots.txt name: <code>PeatedBot</code>
-          </li>
-          <li>
-            Signature agent: <code>&quot;https://peated.com&quot;</code>
-          </li>
-          <li>
-            Public key directory:{" "}
-            <ContentLink href={KEY_DIRECTORY_URL}>
-              {KEY_DIRECTORY_URL}
-            </ContentLink>
-          </li>
-          <li>
-            Signing algorithm: <code>Ed25519</code>
-          </li>
-        </ContentList>
+      <ContentSection title="Verify a signed request">
         <ContentText>
           Production requests include <code>Signature-Agent</code>,{" "}
           <code>Signature-Input</code>, and <code>Signature</code> headers. A
           website or its network provider can use these headers and the public
           key directory to confirm that a request came from Peated.
         </ContentText>
-      </ContentSection>
-      <ContentSection title="Request signing and public keys">
         <ContentText>
           PeatedBot uses{" "}
-          <ContentLink href={WEB_BOT_AUTH_URL}>Web Bot Auth</ContentLink>, which
-          signs each request with a private key held by Peated. The public key
-          directory is a signed JSON Web Key Set (JWKS), a standard list of
-          public keys. It never includes the private key.
-        </ContentText>
-        <ContentText>
-          Public keys can change during a planned key rotation. Services that
-          verify PeatedBot should read the directory instead of saving a copy of
-          its current key.
+          <ContentLink href={WEB_BOT_AUTH_URL}>Web Bot Auth</ContentLink>. The
+          key directory is a signed JSON Web Key Set (JWKS), a standard list of
+          public keys. It never includes the private key. Public keys can change
+          during a planned rotation, so services should read the directory
+          instead of saving its current key.
         </ContentText>
       </ContentSection>
-      <ContentSection title="Control access">
-        <ContentText>
-          Site owners can block all PeatedBot requests by adding a robots.txt
-          group for <code>PeatedBot</code> with <code>Disallow: /</code>. A more
-          specific rule can allow or block individual paths. After 24 hours,
-          Peated checks robots.txt again before making another request.
-        </ContentText>
-      </ContentSection>
-      <ContentSection title="Contact">
-        <ContentText>
-          If our traffic causes a problem, contact us through the{" "}
-          <ContentLink href={`${config.GITHUB_REPO}/issues`}>
-            Peated issue tracker
-          </ContentLink>{" "}
-          or the{" "}
-          <ContentLink href={config.DISCORD_LINK}>Peated Discord</ContentLink>.
-          Include the hostname, affected paths, UTC request times, HTTP status,
-          and a request ID from your network provider if one is available. Do
-          not post full request headers in a public issue. We will pause a
-          source while investigating an access or rate problem.
-        </ContentText>
-      </ContentSection>
+      <BotSectionGrid>
+        <ContentSection title="What it reads">
+          <ContentText>
+            PeatedBot reads public catalog and product pages for bottle names,
+            producers, ages, strengths, release years, images, prices, and
+            availability. It reads public review pages for titles, writers,
+            dates, scores, bottle names, and review text.
+          </ContentText>
+          <ContentText>
+            Peated stores bottle facts, source links, and credit to the original
+            website. Full review text may be stored privately so Peated can
+            improve how it reads pages without requesting them again. Peated
+            does not publish that full text.
+          </ContentText>
+        </ContentSection>
+        <ContentSection title="How it behaves">
+          <ContentList>
+            <li>It identifies every request with the user agent above.</li>
+            <li>It follows robots.txt rules written for PeatedBot.</li>
+            <li>
+              Each website has its own request limit. PeatedBot spreads those
+              requests across the hour.
+            </li>
+            <li>
+              It obeys HTTP 429 responses and waits for the time named in
+              Retry-After.
+            </li>
+            <li>It limits each run, request, retry, and download.</li>
+            <li>It does not bypass authentication or access controls.</li>
+          </ContentList>
+        </ContentSection>
+        <ContentSection title="Control access">
+          <ContentText>
+            Site owners can block all PeatedBot requests by adding a robots.txt
+            group for <code>PeatedBot</code> with <code>Disallow: /</code>. A
+            more specific rule can allow or block individual paths. After 24
+            hours, Peated checks robots.txt again before making another request.
+          </ContentText>
+        </ContentSection>
+        <ContentSection title="Contact">
+          <ContentText>
+            If our traffic causes a problem, contact us through the{" "}
+            <ContentLink href={`${config.GITHUB_REPO}/issues`}>
+              Peated issue tracker
+            </ContentLink>{" "}
+            or the{" "}
+            <ContentLink href={config.DISCORD_LINK}>Peated Discord</ContentLink>
+            . Include the hostname, affected paths, UTC request times, HTTP
+            status, and a request ID from your network provider if one is
+            available. Do not post full request headers in a public issue. We
+            will pause a source while investigating an access or rate problem.
+          </ContentText>
+        </ContentSection>
+      </BotSectionGrid>
     </ContentPage>
   );
 }

--- a/apps/web/src/app/(app)/bot/page.tsx
+++ b/apps/web/src/app/(app)/bot/page.tsx
@@ -1,3 +1,4 @@
+import { BOT_USER_AGENT } from "@peated/server/constants";
 import {
   ContentLink,
   ContentList,
@@ -9,6 +10,11 @@ import config from "@peated/web/config";
 import type { Metadata } from "next";
 
 export const dynamic = "force-static";
+
+const KEY_DIRECTORY_URL =
+  "https://peated.com/.well-known/http-message-signatures-directory";
+const WEB_BOT_AUTH_URL =
+  "https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/";
 
 export const metadata: Metadata = {
   title: "PeatedBot",
@@ -38,9 +44,7 @@ export default function BotPage() {
       </ContentSection>
       <ContentSection title="How it behaves">
         <ContentList>
-          <li>
-            It identifies requests as PeatedBot/1.0 and links to this page.
-          </li>
+          <li>It identifies every request with the user agent below.</li>
           <li>It follows robots.txt rules written for PeatedBot.</li>
           <li>
             Each website has its own request limit. PeatedBot spreads those
@@ -53,6 +57,48 @@ export default function BotPage() {
           <li>It limits each run, request, retry, and download.</li>
           <li>It does not bypass authentication or access controls.</li>
         </ContentList>
+      </ContentSection>
+      <ContentSection title="Identify a request">
+        <ContentList>
+          <li>
+            User agent: <code>{BOT_USER_AGENT}</code>
+          </li>
+          <li>
+            robots.txt name: <code>PeatedBot</code>
+          </li>
+          <li>
+            Signature agent: <code>&quot;https://peated.com&quot;</code>
+          </li>
+          <li>
+            Public key directory:{" "}
+            <ContentLink href={KEY_DIRECTORY_URL}>
+              {KEY_DIRECTORY_URL}
+            </ContentLink>
+          </li>
+          <li>
+            Signing algorithm: <code>Ed25519</code>
+          </li>
+        </ContentList>
+        <ContentText>
+          Production requests include <code>Signature-Agent</code>,{" "}
+          <code>Signature-Input</code>, and <code>Signature</code> headers. A
+          website or its network provider can use these headers and the public
+          key directory to confirm that a request came from Peated.
+        </ContentText>
+      </ContentSection>
+      <ContentSection title="Request signing and public keys">
+        <ContentText>
+          PeatedBot uses{" "}
+          <ContentLink href={WEB_BOT_AUTH_URL}>Web Bot Auth</ContentLink>, which
+          signs each request with a private key held by Peated. The public key
+          directory is a signed JSON Web Key Set (JWKS), a standard list of
+          public keys. It never includes the private key.
+        </ContentText>
+        <ContentText>
+          Public keys can change during a planned key rotation. Services that
+          verify PeatedBot should read the directory instead of saving a copy of
+          its current key.
+        </ContentText>
       </ContentSection>
       <ContentSection title="Control access">
         <ContentText>
@@ -70,8 +116,10 @@ export default function BotPage() {
           </ContentLink>{" "}
           or the{" "}
           <ContentLink href={config.DISCORD_LINK}>Peated Discord</ContentLink>.
-          Include the hostname and request times. We will pause a source while
-          investigating an access or rate problem.
+          Include the hostname, affected paths, UTC request times, HTTP status,
+          and a request ID from your network provider if one is available. Do
+          not post full request headers in a public issue. We will pause a
+          source while investigating an access or rate problem.
         </ContentText>
       </ContentSection>
     </ContentPage>

--- a/docs/operations/peated-bot.md
+++ b/docs/operations/peated-bot.md
@@ -85,10 +85,12 @@ reuse the signature before it expires.
 
 ## Register with Cloudflare
 
-In the Cloudflare dashboard, open Manage Account → Configurations → Bot
-Submission Form. Choose **Request Signature** as the verification method. Use
-the public key directory URL for **Validation Instructions** and list
-`PeatedBot/1.0 (+https://peated.com/bot)` as the user agent.
+In the Cloudflare dashboard, open Protect & Connect → Application Security →
+BotBase → Submission form. Choose **Request Signature** as the verification
+method. Use the public key directory URL for **Validation Instructions** and
+list `PeatedBot/1.0 (+https://peated.com/bot)` as the user agent. Cloudflare's
+older Web Bot Auth instructions may still point to Manage Account →
+Configurations, but Cloudflare moved the form to BotBase in August 2026.
 
 After Cloudflare accepts the submission:
 


### PR DESCRIPTION
PeatedBot's public page now lists its exact user agent, robots.txt name,
Signature-Agent origin, Ed25519 algorithm, and signed public key directory. It
also explains how sites can verify requests, how public-key rotation works, and
which diagnostic details to include when reporting traffic problems without
posting full request headers. The displayed user agent comes from the same
constant as outgoing scraper requests, with focused regression coverage.

The operations guide now points to Cloudflare's new BotBase submission form;
Cloudflare removed the form from the older account Configurations page.
