### PR TITLE
feat(scraper): discover advertised review feeds

### DIFF
--- a/apps/server/__fixtures__/scraper-websites/rss/feed.xml
+++ b/apps/server/__fixtures__/scraper-websites/rss/feed.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+  <title>Whisky Feed</title>
+  <item>
+    <title>Two island malts</title>
+    <link>{{origin}}/reviews/island-pair</link>
+  </item>
+  <item>
+    <title>Hill Malt review</title>
+    <link>{{origin}}/reviews/hill-malt</link>
+  </item>
+</channel>
+</rss>

--- a/apps/server/__fixtures__/scraper-websites/rss/hill-malt.html
+++ b/apps/server/__fixtures__/scraper-websites/rss/hill-malt.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head><title>Hill Malt review | Whisky Feed</title></head>
+<body>
+<main>
+<article><h1 class="post-title">Hill Malt review</h1>
+<time datetime="2026-08-19">August 19, 2026</time><span class="byline">Mara Vale</span>
+<div class="entry-content"><section class="tasting"><h2>Hill Malt 10 Year</h2>
+<p class="notes">Malt, honey and fresh apples.</p><p>Score: <strong class="score">89/100</strong></p></section></div></article>
+</main>
+</body>
+</html>

--- a/apps/server/__fixtures__/scraper-websites/rss/index.html
+++ b/apps/server/__fixtures__/scraper-websites/rss/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <title>Whisky Feed</title>
+  <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+</head>
+<body>
+<main>
+  <h1>Whisky Feed</h1>
+  <map name="navigation"><area href="/feed.xml" alt="RSS feed"></map>
+  <a href="/reviews">Review archive</a>
+</main>
+</body>
+</html>

--- a/apps/server/__fixtures__/scraper-websites/rss/island-pair.html
+++ b/apps/server/__fixtures__/scraper-websites/rss/island-pair.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head><title>Two island malts | Whisky Feed</title></head>
+<body>
+<main>
+<article><h1 class="post-title">Two island malts</h1>
+<time datetime="2026-08-22">August 22, 2026</time><span class="byline">Mara Vale</span>
+<div class="entry-content">
+<section class="tasting"><h2>Island Malt First Release</h2><p class="notes">Lemon oil and coastal smoke.</p><p>Score: <strong class="score">88/100</strong></p></section>
+<section class="tasting"><h2>Island Malt Loch Edition</h2><p class="notes">Heather, brine and soft peat.</p><p>Score: <strong class="score">85/100</strong></p></section>
+</div></article>
+</main>
+</body>
+</html>

--- a/apps/server/__fixtures__/scraper-websites/rss/reviews.html
+++ b/apps/server/__fixtures__/scraper-websites/rss/reviews.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head><title>Review archive | Whisky Feed</title></head>
+<body>
+<main>
+  <h1>Review archive</h1>
+  <article class="review-card"><a href="/reviews/island-pair">Two island malts</a></article>
+</main>
+</body>
+</html>

--- a/apps/server/src/scraper/configured/createScraper.eval.test.ts
+++ b/apps/server/src/scraper/configured/createScraper.eval.test.ts
@@ -162,6 +162,10 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
           previewStatus: "pending",
           active: false,
         });
+        if (website.key === "rss") {
+          expect(revision.listUrl).toBe(`${origin}/feed.xml`);
+          expect(revision.rules).toMatchObject({ kind: "review" });
+        }
         expect(revision.aiModel).toBeTruthy();
         expect(await db.select().from(externalReviews)).toEqual([]);
 

--- a/apps/server/src/scraper/configured/discovery.test.ts
+++ b/apps/server/src/scraper/configured/discovery.test.ts
@@ -1,7 +1,85 @@
 import { expect, test } from "vitest";
-import { findLikelyDetailPages, findLikelyListPages } from "./discovery";
+import {
+  findAdvertisedSyndicationPages,
+  findLikelyDetailPages,
+  findLikelyListPages,
+  inspectSyndicationFeed,
+} from "./discovery";
 
 const DETAIL_PAGE_LIMIT = 3;
+
+test("finds Whiskyfun's advertised RSS page without guessing its URL", () => {
+  expect(
+    findAdvertisedSyndicationPages({
+      pageUrl: new URL("https://www.whiskyfun.com/"),
+      html: `
+        <link rel="alternate" type="application/rss+xml" href="whatsnew.xml">
+        <map><area href="whatsnew.xml"></map>
+      `,
+    }),
+  ).toEqual(["https://www.whiskyfun.com/whatsnew.xml"]);
+});
+
+test("prioritizes standard feed metadata and keeps discovery on the website", () => {
+  expect(
+    findAdvertisedSyndicationPages({
+      pageUrl: new URL("https://example.test/"),
+      html: `
+        <a href="/reviews.xml">Review XML</a>
+        <link rel="alternate" type="application/atom+xml" href="/feed">
+        <link rel="alternate" type="application/rss+xml" href="https://other.test/feed.xml">
+        <link rel="alternate" type="text/html" href="/print">
+      `,
+    }),
+  ).toEqual(["https://example.test/feed", "https://example.test/reviews.xml"]);
+});
+
+test("validates RSS, Atom, and RDF feeds with same-site article links", () => {
+  const pageUrl = new URL("https://example.test/feed.xml");
+  expect(
+    inspectSyndicationFeed({
+      pageUrl,
+      xml: "<rss><channel><item><link>/reviews/one</link></item></channel></rss>",
+    }),
+  ).toEqual({
+    format: "rss",
+    links: ["https://example.test/reviews/one"],
+  });
+  expect(
+    inspectSyndicationFeed({
+      pageUrl,
+      xml: '<feed><entry><link rel="alternate" href="/reviews/two"/></entry></feed>',
+    }),
+  ).toEqual({
+    format: "atom",
+    links: ["https://example.test/reviews/two"],
+  });
+  expect(
+    inspectSyndicationFeed({
+      pageUrl,
+      xml: '<rdf:RDF xmlns:rdf="urn:rdf"><item><link>/reviews/three</link></item></rdf:RDF>',
+    }),
+  ).toEqual({
+    format: "rdf",
+    links: ["https://example.test/reviews/three"],
+  });
+});
+
+test("rejects advertised pages that are not usable feeds", () => {
+  const pageUrl = new URL("https://example.test/feed.xml");
+  expect(
+    inspectSyndicationFeed({
+      pageUrl,
+      xml: '<html><a href="/reviews/one">Review</a></html>',
+    }),
+  ).toBeNull();
+  expect(
+    inspectSyndicationFeed({
+      pageUrl,
+      xml: "<rss><channel><item><link>https://other.test/review</link></item></channel></rss>",
+    }),
+  ).toBeNull();
+});
 
 test("limits same-site review pages", () => {
   const result = findLikelyListPages({
@@ -71,6 +149,33 @@ test("limits detail pages found in list-page cards", () => {
     "https://example.test/reviews/0",
     "https://example.test/reviews/1",
     "https://example.test/reviews/2",
+  ]);
+});
+
+test("uses validated feed entries as priority detail examples", () => {
+  expect(
+    findLikelyDetailPages({
+      kind: "review",
+      limit: 2,
+      pages: [
+        {
+          url: "https://example.test/",
+          html: '<article class="review-card"><a href="/reviews/html">HTML review</a></article>',
+        },
+        {
+          url: "https://example.test/feed.xml",
+          html: `
+            <rss><channel>
+              <item><link>https://example.test/reviews/feed-one</link></item>
+              <item><link>https://example.test/reviews/feed-two</link></item>
+            </channel></rss>
+          `,
+        },
+      ],
+    }),
+  ).toEqual([
+    "https://example.test/reviews/feed-one",
+    "https://example.test/reviews/feed-two",
   ]);
 });
 

--- a/apps/server/src/scraper/configured/discovery.ts
+++ b/apps/server/src/scraper/configured/discovery.ts
@@ -3,6 +3,14 @@ import type { ScrapeSourceKind } from "./rules";
 
 export const MAX_LIKELY_LIST_PAGES = 4;
 
+const SYNDICATION_TYPES = new Set([
+  "application/atom+xml",
+  "application/rdf+xml",
+  "application/rss+xml",
+]);
+
+const SYNDICATION_PATH = /(?:^|[/.\-_])(atom|feed|rss)(?:$|[/.\-_])/i;
+
 const LIST_PAGE_WORDS = {
   review: ["review", "reviews", "rating", "ratings", "tasting", "archive"],
   price: [
@@ -58,6 +66,141 @@ function scoreLink(url: URL, text: string, kind: ScrapeSourceKind) {
     0,
   );
   return pathScore + textScore - pathParts.length;
+}
+
+function sameWebsiteUrl(href: string, pageUrl: URL) {
+  try {
+    const url = new URL(href, pageUrl);
+    if (
+      !["http:", "https:"].includes(url.protocol) ||
+      url.origin !== pageUrl.origin ||
+      url.username ||
+      url.password
+    ) {
+      return null;
+    }
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function looksLikeSyndicationLink(url: URL, text: string) {
+  return (
+    url.pathname.toLowerCase().endsWith(".xml") ||
+    SYNDICATION_PATH.test(url.pathname) ||
+    /\b(atom|feed|rss)\b/i.test(text)
+  );
+}
+
+/** Finds public feeds advertised by the website, with standard metadata first. */
+export function findAdvertisedSyndicationPages(input: {
+  pageUrl: URL;
+  html: string;
+}) {
+  const $ = load(input.html);
+  const found = new Map<string, { priority: number; order: number }>();
+  let order = 0;
+
+  for (const element of $("link[href], a[href], area[href]").toArray()) {
+    order += 1;
+    const href = $(element).attr("href");
+    if (!href) continue;
+    const value = sameWebsiteUrl(href, input.pageUrl);
+    if (!value || value === input.pageUrl.toString()) continue;
+
+    const tagName = element.tagName.toLowerCase();
+    const type = ($(element).attr("type") ?? "")
+      .split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
+    const alternate = ($(element).attr("rel") ?? "")
+      .toLowerCase()
+      .split(/\s+/)
+      .includes("alternate");
+    const typedFeed = type ? SYNDICATION_TYPES.has(type) : false;
+    const namedFeed = looksLikeSyndicationLink(
+      new URL(value),
+      $(element).text(),
+    );
+    const eligibleTypedFeed =
+      tagName === "link" ? alternate && typedFeed : typedFeed;
+    const eligibleNamedFeed =
+      tagName === "link" ? alternate && namedFeed : namedFeed;
+    const priority =
+      tagName === "link" && alternate && typedFeed
+        ? 3
+        : eligibleTypedFeed
+          ? 2
+          : eligibleNamedFeed
+            ? 1
+            : 0;
+    if (priority === 0) continue;
+
+    const current = found.get(value);
+    if (!current || priority > current.priority) {
+      found.set(value, { priority, order });
+    }
+  }
+
+  return [...found.entries()]
+    .sort(([, left], [, right]) =>
+      right.priority === left.priority
+        ? left.order - right.order
+        : right.priority - left.priority,
+    )
+    .map(([url]) => url);
+}
+
+export type SyndicationFeed = {
+  format: "atom" | "rdf" | "rss";
+  links: string[];
+};
+
+/** Accepts only a recognizable feed with usable links on the source website. */
+export function inspectSyndicationFeed(input: {
+  pageUrl: URL;
+  xml: string;
+}): SyndicationFeed | null {
+  const $ = load(input.xml, { xmlMode: true });
+  const root = $.root().children().first();
+  const rootName = root.prop("tagName")?.toLowerCase();
+  const format =
+    rootName === "rss"
+      ? "rss"
+      : rootName === "feed"
+        ? "atom"
+        : rootName === "rdf:rdf"
+          ? "rdf"
+          : null;
+  if (!format) return null;
+
+  const items =
+    format === "atom"
+      ? root.children("entry").toArray()
+      : format === "rss"
+        ? root.children("channel").first().children("item").toArray()
+        : root.children("item").toArray();
+  const links = new Set<string>();
+  for (const item of items) {
+    const raw =
+      format === "atom"
+        ? $(item)
+            .children("link")
+            .filter((_, link) => {
+              const rel = $(link).attr("rel");
+              return !rel || rel.toLowerCase() === "alternate";
+            })
+            .first()
+            .attr("href")
+        : $(item).children("link").first().text().trim();
+    if (!raw) continue;
+    const value = sameWebsiteUrl(raw, input.pageUrl);
+    if (value) links.add(value);
+  }
+  if (links.size === 0) return null;
+  return { format, links: [...links] };
 }
 
 export function findLikelyListPages(input: {
@@ -117,6 +260,14 @@ export function findLikelyDetailPages(input: {
 
   for (const page of input.pages) {
     const pageUrl = new URL(page.url);
+    const feed = inspectSyndicationFeed({ pageUrl, xml: page.html });
+    if (feed) {
+      for (const url of feed.links) {
+        order += 1;
+        if (pageUrls.has(url)) continue;
+        found.set(url, { score: 100, order });
+      }
+    }
     const $ = load(page.html);
     for (const element of $("a[href]").toArray()) {
       order += 1;

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -27,7 +27,13 @@ import type {
   ScraperSink,
   ScraperSourceDefinition,
 } from "../types";
-import { findLikelyDetailPages, findLikelyListPages } from "./discovery";
+import {
+  MAX_LIKELY_LIST_PAGES,
+  findAdvertisedSyndicationPages,
+  findLikelyDetailPages,
+  findLikelyListPages,
+  inspectSyndicationFeed,
+} from "./discovery";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
 import {
   ScrapeSourcePreviewPageSchema,
@@ -482,26 +488,63 @@ export async function resolveScrapeSourceRunRegistry(
                 new URL(value).toString(),
               ),
             );
+            const entryFeed =
+              suggestion.source.kind === "review"
+                ? inspectSyndicationFeed({
+                    pageUrl: entryResponse.url,
+                    xml: entryResponse.body,
+                  })
+                : null;
             const listPages = [
               {
                 url: entryResponse.url.toString(),
                 html: entryResponse.body,
+                document: entryFeed ? ("xml" as const) : ("html" as const),
               },
             ];
-            const likelyListPages = findLikelyListPages({
-              kind: suggestion.source.kind,
-              pageUrl: entryResponse.url,
-              html: entryResponse.body,
-            }).filter((value) => !sampleUrls.has(value));
+            const advertisedFeeds =
+              suggestion.source.kind === "review" && !entryFeed
+                ? findAdvertisedSyndicationPages({
+                    pageUrl: entryResponse.url,
+                    html: entryResponse.body,
+                  })
+                : [];
+            const advertisedFeedSet = new Set(advertisedFeeds);
+            const likelyListPages = [
+              ...advertisedFeeds,
+              ...findLikelyListPages({
+                kind: suggestion.source.kind,
+                pageUrl: entryResponse.url,
+                html: entryResponse.body,
+              }),
+            ]
+              .filter(
+                (value, index, values) =>
+                  !sampleUrls.has(value) && values.indexOf(value) === index,
+              )
+              .slice(0, MAX_LIKELY_LIST_PAGES);
             for (const value of likelyListPages) {
               try {
                 const response = await session.request({
                   target: target.key,
                   url: new URL(value),
                 });
+                const advertisedFeed = advertisedFeedSet.has(value);
+                if (
+                  advertisedFeed &&
+                  !inspectSyndicationFeed({
+                    pageUrl: response.url,
+                    xml: response.body,
+                  })
+                ) {
+                  continue;
+                }
                 listPages.push({
                   url: response.url.toString(),
                   html: response.body,
+                  document: advertisedFeed
+                    ? ("xml" as const)
+                    : ("html" as const),
                 });
               } catch (error) {
                 if (
@@ -523,6 +566,7 @@ export async function resolveScrapeSourceRunRegistry(
               detailPages.push({
                 url: response.url.toString(),
                 html: response.body,
+                document: "html" as const,
               });
             }
             const suppliedDetailUrls = new Set(
@@ -542,6 +586,7 @@ export async function resolveScrapeSourceRunRegistry(
                 detailPages.push({
                   url: response.url.toString(),
                   html: response.body,
+                  document: "html" as const,
                 });
               } catch (error) {
                 if (
@@ -567,6 +612,7 @@ export async function resolveScrapeSourceRunRegistry(
                 return {
                   url: response.url.toString(),
                   html: response.body,
+                  document: "html" as const,
                 };
               },
             });

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -126,6 +126,28 @@ test("keeps links and review facts after a large page header", () => {
   expect(pages[0]!.html).toContain("/* page script */");
 });
 
+test("keeps feed links visible to the setup agent", () => {
+  const [prepared] = preparePagesForSetup([
+    {
+      url: "https://example.test/feed.xml",
+      document: "xml",
+      html: `
+        <rss><channel><item>
+          <title>Latest whisky reviews</title>
+          <link>https://example.test/reviews/latest</link>
+        </item></channel></rss>
+      `,
+    },
+  ]);
+
+  expect(prepared).toMatchObject({
+    document: "xml",
+    url: "https://example.test/feed.xml",
+  });
+  const $ = load(prepared!.html, { xmlMode: true });
+  expect($("item > link").text()).toBe("https://example.test/reviews/latest");
+});
+
 test("returns rules only after the rule check passes", async () => {
   const request = vi
     .fn()
@@ -217,6 +239,9 @@ test("returns rules only after the rule check passes", async () => {
   expect(JSON.stringify(secondRequest?.input)).toContain("North Coast 12");
   expect(secondRequest?.instructions).toContain(
     "Your work is complete only when check_rules accepts the rules.",
+  );
+  expect(secondRequest?.instructions).toContain(
+    "Code shares one article-level reviewer across its reviews.",
   );
 });
 

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -20,7 +20,7 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v20";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v21";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_PAGES_TO_CHECK = 3;
 const MAX_RULE_CHECKS = 3;
@@ -30,7 +30,11 @@ const CHECK_RULES_TOOL_DESCRIPTION =
   "Try a complete set of rules on the given website pages. Rules that pass are ready to save.";
 const SETUP_AGENT_NAME = "Scrape source setup";
 
-export type WebsitePage = { url: string; html: string };
+export type WebsitePage = {
+  url: string;
+  html: string;
+  document?: "html" | "xml";
+};
 
 /** Counts requests needed to find pages and try three sets of rules. */
 export function setupRequestLimit(samplePageCount: number) {
@@ -109,9 +113,12 @@ const RULE_INSTRUCTIONS = [
   "You have at most three checks. Do not answer with an explanation.",
   "</tool>",
   "<success_criteria>",
+  'For reviews, prefer a start page marked document "xml". It is a public RSS, Atom, or RDF feed advertised by the website and already checked for usable same-site article links.',
+  "Use the feed only to find article links. Read review details from the linked HTML pages.",
   "Use short CSS selectors that work on every given page.",
   "For several reviews on one page, select the HTML element around each review. If there is no such element, set item to null; each name then starts a review.",
   "Set the review name to null only when one review's article title is the Bottle name. If the title adds words such as review or tasting notes, select the Bottle name on the page.",
+  "Set reviewer when the page shows an author or byline, including when it appears once for the whole article. Code shares one article-level reviewer across its reviews.",
   "Set tastingNotes only when a narrower selector reliably finds flavor notes. The full review body comes from the review area or item.",
   "Use an optional field only when every given page clearly provides it.",
   "For catalog sources, collect only the displayed name, product URL, stable product ID, image URL, volume, ABV, age, edition, and release year.",
@@ -151,12 +158,16 @@ export function preparePagesForSetup(pages: WebsitePage[]) {
     Math.floor(MAX_AI_INPUT_CHARS / pages.length),
   );
   return pages.map((page) => {
-    const $ = load(page.html);
+    const $ = load(
+      page.html,
+      page.document === "xml" ? { xmlMode: true } : undefined,
+    );
     // Remove page code before shortening the HTML so the useful content remains.
     $("script, style").remove();
     return {
       url: page.url,
       html: $.html().slice(0, charsPerPage),
+      document: page.document ?? "html",
     };
   });
 }

--- a/apps/server/src/scraper/configured/testWebsites.ts
+++ b/apps/server/src/scraper/configured/testWebsites.ts
@@ -5,7 +5,7 @@ import { createServer } from "node:http";
 import { z } from "zod";
 
 export type ReviewWebsite = {
-  key: "decimal" | "stars" | "points";
+  key: "decimal" | "rss" | "stars" | "points";
   name: string;
   pages: Record<string, string>;
   policy: ExternalReviewScoringPolicy | null;
@@ -20,6 +20,44 @@ export type ReviewWebsite = {
 };
 
 export const reviewWebsites: ReviewWebsite[] = [
+  {
+    key: "rss",
+    name: "Whisky Feed",
+    pages: {
+      "/": "index.html",
+      "/feed.xml": "feed.xml",
+      "/reviews": "reviews.html",
+      "/reviews/island-pair": "island-pair.html",
+      "/reviews/hill-malt": "hill-malt.html",
+    },
+    policy: null,
+    reviews: [
+      {
+        name: "Island Malt First Release",
+        reviewerName: "Mara Vale",
+        url: "/reviews/island-pair",
+        publishedAt: "2026-08-22T00:00:00.000Z",
+        nativeScore: { value: 88, scale: 100, display: "88/100" },
+        score: 88,
+      },
+      {
+        name: "Island Malt Loch Edition",
+        reviewerName: "Mara Vale",
+        url: "/reviews/island-pair",
+        publishedAt: "2026-08-22T00:00:00.000Z",
+        nativeScore: { value: 85, scale: 100, display: "85/100" },
+        score: 85,
+      },
+      {
+        name: "Hill Malt 10 Year",
+        reviewerName: "Mara Vale",
+        url: "/reviews/hill-malt",
+        publishedAt: "2026-08-19T00:00:00.000Z",
+        nativeScore: { value: 89, scale: 100, display: "89/100" },
+        score: 89,
+      },
+    ],
+  },
   {
     key: "decimal",
     name: "Malt Journal",
@@ -145,8 +183,14 @@ export async function startReviewWebsite(website: ReviewWebsite) {
       response.writeHead(404).end();
       return;
     }
-    response.setHeader("content-type", "text/html; charset=utf-8");
-    response.end(html);
+    response.setHeader(
+      "content-type",
+      path.endsWith(".xml")
+        ? "application/rss+xml; charset=utf-8"
+        : "text/html; charset=utf-8",
+    );
+    const host = request.headers.host;
+    response.end(host ? html.replaceAll("{{origin}}", `http://${host}`) : html);
   });
   server.listen(0, "127.0.0.1");
   await once(server, "listening");


### PR DESCRIPTION
Review-source setup now discovers same-site RSS, Atom, and RDF feeds advertised through standard alternate metadata, normal links, or image-map areas. It validates that a candidate is a real feed with usable article links, prioritizes it over HTML archives, and preserves the XML document for the setup model while still extracting review details from linked HTML pages.

This covers the pattern used by Whiskyfun without guessing common feed paths. Invalid and cross-site feeds are ignored. Regression coverage includes the exact Whiskyfun homepage shape, all three supported feed formats, rejection cases, priority detail discovery, XML model input, and a live homepage-to-collection model check.
