### PR TITLE
fix(scraper): block non-public network destinations

### DIFF
--- a/apps/server/__fixtures__/scraper-websites/README.md
+++ b/apps/server/__fixtures__/scraper-websites/README.md
@@ -30,9 +30,10 @@ dates, reviewers, original scores, Bottle assignments, totals alongside a
 member score, and repeated collection.
 Multi-review pages retain one shared article byline without mixing bottle scores.
 
-A local HTTP server supplies the website HTML in the real-model suite.
-Model requests go directly to the configured provider without interception;
-the model chooses all parsing rules.
+A local HTTP server supplies the website HTML in the real-model suite. The suite
+intercepts only each fixture's `.example` origin and forwards it to that server.
+Model requests go directly to the configured provider; the model chooses all
+parsing rules.
 All parsing, setup checks, API validation, database writes, and relevant worker
 jobs are real. This suite uses real request timing, Redis queues, BullMQ workers,
 and registered production job handlers. Existing Bottle References keep Bottle

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -69,6 +69,7 @@
     "toad-scheduler": "^3.0.1",
     "tsx": "catalog:",
     "typescript": "catalog:",
+    "undici": "7.22.0",
     "web-bot-auth": "0.2.0",
     "wkx": "^0.5.0",
     "zod": "catalog:"

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -5,8 +5,8 @@ jobs separate:
 
 - definitions list which websites each source may request;
 - runs limit work and save enough progress to resume;
-- coordination and HTTP space requests, retry temporary failures, and enforce
-  limits;
+- coordination spaces requests and enforces limits;
+- HTTP rejects non-public destinations and retries temporary failures;
 - adapters read responses and pass results through the current run.
 
 Code outside this module uses `index.ts` to initialize, queue, or execute a run.
@@ -14,8 +14,9 @@ It must not call adapters, request controls, robots checks, or scraper HTTP code
 directly. The files are split by responsibility:
 
 - `lifecycle.ts` creates runs and sends them to the worker queue;
-- `runs.ts`, `session.ts`, `http.ts`, `robots.ts`, and `coordinator.ts` own core
-  execution without importing production registry or worker infrastructure;
+- `runs.ts`, `session.ts`, `http.ts`, `networkPolicy.ts`, `robots.ts`, and
+  `coordinator.ts` own core execution without importing production registry or
+  worker infrastructure;
 - `registry.ts` lists the built-in sources and request settings;
 - `adapters/legacy/` contains migrated source implementations that still use
   the old helpers in `legacy/`;

--- a/apps/server/src/scraper/configured/createScraper.eval.test.ts
+++ b/apps/server/src/scraper/configured/createScraper.eval.test.ts
@@ -28,6 +28,7 @@ import {
   describe,
   expect,
   test,
+  vi,
 } from "vitest";
 import { AI_INSTRUCTIONS_VERSION } from "./setupAgent";
 import { reviewWebsites, startReviewWebsite } from "./testWebsites";
@@ -93,6 +94,7 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
     afterEach(async () => {
       await workerRuntime?.close();
       workerRuntime = undefined;
+      vi.unstubAllGlobals();
       await fixtureWebsite?.close();
       fixtureWebsite = undefined;
     });
@@ -109,6 +111,7 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         fixtures,
       }) => {
         fixtureWebsite = await startReviewWebsite(website);
+        vi.stubGlobal("fetch", fixtureWebsite.fetchImpl);
         const { origin, requestedPages } = fixtureWebsite;
         const admin = await fixtures.User({ admin: true });
         const context = { context: { user: admin } };

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -17,10 +17,11 @@ import {
   storePrices,
   users,
 } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
 import { eq } from "drizzle-orm";
 import { vi } from "vitest";
 import { createScraperRegistry } from "../definitions";
-import type { ScraperHttpClock } from "../http";
+import { ScraperRequestError, type ScraperHttpClock } from "../http";
 import { executeScraperRun } from "../runs";
 import type { ScrapeRules } from "./rules";
 import {
@@ -127,7 +128,9 @@ function catalogRules() {
   } as const satisfies ScrapeRules;
 }
 
-async function setupCatalogSource() {
+async function setupCatalogSource(
+  websiteUrl = "https://catalog.example/whisky",
+) {
   const [user] = await db
     .insert(users)
     .values({
@@ -140,7 +143,7 @@ async function setupCatalogSource() {
   const { site, source } = await createSiteWithScrapeSource({
     name: "Official Catalog",
     kind: "catalog",
-    websiteUrl: "https://catalog.example/whisky",
+    websiteUrl,
     createdById: user.id,
   });
   const revision = await createScrapeSourceRevision({
@@ -396,6 +399,38 @@ test("resumes a detail page from its redirect", async () => {
     detailUrls: ["https://catalog.example/whisky/release"],
     detailIndex: 1,
   });
+});
+
+test("fails a configured source before requesting a reserved destination", async () => {
+  const { revision, site, source, user } = await setupCatalogSource(
+    "http://127.0.0.1/catalog",
+  );
+  const pinned = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    scrapeSourceId: source.id,
+    revisionId: revision.id,
+    requestedById: user.id,
+    trigger: "manual",
+    purpose: "preview",
+  });
+  const fetchImpl = vi.fn<typeof fetch>();
+
+  const error = await waitError(
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl,
+      executionToken: "reserved-destination-owner",
+    }),
+    ScraperRequestError,
+  );
+  expect(error.category).toBe("invalid_request");
+
+  expect(fetchImpl).not.toHaveBeenCalled();
+  const [run] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, pinned.run.id));
+  expect(run).toMatchObject({ status: "failed", requestCount: 0 });
 });
 
 test("collects and updates only catalog listings", async () => {

--- a/apps/server/src/scraper/configured/testWebsites.ts
+++ b/apps/server/src/scraper/configured/testWebsites.ts
@@ -154,8 +154,9 @@ export const reviewWebsites: ReviewWebsite[] = [
   },
 ];
 
-/** Live model checks serve fixture HTML over HTTP without intercepting model traffic. */
+/** Live model checks intercept only the fixture origin; model traffic uses system fetch. */
 export async function startReviewWebsite(website: ReviewWebsite) {
+  const systemFetch = globalThis.fetch;
   const pages = new Map(
     await Promise.all(
       Object.entries(website.pages).map(
@@ -169,6 +170,7 @@ export async function startReviewWebsite(website: ReviewWebsite) {
   );
   const requestedPages: string[] = [];
   const missingPages: string[] = [];
+  const origin = `http://${website.key}.reviews.example`;
   const server = createServer((request, response) => {
     const path = request.url ?? "/";
     requestedPages.push(path);
@@ -189,16 +191,25 @@ export async function startReviewWebsite(website: ReviewWebsite) {
         ? "application/rss+xml; charset=utf-8"
         : "text/html; charset=utf-8",
     );
-    const host = request.headers.host;
-    response.end(host ? html.replaceAll("{{origin}}", `http://${host}`) : html);
+    response.end(html.replaceAll("{{origin}}", origin));
   });
   server.listen(0, "127.0.0.1");
   await once(server, "listening");
   const address = z
     .object({ port: z.number().int().positive() })
     .parse(server.address());
+  const localOrigin = `http://127.0.0.1:${address.port}`;
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.origin !== origin) return await systemFetch(input, init);
+    return await systemFetch(
+      new URL(`${url.pathname}${url.search}`, localOrigin),
+      init,
+    );
+  };
   return {
-    origin: `http://127.0.0.1:${address.port}`,
+    origin,
+    fetchImpl,
     requestedPages,
     async close() {
       server.closeAllConnections();

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -26,6 +26,7 @@ import {
   type ScraperHttpClock,
   type ScraperHttpStatusError,
 } from "./http";
+import { ScraperNetworkPolicyError } from "./networkPolicy";
 import { syncScraperDefinitions } from "./syncDefinitions";
 
 const adapter = async () => {};
@@ -419,6 +420,61 @@ test("returns the redirect URL when saved work must wait", async () => {
     reason: "target_spacing",
     resumeUrl: new URL("https://example.com/final"),
   });
+  expect(fetchImpl).toHaveBeenCalledOnce();
+});
+
+test("rejects a redirect to a reserved literal address before contact", async () => {
+  const { registry, run } = await setupRuntime({
+    origins: ["https://example.com", "http://127.0.0.1"],
+  });
+  const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
+    new Response(null, {
+      status: 302,
+      headers: { location: "http://127.0.0.1/metadata" },
+    }),
+  );
+
+  const error = await waitError(
+    requestScraperUrl({
+      runId: run.id,
+      sourceKey: "finedrams",
+      request: {
+        target: "operator",
+        url: new URL("https://example.com/start"),
+      },
+      registry,
+      fetchImpl,
+      clock: clockAt(),
+    }),
+    ScraperRequestError,
+  );
+  expect(error.category).toBe("invalid_request");
+  expect(fetchImpl).toHaveBeenCalledOnce();
+});
+
+test("does not retry a DNS result rejected by the network policy", async () => {
+  const { registry, run } = await setupRuntime();
+  const fetchImpl = vi.fn<typeof fetch>().mockRejectedValue(
+    new TypeError("fetch failed", {
+      cause: new ScraperNetworkPolicyError(),
+    }),
+  );
+
+  const error = await waitError(
+    requestScraperUrl({
+      runId: run.id,
+      sourceKey: "finedrams",
+      request: {
+        target: "operator",
+        url: new URL("https://example.com/catalog"),
+      },
+      registry,
+      fetchImpl,
+      clock: clockAt(),
+    }),
+    ScraperRequestError,
+  );
+  expect(error.category).toBe("invalid_request");
   expect(fetchImpl).toHaveBeenCalledOnce();
 });
 

--- a/apps/server/src/scraper/http.ts
+++ b/apps/server/src/scraper/http.ts
@@ -7,6 +7,11 @@ import {
   releaseScrapePermit,
 } from "./coordinator";
 import { resolveScraperOrigin } from "./definitions";
+import {
+  fetchScraperUrl,
+  hasBlockedScraperLiteralAddress,
+  isScraperNetworkPolicyError,
+} from "./networkPolicy";
 import { signScraperRequest } from "./signing";
 import type { ScraperRegistry, ScraperRequest, ScraperResponse } from "./types";
 
@@ -170,6 +175,7 @@ function transientStatus(status: number) {
 }
 
 function transportCategory(error: Error): ScraperRequestErrorCategory {
+  if (isScraperNetworkPolicyError(error)) return "invalid_request";
   if (
     error instanceof DOMException &&
     (error.name === "AbortError" || error.name === "TimeoutError")
@@ -259,7 +265,7 @@ export async function requestScraperUrl({
   request,
   registry,
   checkRedirect,
-  fetchImpl = fetch,
+  fetchImpl = fetchScraperUrl,
   clock = scraperSystemClock,
 }: {
   runId: number;
@@ -301,6 +307,9 @@ export async function requestScraperUrl({
 
   for (let redirect = 0; redirect <= MAX_REDIRECTS; redirect += 1) {
     resolveScraperOrigin(registry, sourceKey, request.target, currentUrl);
+    if (hasBlockedScraperLiteralAddress(currentUrl)) {
+      throw new ScraperRequestError("invalid_request");
+    }
     if (
       currentUrl.origin !== initialOrigin &&
       (hasTargetSpecificHeaders || method !== "GET")
@@ -362,7 +371,11 @@ export async function requestScraperUrl({
           now: clock.now(),
         });
         await recordScrapeRequestError({ runId, executionToken });
+        const category = transportCategory(
+          error instanceof Error ? error : new Error(),
+        );
         const canRetry =
+          category !== "invalid_request" &&
           retry < permit.maxRetries &&
           (method === "GET" || request.retryable === true);
         if (canRetry && permit.remainingRequests <= 0) {
@@ -373,9 +386,7 @@ export async function requestScraperUrl({
           await clock.sleep(retryDelay(retry, clock.random()));
           continue;
         }
-        throw new ScraperRequestError(
-          transportCategory(error instanceof Error ? error : new Error()),
-        );
+        throw new ScraperRequestError(category);
       }
 
       const retryAfter = parseRetryAfter(

--- a/apps/server/src/scraper/networkPolicy.test.ts
+++ b/apps/server/src/scraper/networkPolicy.test.ts
@@ -1,0 +1,91 @@
+import waitError from "@peated/server/lib/test/waitError";
+import type { LookupFunction } from "node:net";
+import { vi } from "vitest";
+import {
+  createPublicAddressLookup,
+  hasBlockedScraperLiteralAddress,
+  isPublicScraperAddress,
+  ScraperNetworkPolicyError,
+} from "./networkPolicy";
+
+test.each([
+  "0.0.0.0",
+  "10.1.2.3",
+  "100.100.100.200",
+  "127.0.0.1",
+  "168.63.129.16",
+  "169.254.169.254",
+  "172.31.2.3",
+  "192.168.1.1",
+  "224.0.0.1",
+  "255.255.255.255",
+  "::",
+  "::1",
+  "::ffff:127.0.0.1",
+  "fc00::1",
+  "fd00:ec2::254",
+  "fe80::1",
+  "ff02::1",
+])("rejects the non-public or reserved address %s", (address) => {
+  expect(isPublicScraperAddress(address)).toBe(false);
+});
+
+test.each([
+  "8.8.8.8",
+  "93.184.216.34",
+  "192.0.0.9",
+  "2001:4860:4860::8888",
+  "2606:2800:220:1:248:1893:25c8:1946",
+])("allows the public address %s", (address) => {
+  expect(isPublicScraperAddress(address)).toBe(true);
+});
+
+test.each([
+  "http://127.0.0.1/metadata",
+  "http://2130706433/metadata",
+  "http://[::1]/metadata",
+])("rejects the reserved literal URL %s", (url) => {
+  expect(hasBlockedScraperLiteralAddress(new URL(url))).toBe(true);
+});
+
+function lookupResults(
+  results: Array<{ address: string; family: 4 | 6 }>,
+): LookupFunction {
+  return vi.fn((_hostname, _options, callback) => {
+    callback(null, results);
+  });
+}
+
+function runLookup(lookup: LookupFunction) {
+  return new Promise<void>((resolve, reject) => {
+    lookup("publisher.example", { all: true }, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+test("allows DNS only when every address returned to the socket is public", async () => {
+  await expect(
+    runLookup(
+      createPublicAddressLookup(
+        lookupResults([
+          { address: "93.184.216.34", family: 4 },
+          { address: "2606:2800:220:1:248:1893:25c8:1946", family: 6 },
+        ]),
+      ),
+    ),
+  ).resolves.toBeUndefined();
+
+  await waitError(
+    runLookup(
+      createPublicAddressLookup(
+        lookupResults([
+          { address: "93.184.216.34", family: 4 },
+          { address: "127.0.0.1", family: 4 },
+        ]),
+      ),
+    ),
+    ScraperNetworkPolicyError,
+  );
+});

--- a/apps/server/src/scraper/networkPolicy.ts
+++ b/apps/server/src/scraper/networkPolicy.ts
@@ -1,0 +1,141 @@
+import { lookup as systemLookup } from "node:dns";
+import { BlockList, isIP, type LookupFunction } from "node:net";
+import { Agent } from "undici";
+
+const blockedAddresses = new BlockList();
+
+for (const [network, prefix] of [
+  ["0.0.0.0", 8],
+  ["10.0.0.0", 8],
+  ["100.64.0.0", 10],
+  ["127.0.0.0", 8],
+  ["169.254.0.0", 16],
+  ["172.16.0.0", 12],
+  ["192.0.0.0", 24],
+  ["192.0.2.0", 24],
+  ["192.88.99.0", 24],
+  ["192.168.0.0", 16],
+  ["198.18.0.0", 15],
+  ["198.51.100.0", 24],
+  ["203.0.113.0", 24],
+  ["224.0.0.0", 4],
+  ["240.0.0.0", 4],
+] as const) {
+  blockedAddresses.addSubnet(network, prefix, "ipv4");
+}
+
+for (const [network, prefix] of [
+  ["::", 128],
+  ["::1", 128],
+  ["64:ff9b::", 96],
+  ["64:ff9b:1::", 48],
+  ["100::", 64],
+  ["100:0:0:1::", 64],
+  ["2001::", 32],
+  ["2001:2::", 48],
+  ["2001:10::", 28],
+  ["2001:db8::", 32],
+  ["2002::", 16],
+  ["3fff::", 20],
+  ["5f00::", 16],
+  ["fc00::", 7],
+  ["fe80::", 10],
+  ["ff00::", 8],
+] as const) {
+  blockedAddresses.addSubnet(network, prefix, "ipv6");
+}
+
+// Crawler HTTP treats Azure's host-local platform address as metadata, even
+// though Azure assigns it from public IPv4 space.
+blockedAddresses.addAddress("168.63.129.16", "ipv4");
+
+const publicProtocolAddresses = new BlockList();
+for (const address of ["192.0.0.9", "192.0.0.10"] as const) {
+  publicProtocolAddresses.addAddress(address, "ipv4");
+}
+
+const publicIpv6Addresses = new BlockList();
+publicIpv6Addresses.addSubnet("2000::", 3, "ipv6");
+
+export class ScraperNetworkPolicyError extends Error {
+  override name = "ScraperNetworkPolicyError";
+
+  constructor() {
+    super("Scraper requests require a public network destination.");
+  }
+}
+
+export function isPublicScraperAddress(address: string) {
+  const family = isIP(address);
+  if (family === 4) {
+    if (publicProtocolAddresses.check(address, "ipv4")) return true;
+    return !blockedAddresses.check(address, "ipv4");
+  }
+  if (family === 6) {
+    return (
+      publicIpv6Addresses.check(address, "ipv6") &&
+      !blockedAddresses.check(address, "ipv6")
+    );
+  }
+  return false;
+}
+
+export function hasBlockedScraperLiteralAddress(url: URL) {
+  const hostname = url.hostname.replace(/^\[|\]$/g, "");
+  return isIP(hostname) !== 0 && !isPublicScraperAddress(hostname);
+}
+
+/** Validates every DNS result before the socket can select an address. */
+export function createPublicAddressLookup(
+  lookupImpl: LookupFunction = systemLookup,
+): LookupFunction {
+  return (hostname, options, callback) => {
+    lookupImpl(hostname, options, (error, address, family) => {
+      if (error) {
+        callback(error, address, family);
+        return;
+      }
+      const results = Array.isArray(address)
+        ? address
+        : [{ address, family: family ?? isIP(address) }];
+      if (
+        results.length === 0 ||
+        results.some((result) => !isPublicScraperAddress(result.address))
+      ) {
+        callback(new ScraperNetworkPolicyError(), address, family);
+        return;
+      }
+      callback(null, address, family);
+    });
+  };
+}
+
+/** Checks an error's cause chain for a crawler network rejection. */
+export function isScraperNetworkPolicyError(error: Error) {
+  let current: Error | undefined = error;
+  const visited = new Set<Error>();
+  while (current && !visited.has(current)) {
+    if (current instanceof ScraperNetworkPolicyError) return true;
+    visited.add(current);
+    current = current.cause instanceof Error ? current.cause : undefined;
+  }
+  return false;
+}
+
+// Crawler transport owns the public-destination rule: every new socket checks
+// the DNS result it will use, including sockets opened after redirects.
+const scraperDispatcher = new Agent({
+  autoSelectFamily: true,
+  connect: { lookup: createPublicAddressLookup() },
+});
+
+/** Fetches through the crawler-owned dispatcher that validates socket addresses. */
+export const fetchScraperUrl: typeof fetch = async (input, init) => {
+  const requestInit: RequestInit = {
+    ...init,
+  };
+  // Node fetch accepts Undici's dispatcher at runtime, but Node and the direct
+  // dependency expose separate copies of its type.
+  Object.assign(requestInit, { dispatcher: scraperDispatcher });
+  return fetch(input, requestInit);
+};

--- a/apps/server/src/scraper/robots.ts
+++ b/apps/server/src/scraper/robots.ts
@@ -158,7 +158,7 @@ export async function ensureRobotsAllowed({
   url,
   canResumeLater,
   registry,
-  fetchImpl = fetch,
+  fetchImpl,
   clock,
 }: {
   runId: number;

--- a/apps/server/src/scraper/runs.ts
+++ b/apps/server/src/scraper/runs.ts
@@ -290,7 +290,7 @@ export async function executeScraperRun(
   input: ScraperRunPayload,
   {
     registry,
-    fetchImpl = fetch,
+    fetchImpl,
     clock = scraperSystemClock,
     executionToken = randomUUID(),
   }: {

--- a/apps/server/src/scraper/session.ts
+++ b/apps/server/src/scraper/session.ts
@@ -39,7 +39,7 @@ export function createScraperSession<TCursor, TObservation>({
   source,
   registry,
   executionToken,
-  fetchImpl = fetch,
+  fetchImpl,
   clock = scraperSystemClock,
 }: {
   run: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      undici:
+        specifier: 7.22.0
+        version: 7.22.0
       web-bot-auth:
         specifier: 0.2.0
         version: 0.2.0


### PR DESCRIPTION
Dynamic crawler requests now reject literal or resolved IPv4 and IPv6 destinations that are not public. The check runs in the shared HTTP transport for configured URLs, discovered links, redirects, and robots requests; existing origin and target checks remain unchanged. Policy failures use the existing `invalid_request` result and are not retried.

DNS results are checked when each socket connects, which closes the setup-time DNS rebinding gap. Mixed public and non-public results fail closed instead of allowing the transport to select an unsafe address.

Live scraper eval fixtures now use `.example` origins and intercept only fixture-site fetches. This keeps the real queued crawler lifecycle covered without allowing production loopback requests or intercepting model-provider traffic.

Fixes #1192.
