### PR TITLE
docs(catalog): finish Brora audit

### DIFF
--- a/docs/research/catalog/2026-09-07-brora.md
+++ b/docs/research/catalog/2026-09-07-brora.md
@@ -449,15 +449,18 @@ even though the original site was later renamed Brora.
   [Rare Old cask RO/15/01](https://www.whiskybase.com/whiskies/whisky/70325/brora-1982-gm).
   The 2000 Connoisseurs Choice B52288 was repaired with its stated coloring and
   chill-filtration facts. Production now also has B55805, B55809, B55810,
-  B55812, B55813, B55814, and B55930 through B55938, all with Gordon & MacPhail
-  as Brand and bottler and Brora as distiller. B55930 through B55934 complete
-  the 1993 through 1997 Connoisseurs Choice sequence after the deployed exact
-  identity guard began comparing bottling year. B55935 is the undated 1972
-  Spirit of Scotland release; B55936 and B55938 are the 1997 and 2002 1982
-  Connoisseurs Choice releases; and B55937 is the 1999 Spirit of Scotland
-  release. Rare Old S0807 and Reserve S0808 were created; the existing
-  Connoisseurs Choice S0097 and Spirit of Scotland S0299 were reused. Their
-  verified release counts are 35 and six respectively.
+  B55812, B55813, B55814, B55930 through B55938, B55986, and B55988, all with
+  Gordon & MacPhail as Brand and bottler and Brora as distiller. B55930 through
+  B55934 complete the 1993 through 1997 Connoisseurs Choice sequence after the
+  deployed exact identity guard began comparing bottling year. B55935 is the
+  undated 1972 Spirit of Scotland release; B55936 and B55938 are the 1997 and
+  2002 1982 Connoisseurs Choice releases; and B55937 is the 1999 Spirit of
+  Scotland release. Rare Old S0807 and Reserve S0808 were created; the existing
+  Connoisseurs Choice S0097 and Spirit of Scotland S0299 were reused. B55986 is
+  the 1972 Rare Old release bottled in 1997, and B55988 is the 1982 Spirit of
+  Scotland release bottled in 1997. They became representable after the exact
+  identity guard began comparing Series. Verified release counts are 35 for
+  Connoisseurs Choice, seven for Spirit of Scotland, and three for Rare Old.
   The 2006 Connoisseurs Choice is a distinct liquid release even though the
   main inventory hides it as a version. A
   [50 ml compilation](https://www.whiskybase.com/whiskies/whisky/158447/brora-1972-gm),
@@ -466,15 +469,13 @@ even though the original site was later renamed Brora.
   and [1995](https://www.whiskybase.com/whiskies/whisky/192093/brora-1972-gm),
   and the [750 ml version](https://www.whiskybase.com/whiskies/whisky/125947/brora-1978-gm)
   of the same RO/13/05 cask were excluded because package size or market label
-  alone does not establish a different liquid. Two of the 18 supported
-  identities remain unwritten: the 1972 Rare Old release and the 1997 1982
-  Spirit of Scotland release. Each has the same stored exact fields as that
-  year's Connoisseurs Choice release and differs by Bottle Series, which the
-  exact identity guard intentionally does not compare. No invented edition or
-  release date was used to bypass that limit. A second
+  alone does not establish a different liquid. All 18 supported identities are
+  now represented. No invented edition or release date was used to distinguish
+  them. A second
   exact-label audit checked auction records and the
   [Brora bottling index](https://www.whiskyfun.com/Brora-Index.html). It found
-  no stated cask numbers or release dates for the two blocked identities.
+  no additional stated cask numbers or release dates for the same-title
+  identities.
   Codes such as `IG/ABC`, `JJ/BFI`, `II/BJF`, and `JF/CD` are bottle or label
   codes, not cask numbers, so they were not repurposed as identity fields.
   Distillation and bottling months on later labels likewise do not establish a
@@ -504,12 +505,12 @@ even though the original site was later renamed Brora.
   30 The Old Malt Cask, one Selected by The Whisky Shop, and one Premier Barrel
   Selection. Production now has all 12 Old & Rare releases as B55828 through
   B55839, using the existing Old & Rare Brand E366645 and Platinum Selection
-  S0488 with Douglas Laing as historical bottler. It has 27 representable Old
+  S0488 with Douglas Laing as historical bottler. It has all 30 Old
   Malt Cask releases as B55844 through B55858, B55861 through B55865, B55867,
-  B55868 through B55872, and B55939, using The Old Malt Cask Brand E366649 and
-  Douglas Laing as bottler. The existing Douglas Laing-owned Old Malt Cask
-  Series S0357 was not used because the stored Brand already represents that
-  product line.
+  B55868 through B55872, B55939, and B55989 through B55991, using The Old Malt
+  Cask Brand E366649 and Douglas Laing as bottler. The existing Douglas
+  Laing-owned Old Malt Cask Series S0357 was not used because the stored Brand
+  already represents that product line.
   Brorageddon is the edition on B55849, and the two Final Vintage releases are
   editions B55869 and B55870. The one-off 1972 Selected by The Whisky Shop is
   B55873, and the yearless 23-year-old Premier Barrel is B55874 under S0105.
@@ -528,20 +529,19 @@ even though the original site was later renamed Brora.
   Three 200 ml advance samples and one 50 ml miniature were excluded. B55939 is
   the 1981 18-year-old sherry-cask release bottled in July 2000 with a
   732-bottle outturn. Its distinct bottling year became representable after the
-  deployed exact identity guard began comparing that field. Three supported
-  full-size Old Malt Cask identities remain unwritten because outturn remains
-  outside exact identity comparison. The blocked releases are the
+  deployed exact identity guard began comparing that field. B55989 is the
   [1971/29-year/285-bottle release](https://www.whiskybase.com/whiskies/whisky/207823/brora-1971-dl),
-  the [1981/18-year/291-bottle release](https://www.whiskybase.com/whiskies/whisky/46227/brora-1981-dl),
-  and the [1982/19-year/732-bottle release](https://www.whiskybase.com/whiskies/whisky/13710/brora-1982-dl).
+  B55990 is the [1981/18-year/291-bottle release](https://www.whiskybase.com/whiskies/whisky/46227/brora-1981-dl),
+  and B55991 is the [1982/19-year/732-bottle release](https://www.whiskybase.com/whiskies/whisky/13710/brora-1982-dl).
+  They became representable after the exact identity guard began comparing
+  stated outturn.
   A second audit of exact auction and retailer records confirmed bottling
   months for these releases—March 2000 for the 1971 release, July 1999 for the
-  1981 release, and April 2001 for the 1982 release—but found no genuine cask
-  number or marketed release date that distinguishes them under the current
-  identity comparison. Distillation/bottling codes such as `D11/'82 B11/'01`
-  describe dates, not casks. No false edition, release date, or cask number was
-  added to bypass the conflicts. Useful source images did not state reusable
-  rights, so none were copied.
+  1981 release, and April 2001 for the 1982 release. Those bottling months were
+  not converted to marketed release dates. Distillation/bottling codes such as
+  `D11/'82 B11/'01` describe dates, not casks. No false edition, release date,
+  or cask number was added. Useful source images did not state reusable rights,
+  so none were copied.
 - Silver Seal's three rows in the
   [Brora distillery inventory](https://www.whiskybase.com/whiskies/distillery/106/whiskies)
   and exact records establish three full-size releases: the 1982 19-year-old
@@ -609,9 +609,9 @@ even though the original site was later renamed Brora.
   release; B49740's 1974/20-year/57.5% combination likewise has no exact Brora
   release evidence. B17620 has a generic 30-year review that could belong to
   the 2003, 2006, or 2007 55.7% annual release and remains unresolved.
-- The final production inventory query returns 235 Bottles linked to Brora as
+- The final production inventory query returns 240 Bottles linked to Brora as
   distiller across 33 Brands. The initial three-page verification found 225
-  unique Bottle IDs; all ten later creates were fetched individually and
+  unique Bottle IDs; all 15 later creates were fetched individually and
   verified for Brand, bottler, distiller, Series, category, and exact facts.
   Every result is a single malt, has a Brand, retains Brora as distiller, and
   has no repeated identity across the exact fields compared by the production
@@ -644,17 +644,15 @@ even though the original site was later renamed Brora.
   the Highlands Series were created, completing its six-release Brora family.
   Thirty-eight Signatory-associated releases and five Signatory Vintage Series
   were created separately, including one Prestonfield-branded release. One
-  existing Gordon & MacPhail release was repaired, fifteen were created with
-  two new Series, and two more researched identities remain blocked by the
-  production duplicate guard. Three McGibbon's Provenance releases were
+  existing Gordon & MacPhail release was repaired, and seventeen were created
+  with two new Series. Three McGibbon's Provenance releases were
   created using the existing Douglas Laing-owned Series and the historical
-  Douglas McGibbon bottler relationship. Forty-one additional Douglas
+  Douglas McGibbon bottler relationship. Forty-four additional Douglas
   Laing-associated releases were created across Old & Rare, The Old Malt Cask,
-  Selected by The Whisky Shop, and Premier Barrel; three more remain blocked by
-  the same duplicate-guard limitation. Three Silver Seal releases and all 23
-  historical Scotch Malt Whisky Society releases were created. The Whisky
-  Exchange Fine Old Rare name was added as an alias to the existing Whisky Show
-  2011 Bottle instead of creating a duplicate.
+  Selected by The Whisky Shop, and Premier Barrel. Three Silver Seal releases
+  and all 23 historical Scotch Malt Whisky Society releases were created. The
+  Whisky Exchange Fine Old Rare name was added as an alias to the existing
+  Whisky Show 2011 Bottle instead of creating a duplicate.
   The Brora Entity already had a licensed Wikimedia Commons image and complete
   ownership, location, and history fields. Existing Bottle images have no
   stored source or license, and useful producer, retailer, review, and auction


### PR DESCRIPTION
The Brora catalog audit now records the five releases created after Series and outturn became part of exact duplicate detection. Production has 240 Brora Bottles: all 18 supported Gordon & MacPhail identities and all 30 Old Malt Cask identities are represented.

The final read-back verified each new Bottle’s relationships, Series, category, and exact facts. It also records that no invented identity fields, unsupported images, aliases, or import references were added.
