### PR TITLE
fix(web): recover stale sessions from sign in

### DIFF
--- a/apps/web/e2e/profile-header.spec.ts
+++ b/apps/web/e2e/profile-header.spec.ts
@@ -3,14 +3,24 @@ import { expect, test } from "./test";
 import { adminUser, testAccessToken, testUser } from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 
-test("updates the profile actions after an administrator changes the moderator role", async ({
+test("keeps account state current across navigation and reload", async ({
   context,
   page,
 }, testInfo) => {
+  await page.goto("/");
+  await expect(page.getByRole("link", { name: "Sign in" })).toBeVisible();
+
+  // A restored tab can retain signed-out client state after its cookie becomes valid.
   await signIn(context, {
     accessToken: `${testAccessToken}-profile-role-update-${testInfo.project.name}-${testInfo.retry}`,
     user: adminUser,
   });
+  await page.getByRole("link", { name: "Sign in" }).click();
+
+  await expect(page).toHaveURL("/");
+  await expect(
+    page.getByRole("button", { name: "Open account menu" }),
+  ).toBeVisible();
 
   await page.goto(`/users/${testUser.username}/activity`);
   const profileActions = page.getByRole("button", {

--- a/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
@@ -95,7 +95,13 @@ export function ApplicationLayout({ children }: { children: ReactNode }) {
               </ButtonLink>
             ) : (
               <>
-                <ButtonLink href="/login" size="sm" variant="text">
+                {/* Auth requires a document load to rebuild a restored tab's session state. */}
+                <ButtonLink
+                  href="/login"
+                  reloadDocument
+                  size="sm"
+                  variant="text"
+                >
                   Sign in
                 </ButtonLink>
                 <ButtonLink href="/register" size="sm" variant="default">

--- a/apps/web/src/components/appLink.tsx
+++ b/apps/web/src/components/appLink.tsx
@@ -10,6 +10,8 @@ import { textLinkStyles } from "./textLinkStyles.stylex";
 
 export type AppLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   prefetch?: boolean | null;
+  /** Use a native navigation when the destination must rebuild the root layout. */
+  reloadDocument?: boolean;
 };
 
 export function isInternalAppHref(href: string) {
@@ -17,7 +19,8 @@ export function isInternalAppHref(href: string) {
 }
 
 /**
- * Uses client navigation for app routes and native anchors for other targets.
+ * Uses client navigation for app routes and native anchors for other targets
+ * or when the caller requests a document reload.
  * A bare link gets the shared text-link interaction treatment and inherits its
  * surrounding typography. Composite components replace that treatment by
  * supplying their own class. Use TextLink for inline text because its API also
@@ -30,6 +33,7 @@ export const AppLink = forwardRef(function AppLink(
     download,
     href,
     prefetch = false,
+    reloadDocument = false,
     style,
     ...props
   }: AppLinkProps,
@@ -44,7 +48,12 @@ export const AppLink = forwardRef(function AppLink(
     style: fallbackProps?.style ? { ...fallbackProps.style, ...style } : style,
   };
 
-  if (!href || !isInternalAppHref(href) || download !== undefined) {
+  if (
+    !href ||
+    !isInternalAppHref(href) ||
+    download !== undefined ||
+    reloadDocument
+  ) {
     return (
       <a {...linkProps} download={download} href={href} ref={ref}>
         {children}

--- a/apps/web/src/components/button.stylex.tsx
+++ b/apps/web/src/components/button.stylex.tsx
@@ -103,6 +103,7 @@ export function ButtonLink({
       {children}
       {props.href &&
       isInternalAppHref(props.href) &&
+      !props.reloadDocument &&
       props.download === undefined ? (
         <LinkPending />
       ) : null}


### PR DESCRIPTION
Restored tabs can retain signed-out state in Next's persistent root layout even when the session cookie is still valid. In that state, clicking Sign in reached the server, redirected home, and left the client shell showing signed-out controls.

The header's Sign in link now uses a native document navigation so the root session provider is rebuilt from the cookie. The shared link primitive exposes this behavior explicitly and avoids showing the client-navigation progress indicator for document reloads. Browser coverage now recreates the stale-shell state and verifies that the account menu appears after the redirect.
