### PR TITLE
fix(scraper): unblock version 10 migrations

### DIFF
--- a/apps/cli/src/commands/scrapers.ts
+++ b/apps/cli/src/commands/scrapers.ts
@@ -41,7 +41,7 @@ const subcommand = program
 subcommand
   .command("preview")
   .description("Preview saved parsing rules without writing products")
-  .requiredOption("--site <key>", "Existing code-owned external site key")
+  .requiredOption("--site <key>", "Site key for the local preview")
   .requiredOption("--input <file>", "JSON file containing listUrl and rules")
   .option(
     "--limit <count>",

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -89,10 +89,12 @@ stay on the source website. Code reads at most five list pages and stops at
 Fields on an article or product page are CSS selectors too. Code reads text by
 default. It reads `href` from links, `src` from images, `datetime` from dates,
 `content` from meta tags, and `value` from form fields. It also trims spaces,
-makes full URLs, and reads prices, scores, dates, and volumes. A price source
-can use a number of milliliters as a fixed volume. Rules do not contain cleanup
-steps or text templates. Put unusual cleanup for one source in a small named
-function.
+makes full URLs, and reads prices, scores, dates, volumes, strength, ages, and
+release years. A selector may match a short group of facts; code finds values
+beside familiar labels such as `70cl`, `46% ABV`, `10 Year Old`, and `91 points`.
+A price source can use a number of milliliters as a fixed volume. Rules do not
+contain cleanup steps or text templates. Put unusual cleanup for one source in
+a small named function.
 
 For reviews, `detail.reviews.area` selects the one area containing the review
 text. Set `item` to the HTML element around each review. When reviews have no
@@ -172,7 +174,8 @@ pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 
 
 The input has the same `listUrl` and `rules` fields accepted by the API. Set
 `rulesVersion` to `10` for new rules. An omitted version means version 1 so
-existing preview files keep their original behavior:
+existing preview files keep their original behavior. If the site exists only
+in production, the command creates the local records needed for the preview:
 
 ```json
 {

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -122,6 +122,145 @@ it("reports an invalid list selector", () => {
   });
 });
 
+it("reads common Bottle facts from surrounding text", () => {
+  const rules = {
+    kind: "catalog",
+    list: { links: "a.product", nextPage: null, limit: 10 },
+    detail: {
+      name: "h1",
+      url: null,
+      id: null,
+      image: null,
+      volume: ".facts",
+      abv: ".facts",
+      age: ".facts",
+      edition: null,
+      year: ".release",
+    },
+  } satisfies ScrapeRules;
+
+  expect(
+    parseScrapeDetail(
+      rules,
+      `<h1>Example 2012</h1>
+       <p class="facts">Distilled in 2012</p>
+       <p class="facts">10 Year Old</p>
+       <p class="facts">46.3% ABV</p>
+       <p class="facts">70cl</p>
+       <p class="release">Released in 2024</p>`,
+      new URL("https://example.test/whisky/one"),
+    ),
+  ).toMatchObject({
+    kind: "catalog",
+    issues: [],
+    value: [
+      {
+        volume: 700,
+        sourceBottleIdentity: {
+          stated_age: 10,
+          abv: 46.3,
+          release_year: 2024,
+        },
+      },
+    ],
+  });
+});
+
+it("does not use an unrelated fact as the stated age", () => {
+  const rules = {
+    kind: "catalog",
+    list: { links: "a.product", nextPage: null, limit: 10 },
+    detail: {
+      name: "h1",
+      url: null,
+      id: null,
+      image: null,
+      volume: null,
+      abv: ".facts",
+      age: ".facts",
+      edition: null,
+      year: null,
+    },
+  } satisfies ScrapeRules;
+
+  expect(
+    parseScrapeDetail(
+      rules,
+      '<h1>Example Whisky</h1><p class="facts">64.1% ABV</p>',
+      new URL("https://example.test/whisky/one"),
+    ),
+  ).toMatchObject({
+    kind: "catalog",
+    issues: [],
+    value: [
+      {
+        sourceBottleIdentity: {
+          stated_age: null,
+          abv: 64.1,
+        },
+      },
+    ],
+  });
+});
+
+it("removes a displayed price from a product name", () => {
+  const rules = {
+    kind: "price",
+    list: { links: "a.product", nextPage: null, limit: 10 },
+    detail: {
+      name: "h1",
+      url: null,
+      id: null,
+      image: null,
+      volume: 700,
+      price: ".price",
+      currency: "gbp",
+      barcode: null,
+    },
+  } satisfies ScrapeRules;
+
+  expect(
+    parseScrapeDetail(
+      rules,
+      '<h1>Island Malt, 18 Years Old – £75.00</h1><p class="price">£62.50</p>',
+      new URL("https://example.test/whisky/one"),
+    ),
+  ).toMatchObject({
+    kind: "price",
+    issues: [],
+    value: [{ name: "Island Malt, 18 Years Old", price: 6250 }],
+  });
+});
+
+it("reads a product ID from an element ID", () => {
+  const rules = {
+    kind: "price",
+    list: { links: "a.product", nextPage: null, limit: 10 },
+    detail: {
+      name: "h1",
+      url: null,
+      id: "div.product",
+      image: null,
+      volume: 700,
+      price: ".price",
+      currency: "gbp",
+      barcode: null,
+    },
+  } satisfies ScrapeRules;
+
+  expect(
+    parseScrapeDetail(
+      rules,
+      '<div class="product" id="product-21952"><h1>Island Malt</h1><p class="price">£62.50</p></div>',
+      new URL("https://example.test/whisky/one"),
+    ),
+  ).toMatchObject({
+    kind: "price",
+    issues: [],
+    value: [{ externalProductId: "21952" }],
+  });
+});
+
 it("splits unwrapped reviews at their name selectors", () => {
   const rules = {
     kind: "review",
@@ -217,6 +356,46 @@ it("uses an article writer for each wrapped review", () => {
   });
 });
 
+it("uses an article Bottle name for one wrapped review", () => {
+  const rules = {
+    kind: "review",
+    list: { links: "a.review", nextPage: null, limit: 10 },
+    detail: {
+      url: null,
+      title: "h1.article-title",
+      date: null,
+      reviews: {
+        area: "article",
+        item: "section.review",
+        name: "h1.bottle-name",
+        reviewer: null,
+        tastingNotes: null,
+        score: null,
+      },
+    },
+  } satisfies ScrapeRules;
+  const result = parseScrapeDetail(
+    rules,
+    `<article><h1 class="article-title">Full Circle</h1>
+      <h1 class="bottle-name">Bladnoch 10 Year Old</h1>
+      <time datetime="2026-08-22"></time>
+      <section class="review"><p>The review body.</p></section>
+    </article>`,
+    new URL("https://reviews.example/full-circle"),
+  );
+
+  expect(result).toMatchObject({
+    kind: "review",
+    issues: [],
+    value: {
+      article: {
+        title: "Full Circle",
+        externalReviews: [{ name: "Bladnoch 10 Year Old" }],
+      },
+    },
+  });
+});
+
 it("removes a trailing review label from a single article title", () => {
   const rules = {
     kind: "review",
@@ -252,6 +431,51 @@ it("removes a trailing review label from a single article title", () => {
         title: "Orchard Bourbon review",
         externalReviews: [
           { name: "Orchard Bourbon", reviewerName: "Jon Bell" },
+        ],
+      },
+    },
+  });
+});
+
+it("cleans common review labels without extra rules", () => {
+  const rules = {
+    kind: "review",
+    list: { links: "a.review", nextPage: null, limit: 10 },
+    detail: {
+      url: null,
+      title: "h1",
+      date: null,
+      reviews: {
+        area: "article",
+        item: null,
+        name: null,
+        reviewer: ".author",
+        tastingNotes: null,
+        score: { selector: ".score", outOf: 100 },
+      },
+    },
+  } satisfies ScrapeRules;
+  const result = parseScrapeDetail(
+    rules,
+    `<article><h1>Orchard Bourbon Shelf Review</h1>
+      <time datetime="2026-08-21"></time>
+      <span class="author">By Jon Bell</span>
+      <b class="score">SGP: 551 - 91 points</b>
+    </article>`,
+    new URL("https://reviews.example/orchard-bourbon"),
+  );
+
+  expect(result).toMatchObject({
+    kind: "review",
+    issues: [],
+    value: {
+      article: {
+        externalReviews: [
+          {
+            name: "Orchard Bourbon",
+            reviewerName: "Jon Bell",
+            nativeScore: { value: 91, scale: 100 },
+          },
         ],
       },
     },

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -635,6 +635,21 @@ function parseNumber(value: string | null) {
   return Number.isFinite(number) ? number : null;
 }
 
+function parseScore(value: string | null) {
+  if (!value) return null;
+  const labeled = value
+    .replaceAll(",", "")
+    .match(/(-?\d+(?:\.\d+)?)\s*(?:points?\b|\/\s*\d+)/iu);
+  return labeled ? Number(labeled[1]) : parseNumber(value);
+}
+
+function parsePlainNumber(value: string) {
+  const normalized = value.trim().replaceAll(",", "");
+  if (!/^-?\d+(?:\.\d+)?$/u.test(normalized)) return null;
+  const number = Number(normalized);
+  return Number.isFinite(number) ? number : null;
+}
+
 function parsePriceInSmallestUnit(value: string | null) {
   const number = parseNumber(value);
   if (number === null || number <= 0) return null;
@@ -658,13 +673,34 @@ function parseDisplayedPrice(value: string | null) {
 function parseVolume(value: string | null) {
   if (!value) return null;
   const normalized = value.toLowerCase().replaceAll(",", "");
-  const number = parseNumber(normalized);
+  const amount = normalized.match(/(-?\d+(?:\.\d+)?)\s*(ml|cl|l)(?:\b|$)/u);
+  const number = amount ? Number(amount[1]) : parsePlainNumber(normalized);
   if (number === null || number <= 0) return null;
-  if (normalized.includes("cl")) return Math.round(number * 10);
-  if (/(?:^|[^a-z])l(?:[^a-z]|$)/.test(normalized)) {
-    return Math.round(number * 1000);
-  }
+  if (amount?.[2] === "cl") return Math.round(number * 10);
+  if (amount?.[2] === "l") return Math.round(number * 1000);
   return Math.round(number);
+}
+
+function parseAbv(value: string | null) {
+  if (!value) return null;
+  const match = value.match(
+    /(?:\b(?:abv|alcohol)\s*:?\s*)?(\d+(?:\.\d+)?)\s*%(?:\s*(?:abv|vol(?:ume)?))?/iu,
+  );
+  return match ? Number(match[1]) : parsePlainNumber(value);
+}
+
+function parseStatedAge(value: string | null) {
+  if (!value) return null;
+  const match = value.match(
+    /(\d+(?:\.\d+)?)\s*(?:years?\s*old|y\.?\s*o\.?)\b/iu,
+  );
+  return match ? Number(match[1]) : parsePlainNumber(value);
+}
+
+function parseReleaseYear(value: string | null) {
+  if (!value) return null;
+  const match = value.match(/\b(?:19|20)\d{2}\b/u);
+  return match ? Number(match[0]) : parsePlainNumber(value);
 }
 
 function validationIssues(
@@ -1458,11 +1494,15 @@ function readElement(
   selected: ReturnType<ReturnType<typeof load>>,
   kind: PageValueKind,
 ) {
-  return (
-    PAGE_VALUE_ATTRIBUTES[kind]
-      .map((attribute) => normalizeValue(selected.attr(attribute)))
-      .find(Boolean) ?? normalizeValue(readText(selected))
-  );
+  const attributeValue = PAGE_VALUE_ATTRIBUTES[kind]
+    .map((attribute) => normalizeValue(selected.attr(attribute)))
+    .find(Boolean);
+  if (attributeValue) return attributeValue;
+  if (kind === "id") {
+    const id = normalizeValue(selected.attr("id"));
+    if (id) return id.replace(/^product-/iu, "");
+  }
+  return normalizeValue(readText(selected));
 }
 
 function readSelectedValue(
@@ -1504,7 +1544,11 @@ function readArticleReviewValue(
 }
 
 function reviewNameFromTitle(title: string) {
-  return title.replace(/\s+review$/iu, "").trim() || title;
+  return title.replace(/\s+(?:shelf\s+)?review$/iu, "").trim() || title;
+}
+
+function reviewerNameFromText(value: string | null) {
+  return value?.replace(/^by\s+/iu, "").trim() || null;
 }
 
 function dateFromPageUrl(pageUrl: URL) {
@@ -1702,10 +1746,15 @@ function parseReviewPage(
     reviewItems && reviewerSelector
       ? readArticleReviewValue($, reviewerSelector, reviewItems)
       : null;
+  const nameSelector = rules.detail.reviews.name;
+  const sharedReviewName =
+    reviewItems?.length === 1 && nameSelector
+      ? readArticleReviewValue($, nameSelector, reviewItems)
+      : null;
 
   reviewItems?.forEach(({ body, item }, index) => {
-    const name = rules.detail.reviews.name
-      ? readSelectedValue(item, rules.detail.reviews.name)
+    const name = nameSelector
+      ? (readSelectedValue(item, nameSelector) ?? sharedReviewName)
       : title
         ? reviewNameFromTitle(title)
         : null;
@@ -1716,9 +1765,11 @@ function parseReviewPage(
       });
       return;
     }
-    const reviewerName = reviewerSelector
-      ? (readSelectedValue(item, reviewerSelector) ?? sharedReviewerName)
-      : null;
+    const reviewerName = reviewerNameFromText(
+      reviewerSelector
+        ? (readSelectedValue(item, reviewerSelector) ?? sharedReviewerName)
+        : null,
+    );
     const firstKey = reviewSourceKey(name, reviewerName);
     const repeat = (keyCounts.get(firstKey) ?? 0) + 1;
     keyCounts.set(firstKey, repeat);
@@ -1730,7 +1781,7 @@ function parseReviewPage(
           ? readSelectedValue($, scoreRule.selector)
           : null))
       : null;
-    const scoreValue = parseNumber(scoreText);
+    const scoreValue = parseScore(scoreText);
     if (scoreText && scoreValue === null) {
       issues.push({
         field: "detail.reviews.score",
@@ -1808,6 +1859,14 @@ function readProductUrl(
   return value ? sameWebsiteUrl(value, pageUrl) : pageUrl.toString();
 }
 
+function cleanProductName(value: string | null) {
+  return (
+    value
+      ?.replace(/\s+[–-]\s*[$£€]\s*\d[\d,.]*(?:\s*[A-Z]{3})?\s*$/u, "")
+      .trim() || null
+  );
+}
+
 function readImageUrl(
   $: ReturnType<typeof load>,
   selector: string | null,
@@ -1842,12 +1901,13 @@ function parseProductPage(
   const readOptional = (
     selector: string | null,
     kind: PageValueKind = "text",
-  ) => (selector ? readSelectedValue($, selector, kind) : null);
+    joinMatches = false,
+  ) => (selector ? readSelectedValue($, selector, kind, joinMatches) : null);
   const volume = isFixedVolume(rules.detail.volume)
     ? rules.detail.volume
-    : parseVolume(readOptional(rules.detail.volume));
+    : parseVolume(readOptional(rules.detail.volume, "text", true));
   const common = {
-    name: readSelectedValue($, rules.detail.name),
+    name: cleanProductName(readSelectedValue($, rules.detail.name)),
     url: readProductUrl($, rules.detail.url, pageUrl),
     externalProductId: readOptional(rules.detail.id, "id") ?? undefined,
     imageUrl: readImageUrl($, rules.detail.image, pageUrl),
@@ -1857,7 +1917,9 @@ function parseProductPage(
   if (rules.kind === "price") {
     const result = StorePriceInputSchema.safeParse({
       ...common,
-      price: parseDisplayedPrice(readSelectedValue($, rules.detail.price)),
+      price: parseDisplayedPrice(
+        readSelectedValue($, rules.detail.price, "text", true),
+      ),
       currency: rules.detail.currency,
       barcode: readOptional(rules.detail.barcode, "id") ?? undefined,
     });
@@ -1871,9 +1933,11 @@ function parseProductPage(
   }
 
   const sourceBottleIdentity = {
-    stated_age: parseNumber(readOptional(rules.detail.age)),
-    abv: parseNumber(readOptional(rules.detail.abv)),
-    release_year: parseNumber(readOptional(rules.detail.year)),
+    stated_age: parseStatedAge(readOptional(rules.detail.age, "text", true)),
+    abv: parseAbv(readOptional(rules.detail.abv, "text", true)),
+    release_year: parseReleaseYear(
+      readOptional(rules.detail.year, "text", true),
+    ),
     edition: readOptional(rules.detail.edition),
   };
   const result = CatalogListingInputSchema.safeParse({

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -348,6 +348,56 @@ test("previews an official catalog without writing listings", async () => {
   expect(await db.select().from(storePrices)).toHaveLength(0);
 });
 
+test("resumes a detail page from its redirect", async () => {
+  const { revision, site, source, user } = await setupCatalogSource();
+  const pinned = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    scrapeSourceId: source.id,
+    revisionId: revision.id,
+    requestedById: user.id,
+    trigger: "manual",
+    purpose: "preview",
+  });
+  const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.pathname === "/whisky") {
+      return new Response(
+        '<article class="product"><a href="/old-release">Release</a></article>',
+      );
+    }
+    if (url.pathname === "/old-release") {
+      return new Response(null, {
+        status: 301,
+        headers: { location: "/whisky/release" },
+      });
+    }
+    if (url.pathname === "/whisky/release") {
+      return new Response(
+        '<main data-product-id="official-1"><h1>Official Release</h1><span class="volume">70 cl</span></main>',
+      );
+    }
+    throw new Error(`Unexpected URL: ${url.toString()}`);
+  });
+
+  await expect(
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl,
+      executionToken: "redirected-catalog-preview",
+    }),
+  ).resolves.toEqual({ status: "completed" });
+  expect(fetchImpl).toHaveBeenCalledTimes(3);
+
+  const [run] = await db
+    .select({ cursor: externalSiteRuns.cursor })
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, pinned.run.id));
+  expect(run?.cursor).toMatchObject({
+    detailUrls: ["https://catalog.example/whisky/release"],
+    detailIndex: 1,
+  });
+});
+
 test("collects and updates only catalog listings", async () => {
   const { revision, site, source, user } = await setupCatalogSource();
   await recordScrapeSourcePreview({

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -15,7 +15,7 @@ import {
 } from "@peated/server/schemas";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
-import { ScraperHttpStatusError } from "../http";
+import { ScraperHttpStatusError, ScraperRequestWaitError } from "../http";
 import { catalogListingSink } from "../sinks/catalogListings";
 import { externalReviewSink } from "../sinks/externalReviews";
 import { createStorePriceSink } from "../sinks/storePrices";
@@ -211,11 +211,20 @@ function createScrapeSourceAdapter(
           ]);
         }
         listUrls.add(state.nextListUrl);
-        const listResponse = await session.request({
-          target: input.targetKey,
-          url: new URL(state.nextListUrl),
-          canResumeLater: true,
-        });
+        let listResponse;
+        try {
+          listResponse = await session.request({
+            target: input.targetKey,
+            url: new URL(state.nextListUrl),
+            canResumeLater: true,
+          });
+        } catch (error) {
+          if (error instanceof ScraperRequestWaitError && error.resumeUrl) {
+            state = { ...state, nextListUrl: error.resumeUrl.toString() };
+            await session.checkpoint(state);
+          }
+          throw error;
+        }
         const listResult = parseScrapeList(
           input.rules,
           listResponse.body,
@@ -240,11 +249,22 @@ function createScrapeSourceAdapter(
       while (state.detailIndex < state.detailUrls.length) {
         const link = state.detailUrls[state.detailIndex];
         if (!link) throw new Error("Configured scraper detail URL is missing.");
-        const response = await session.request({
-          target: input.targetKey,
-          url: new URL(link),
-          canResumeLater: true,
-        });
+        let response;
+        try {
+          response = await session.request({
+            target: input.targetKey,
+            url: new URL(link),
+            canResumeLater: true,
+          });
+        } catch (error) {
+          if (error instanceof ScraperRequestWaitError && error.resumeUrl) {
+            const detailUrls = [...state.detailUrls];
+            detailUrls[state.detailIndex] = error.resumeUrl.toString();
+            state = { ...state, detailUrls };
+            await session.checkpoint(state);
+          }
+          throw error;
+        }
         const parsed = parseScrapeDetail(
           input.rules,
           response.body,

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -393,6 +393,35 @@ test("follows declared redirects and rejects an undeclared redirect before conta
   expect(unsafeFetch).toHaveBeenCalledTimes(1);
 });
 
+test("returns the redirect URL when saved work must wait", async () => {
+  const { registry, run } = await setupRuntime({ requestsPerHour: 30 });
+  const fetchImpl = vi.fn<typeof fetch>().mockResolvedValueOnce(
+    new Response(null, {
+      status: 302,
+      headers: { location: "https://example.com/final" },
+    }),
+  );
+
+  await expect(
+    requestScraperUrl({
+      runId: run.id,
+      sourceKey: "finedrams",
+      request: {
+        target: "operator",
+        url: new URL("https://example.com/start"),
+        canResumeLater: true,
+      },
+      registry,
+      fetchImpl,
+      clock: clockAt(),
+    }),
+  ).rejects.toMatchObject({
+    reason: "target_spacing",
+    resumeUrl: new URL("https://example.com/final"),
+  });
+  expect(fetchImpl).toHaveBeenCalledOnce();
+});
+
 test("retries only transient failures and reacquires a permit", async () => {
   const { registry, run } = await setupRuntime();
   const fetchImpl = vi

--- a/apps/server/src/scraper/http.ts
+++ b/apps/server/src/scraper/http.ts
@@ -39,6 +39,7 @@ export class ScraperRequestWaitError extends Error {
   constructor(
     readonly reason: ScraperWaitReason,
     readonly nextEligibleAt: Date | null,
+    readonly resumeUrl: URL | null = null,
   ) {
     super(`Scraper request must wait: ${reason}.`);
   }
@@ -310,14 +311,26 @@ export async function requestScraperUrl({
     let retry = 0;
 
     while (true) {
-      const permit = await acquireOrDefer({
-        runId,
-        executionToken,
-        targetKey: request.target,
-        isRetry: retry > 0,
-        canResumeLater: request.canResumeLater ?? false,
-        clock,
-      });
+      let permit;
+      try {
+        permit = await acquireOrDefer({
+          runId,
+          executionToken,
+          targetKey: request.target,
+          isRetry: retry > 0,
+          canResumeLater: request.canResumeLater ?? false,
+          clock,
+        });
+      } catch (error) {
+        if (error instanceof ScraperRequestWaitError && redirect > 0) {
+          throw new ScraperRequestWaitError(
+            error.reason,
+            error.nextEligibleAt,
+            currentUrl,
+          );
+        }
+        throw error;
+      }
       let requestHeaders: Headers;
       try {
         requestHeaders = await signScraperRequest(
@@ -378,7 +391,11 @@ export async function requestScraperUrl({
           retryAt: retryAfter,
           now: clock.now(),
         });
-        throw new ScraperRequestWaitError("rate_limited", nextEligibleAt);
+        throw new ScraperRequestWaitError(
+          "rate_limited",
+          nextEligibleAt,
+          redirect > 0 ? currentUrl : null,
+        );
       }
 
       if (

--- a/apps/server/src/scraper/localPreview.test.ts
+++ b/apps/server/src/scraper/localPreview.test.ts
@@ -2,6 +2,8 @@ import { db } from "@peated/server/db";
 import {
   externalReviewArticles,
   externalSiteRuns,
+  externalSiteScrapeTargets,
+  externalSites,
   storePrices,
 } from "@peated/server/db/schema";
 import { eq } from "drizzle-orm";
@@ -255,5 +257,90 @@ test("previews price rules without storing prices", async () => {
     ],
   });
   expect(await db.select().from(externalReviewArticles)).toHaveLength(0);
+  expect(await db.select().from(storePrices)).toHaveLength(0);
+  const [site] = await db
+    .select({ id: externalSites.id })
+    .from(externalSites)
+    .where(eq(externalSites.type, "finedrams"));
+  expect(
+    await db
+      .select({ managedBy: externalSiteScrapeTargets.managedBy })
+      .from(externalSiteScrapeTargets)
+      .where(eq(externalSiteScrapeTargets.externalSiteId, site!.id)),
+  ).toContainEqual({ managedBy: "admin" });
+});
+
+test("previews a site that exists only in production", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.pathname === "/robots.txt") {
+      return new Response("User-agent: *\nDisallow:");
+    }
+    if (url.pathname === "/whisky") {
+      return new Response('<a class="product" href="/whisky/one">One</a>');
+    }
+    if (url.pathname === "/whisky/one") {
+      return new Response("<main><h1>Example Whisky</h1></main>");
+    }
+    return new Response(null, { status: 404 });
+  });
+
+  const result = await runLocalScrapeSourcePreview(
+    {
+      site: "production-only-example",
+      listUrl: "https://production-only.example/whisky",
+      rulesVersion: 10,
+      rules: {
+        kind: "catalog",
+        list: {
+          links: "a.product",
+          nextPage: null,
+          limit: 20,
+        },
+        detail: {
+          name: "h1",
+          url: null,
+          id: null,
+          image: null,
+          volume: null,
+          abv: null,
+          age: null,
+          edition: null,
+          year: null,
+        },
+      },
+      limit: 1,
+    },
+    {
+      fetchImpl,
+      clock: previewClock(),
+      executionToken: "production-only-preview-owner",
+    },
+  );
+
+  expect(result.run).toMatchObject({
+    status: "succeeded",
+    requestCount: 3,
+    emittedItemCount: 0,
+  });
+  expect(result.preview).toEqual({
+    issues: [],
+    pages: [
+      {
+        kind: "catalog",
+        url: "https://production-only.example/whisky/one",
+        products: [
+          {
+            externalProductId: null,
+            name: "Example Whisky",
+            url: "https://production-only.example/whisky/one",
+            imageUrl: null,
+            volume: null,
+            sourceBottleIdentity: null,
+          },
+        ],
+      },
+    ],
+  });
   expect(await db.select().from(storePrices)).toHaveLength(0);
 });

--- a/apps/server/src/scraper/localPreview.ts
+++ b/apps/server/src/scraper/localPreview.ts
@@ -3,9 +3,11 @@ import {
   externalSiteRuns,
   externalSites,
   externalSiteScrapeTargets,
+  scrapeOrigins,
   scrapeTargets,
 } from "@peated/server/db/schema";
 import { syncExternalSites } from "@peated/server/lib/externalSites";
+import { ExternalSiteKeySchema } from "@peated/server/schemas/externalSites";
 import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import type { ScrapeSourcePreviewResult } from "./configured/preview";
@@ -16,6 +18,7 @@ import {
 } from "./configured/rules";
 import { createLocalScrapeSourcePreview } from "./configured/runtime";
 import { loadScrapeSourceTarget } from "./configured/target";
+import { defineScrapeTarget } from "./definitions";
 import { scraperSystemClock, type ScraperHttpClock } from "./http";
 import { scraperRegistry } from "./registry";
 import { executeScraperRun } from "./runs";
@@ -23,7 +26,7 @@ import { syncScraperDefinitions } from "./syncDefinitions";
 
 const InputSchema = z
   .object({
-    site: z.string().trim().min(1),
+    site: ExternalSiteKeySchema,
     listUrl: z.url(),
     rulesVersion: z.number().int().positive().default(1),
     rules: z.json(),
@@ -32,6 +35,61 @@ const InputSchema = z
   .strict();
 
 export type LocalScrapeSourcePreviewInput = z.input<typeof InputSchema>;
+
+async function createLocalPreviewTarget(siteKey: string, listUrl: URL) {
+  const target = defineScrapeTarget({
+    key: siteKey,
+    origins: [{ origin: listUrl.origin, robots: { mode: "enforce" } }],
+  });
+  return await db.transaction(async (tx) => {
+    const [createdSite] = await tx
+      .insert(externalSites)
+      .values({ type: siteKey, name: siteKey, runEvery: null })
+      .onConflictDoNothing()
+      .returning();
+    const [existingSite] = createdSite
+      ? []
+      : await tx
+          .select()
+          .from(externalSites)
+          .where(eq(externalSites.type, siteKey));
+    const site = createdSite ?? existingSite;
+    if (!site) throw new Error("Failed to create the local preview site.");
+
+    await tx
+      .insert(scrapeTargets)
+      .values({
+        key: target.key,
+        managedBy: "admin",
+        enabled: true,
+        minimumSpacingMs: target.minimumSpacingMs,
+        requestsPerWindow: target.requestsPerWindow,
+        windowMs: target.windowMs,
+        timeoutMs: target.timeoutMs,
+        maxResponseBytes: target.maxResponseBytes,
+        maxRetries: target.maxRetries,
+      })
+      .onConflictDoNothing();
+    await tx
+      .insert(scrapeOrigins)
+      .values({
+        origin: listUrl.origin,
+        managedBy: "admin",
+        targetKey: target.key,
+        robotsMode: "enforce",
+      })
+      .onConflictDoNothing();
+    await tx
+      .insert(externalSiteScrapeTargets)
+      .values({
+        externalSiteId: site.id,
+        targetKey: target.key,
+        managedBy: "admin",
+      })
+      .onConflictDoNothing();
+    return { site, target };
+  });
+}
 
 export async function runLocalScrapeSourcePreview(
   input: LocalScrapeSourcePreviewInput,
@@ -52,52 +110,57 @@ export async function runLocalScrapeSourcePreview(
   await syncExternalSites();
   await syncScraperDefinitions(scraperRegistry);
 
-  const [site] = await db
+  let [site] = await db
     .select()
     .from(externalSites)
     .where(eq(externalSites.type, parsed.site));
-  if (!site) throw new Error(`External site ${parsed.site} was not found.`);
 
   const codeTarget = scraperRegistry.targets.get(parsed.site);
-  const [storedTarget] = codeTarget
-    ? []
-    : await db
-        .select({ target: scrapeTargets })
-        .from(externalSiteScrapeTargets)
-        .innerJoin(
-          scrapeTargets,
-          eq(scrapeTargets.key, externalSiteScrapeTargets.targetKey),
-        )
-        .where(
-          and(
-            eq(externalSiteScrapeTargets.externalSiteId, site.id),
-            eq(externalSiteScrapeTargets.active, true),
-          ),
-        )
-        .limit(1);
-  const target =
+  const [storedTarget] =
+    !site || codeTarget
+      ? []
+      : await db
+          .select({ target: scrapeTargets })
+          .from(externalSiteScrapeTargets)
+          .innerJoin(
+            scrapeTargets,
+            eq(scrapeTargets.key, externalSiteScrapeTargets.targetKey),
+          )
+          .where(
+            and(
+              eq(externalSiteScrapeTargets.externalSiteId, site.id),
+              eq(externalSiteScrapeTargets.active, true),
+            ),
+          )
+          .limit(1);
+  let target =
     codeTarget ??
     (storedTarget ? await loadScrapeSourceTarget(storedTarget.target) : null);
-  if (!target) {
-    throw new Error(`External site ${parsed.site} has no scrape target.`);
+
+  if (!site || !target) {
+    const local = await createLocalPreviewTarget(
+      parsed.site,
+      new URL(parsed.listUrl),
+    );
+    site = local.site;
+    target = local.target;
   }
   if (codeTarget) {
-    // Local previews still need coordinator authorization after the legacy
-    // source registration is removed. Production migrations own their mapping.
+    // Keep local previews authorized when another preview refreshes the code
+    // definitions. Production owns its own site-to-target mapping.
     await db
       .insert(externalSiteScrapeTargets)
       .values({
         externalSiteId: site.id,
         targetKey: target.key,
-        managedBy: "code",
+        managedBy: "admin",
       })
       .onConflictDoUpdate({
         target: [
           externalSiteScrapeTargets.externalSiteId,
           externalSiteScrapeTargets.targetKey,
         ],
-        set: { active: true, updatedAt: new Date() },
-        setWhere: eq(externalSiteScrapeTargets.managedBy, "code"),
+        set: { active: true, managedBy: "admin", updatedAt: new Date() },
       });
   }
   const [activeRun] = await db


### PR DESCRIPTION
Version 10 scrapers now handle the common page text found during a live pass over every saved-rule source: labeled Bottle facts, review scores and bylines, WooCommerce product IDs, and product titles that include a displayed price. This keeps source rules as CSS selectors instead of adding cleanup or template syntax.

Local preview can now test a site that exists only in production. Configured runs also save a redirect destination before yielding to request spacing, preventing them from repeatedly requesting the redirecting URL without making progress. Redirect destinations still pass the existing origin and robots.txt checks.

This is enabling code only. It does not create, activate, or change any production scraper revision; those migrations will follow after deployment and full production previews.
