### PR TITLE
fix(scraper): preserve data across rule upgrades

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -1495,7 +1495,7 @@ describe("POST /admin/scrape-sources/prepare", () => {
     ]);
   });
 
-  test("prepares repeated Dramface review identities", async ({ fixtures }) => {
+  test("refuses repeated Dramface review identities", async ({ fixtures }) => {
     const firstBottle = await fixtures.Bottle();
     const secondBottle = await fixtures.Bottle();
     const { reviews } = await setupDramfaceMigration([
@@ -1511,21 +1511,14 @@ describe("POST /admin/scrape-sources/prepare", () => {
       })
       .where(eq(externalReviews.id, reviews[1].id));
 
-    await expect(prepareDramface({ apply: true })).resolves.toMatchObject({
-      reviewCount: 2,
-      applied: true,
+    const before = await db.select().from(externalReviews);
+
+    await expect(prepareDramface({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Each review in Dramface article"),
     });
-    expect(
-      await db
-        .select({ sourceKey: externalReviews.sourceKey })
-        .from(externalReviews)
-        .orderBy(externalReviews.id),
-    ).toEqual([
-      { sourceKey: reviewSourceKey(reviews[0].name, reviews[0].reviewerName) },
-      {
-        sourceKey: reviewSourceKey(reviews[0].name, reviews[0].reviewerName, 2),
-      },
-    ]);
+    expect(await db.select().from(externalReviews)).toEqual(before);
+    expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 
   test("refuses an unknown Dramface review key", async ({ fixtures }) => {

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -66,7 +66,7 @@ it("reads price fields from text and their usual HTML attributes", () => {
       rules,
       `<head>
         <link rel="canonical" href="/products/one">
-        <meta property="og:image" content="https://images.example/one.jpg">
+        <meta property="og:image" content="http://images.example/one.jpg">
       </head><body>
         <h1>Example Whisky</h1>
         <span class="price"></span>
@@ -144,9 +144,9 @@ it("reads common Bottle facts from surrounding text", () => {
       rules,
       `<h1>Example 2012</h1>
        <p class="facts">Distilled in 2012</p>
-       <p class="facts">10 Year Old</p>
+       <p class="facts">10-15 Year Old whiskies</p>
        <p class="facts">46.3% ABV</p>
-       <p class="facts">70cl</p>
+       <p class="facts">Volume (ml): 700</p>
        <p class="release">Released in 2024</p>`,
       new URL("https://example.test/whisky/one"),
     ),
@@ -312,6 +312,41 @@ it("splits unwrapped reviews at their name selectors", () => {
       },
     },
   });
+});
+
+it("rejects version 10 reviews without a stable identity", () => {
+  const rules = {
+    kind: "review",
+    list: { links: "a.review", nextPage: null, limit: 10 },
+    detail: {
+      url: null,
+      title: "h1",
+      date: null,
+      reviews: {
+        area: "main",
+        item: "section.review",
+        name: "h2",
+        reviewer: ".writer",
+        tastingNotes: null,
+        score: null,
+      },
+    },
+  } satisfies ScrapeRules;
+  const result = parseScrapeDetail(
+    rules,
+    `<h1>Two reviews</h1><main>
+      <section class="review"><h2>Same Whisky</h2><p class="writer">Ada</p><p>First review.</p></section>
+      <section class="review"><h2>Same Whisky</h2><p class="writer">Ada</p><p>Second review.</p></section>
+    </main>`,
+    new URL("https://reviews.example/2026/09/07/two-reviews"),
+  );
+
+  expect(result.issues).toContainEqual({
+    field: "detail.reviews.name",
+    message:
+      "Each review in an article must have a unique name and writer combination.",
+  });
+  expect(result.value).toBeNull();
 });
 
 it("uses an article writer for each wrapped review", () => {
@@ -2405,7 +2440,7 @@ describe("scrape source parser", () => {
     );
   });
 
-  it("keeps repeated reviews separate", () => {
+  it("rejects reviews without a stable identity", () => {
     const result = parseScrapeDetail(
       currentReviewRules,
       `<article>
@@ -2419,15 +2454,12 @@ describe("scrape source parser", () => {
       </article>`,
       new URL("https://reviews.test/reviews"),
     );
-    if (result.kind !== "review" || !result.value) {
-      throw new Error("Expected parsed reviews.");
-    }
-    const keys = result.value.article.externalReviews.map(
-      ({ sourceKey }) => sourceKey,
-    );
-
-    expect(new Set(keys)).toHaveLength(2);
-    expect(keys[1]).toBe(`${keys[0]}:2`);
+    expect(result.issues).toContainEqual({
+      field: "article.reviews.name",
+      message:
+        "Each review in an article must have a unique name and writer combination.",
+    });
+    expect(result.value).toBeNull();
   });
 
   it("can keep the full article area for one version 8 review", () => {

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -674,10 +674,15 @@ function parseVolume(value: string | null) {
   if (!value) return null;
   const normalized = value.toLowerCase().replaceAll(",", "");
   const amount = normalized.match(/(-?\d+(?:\.\d+)?)\s*(ml|cl|l)(?:\b|$)/u);
-  const number = amount ? Number(amount[1]) : parsePlainNumber(normalized);
+  const labeled = normalized.match(
+    /\bvolume\s*\(\s*(ml|cl|l)\s*\)\s*:?\s*(-?\d+(?:\.\d+)?)/u,
+  );
+  const numberText = amount?.[1] ?? labeled?.[2];
+  const number = numberText ? Number(numberText) : parsePlainNumber(normalized);
   if (number === null || number <= 0) return null;
-  if (amount?.[2] === "cl") return Math.round(number * 10);
-  if (amount?.[2] === "l") return Math.round(number * 1000);
+  const unit = amount?.[2] ?? labeled?.[1];
+  if (unit === "cl") return Math.round(number * 10);
+  if (unit === "l") return Math.round(number * 1000);
   return Math.round(number);
 }
 
@@ -691,6 +696,10 @@ function parseAbv(value: string | null) {
 
 function parseStatedAge(value: string | null) {
   if (!value) return null;
+  const range = value.match(
+    /(\d+(?:\.\d+)?)\s*[-–—]\s*\d+(?:\.\d+)?\s*(?:years?\s*old|y\.?\s*o\.?)\b/iu,
+  );
+  if (range) return Number(range[1]);
   const match = value.match(
     /(\d+(?:\.\d+)?)\s*(?:years?\s*old|y\.?\s*o\.?)\b/iu,
   );
@@ -1264,7 +1273,7 @@ function parseSavedReviewDetail(
   }> = [];
   const externalReviewTexts: Record<string, string> = {};
   const externalReviewBodies: Record<string, string> = {};
-  const reviewKeyCounts = new Map<string, number>();
+  const reviewKeys = new Set<string>();
   const keysUseNameAndWriter = usesNameBasedReviewKeys(rules);
   const reviewItems = selectSavedReviewItems($, rules.article.reviews);
   if (!reviewItems) {
@@ -1299,12 +1308,20 @@ function parseSavedReviewDetail(
     const reviewerName = rules.article.reviews.reviewer
       ? readSavedReviewField($, item, rules.article.reviews.reviewer, index)
       : null;
-    const firstReviewKey = reviewSourceKey(name, reviewerName);
-    const repeatedReviewNumber = (reviewKeyCounts.get(firstReviewKey) ?? 0) + 1;
-    reviewKeyCounts.set(firstReviewKey, repeatedReviewNumber);
     const sourceKey = keysUseNameAndWriter
-      ? reviewSourceKey(name, reviewerName, repeatedReviewNumber)
+      ? reviewSourceKey(name, reviewerName)
       : `${canonicalUrl?.toString() ?? pageUrl.toString()}#review-${index + 1}`;
+    if (keysUseNameAndWriter) {
+      if (reviewKeys.has(sourceKey)) {
+        issues.push({
+          field: "article.reviews.name",
+          message:
+            "Each review in an article must have a unique name and writer combination.",
+        });
+        return;
+      }
+      reviewKeys.add(sourceKey);
+    }
     const scoreRule = rules.article.reviews.score;
     const scoreText = scoreRule
       ? readSavedReviewField($, item, scoreRule, index)
@@ -1727,7 +1744,7 @@ function parseReviewPage(
   }> = [];
   const externalReviewTexts: Record<string, string> = {};
   const externalReviewBodies: Record<string, string> = {};
-  const keyCounts = new Map<string, number>();
+  const reviewKeys = new Set<string>();
   const reviewItems = selectReviews($, rules.detail.reviews);
   if (!reviewItems) {
     issues.push({
@@ -1770,10 +1787,16 @@ function parseReviewPage(
         ? (readSelectedValue(item, reviewerSelector) ?? sharedReviewerName)
         : null,
     );
-    const firstKey = reviewSourceKey(name, reviewerName);
-    const repeat = (keyCounts.get(firstKey) ?? 0) + 1;
-    keyCounts.set(firstKey, repeat);
-    const sourceKey = reviewSourceKey(name, reviewerName, repeat);
+    const sourceKey = reviewSourceKey(name, reviewerName);
+    if (reviewKeys.has(sourceKey)) {
+      issues.push({
+        field: "detail.reviews.name",
+        message:
+          "Each review in an article must have a unique name and writer combination.",
+      });
+      return;
+    }
+    reviewKeys.add(sourceKey);
     const scoreRule = rules.detail.reviews.score;
     const scoreText = scoreRule
       ? (readSelectedValue(item, scoreRule.selector) ??
@@ -1874,7 +1897,12 @@ function readImageUrl(
 ) {
   if (!selector) return undefined;
   const value = readSelectedValue($, selector, "image");
-  return value ? webUrl(value, pageUrl) : undefined;
+  if (!value) return undefined;
+  const url = new URL(webUrl(value, pageUrl));
+  if (pageUrl.protocol === "https:" && url.protocol === "http:") {
+    url.protocol = "https:";
+  }
+  return url.toString();
 }
 
 function isFixedVolume(value: string | number | null): value is number {

--- a/apps/server/src/scraper/configured/prepareReviewSource.ts
+++ b/apps/server/src/scraper/configured/prepareReviewSource.ts
@@ -85,8 +85,7 @@ export async function prepareReviewSource(
           `Check the URL and review records for ${definition.siteName} article ${article.id} before continuing.`,
         );
       }
-      // Migration rule: repeated identical reviews keep their original insert order.
-      const reviewKeyCounts = new Map<string, number>();
+      const reviewKeys = new Set<string>();
       return articleReviews
         .toSorted((left, right) => left.id - right.id)
         .map((review) => {
@@ -95,20 +94,16 @@ export async function prepareReviewSource(
               `Check the URL and review records for ${definition.siteName} article ${article.id} before continuing.`,
             );
           }
-          const firstReviewKey = reviewSourceKey(
-            review.name,
-            review.reviewerName,
-          );
-          const repeatedReviewNumber =
-            (reviewKeyCounts.get(firstReviewKey) ?? 0) + 1;
-          reviewKeyCounts.set(firstReviewKey, repeatedReviewNumber);
+          const sourceKey = reviewSourceKey(review.name, review.reviewerName);
+          if (reviewKeys.has(sourceKey)) {
+            throw new ScrapeSourceValidationError(
+              `Each review in ${definition.siteName} article ${article.id} must have a unique name and writer combination.`,
+            );
+          }
+          reviewKeys.add(sourceKey);
           return {
             id: review.id,
-            sourceKey: reviewSourceKey(
-              review.name,
-              review.reviewerName,
-              repeatedReviewNumber,
-            ),
+            sourceKey,
           };
         });
     });

--- a/apps/server/src/scraper/configured/reviewSourceKey.ts
+++ b/apps/server/src/scraper/configured/reviewSourceKey.ts
@@ -4,17 +4,10 @@ function normalizeReviewKeyPart(value: string) {
   return value.replaceAll(/\s+/g, " ").trim().toLocaleLowerCase("en");
 }
 
-/** Keeps the same review matched when other reviews move on the page. */
-export function reviewSourceKey(
-  name: string,
-  reviewerName: string | null,
-  repeatedReviewNumber = 1,
-) {
+/** A review is matched by its name and writer within an article, never page order. */
+export function reviewSourceKey(name: string, reviewerName: string | null) {
   const digest = createHash("sha256")
     .update([name, reviewerName ?? ""].map(normalizeReviewKeyPart).join("\n"))
     .digest("hex");
-  const baseKey = `review:${digest}`;
-  return repeatedReviewNumber === 1
-    ? baseKey
-    : `${baseKey}:${repeatedReviewNumber}`;
+  return `review:${digest}`;
 }

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -1,5 +1,9 @@
 import { db } from "@peated/server/db";
 import {
+  externalReviewArticles,
+  externalReviewBodies,
+  externalReviews,
+  externalSiteRuns,
   externalSites,
   externalSiteScrapeTargets,
   scrapeOrigins,
@@ -10,6 +14,7 @@ import {
   users,
 } from "@peated/server/db/schema";
 import { eq } from "drizzle-orm";
+import { reviewSourceKey } from "./reviewSourceKey";
 import type { ScrapeRules } from "./rules";
 import { createPinnedScrapeSourceRun } from "./runs";
 import {
@@ -171,6 +176,10 @@ test("keeps immutable revisions and only activates a passing revision", async ()
       purpose: "collect",
     }),
   ]);
+  await db
+    .update(externalSiteRuns)
+    .set({ status: "succeeded", completedAt: new Date() })
+    .where(eq(externalSiteRuns.id, pinned.run.id));
 
   await recordScrapeSourcePreview({
     revisionId: second.id,
@@ -182,6 +191,257 @@ test("keeps immutable revisions and only activates a passing revision", async ()
     revisionId: second.id,
   });
   expect(updated.source.listUrl).toBe("https://versioned.example/new-archive");
+});
+
+test("keeps the original review and the newer scraped data", async ({
+  fixtures,
+}) => {
+  const user = await createUser();
+  const bottle = await fixtures.Bottle();
+  const { site, source } = await createSiteWithScrapeSource({
+    name: "Existing Reviews",
+    kind: "review",
+    websiteUrl: "https://existing.example/",
+    createdById: user.id,
+  });
+  const [article] = await db
+    .insert(externalReviewArticles)
+    .values({
+      externalSiteId: site.id,
+      canonicalUrl: "https://existing.example/review/one",
+    })
+    .returning();
+  if (!article) throw new Error("Failed to create test article.");
+  const [original] = await db
+    .insert(externalReviews)
+    .values({
+      articleId: article.id,
+      sourceKey: `${article.canonicalUrl}#review-1`,
+      name: "Example Whisky",
+      reviewerName: "Reviewer",
+    })
+    .returning();
+  if (!original) throw new Error("Failed to create test review.");
+  const [newer] = await db
+    .insert(externalReviews)
+    .values({
+      articleId: article.id,
+      sourceKey: reviewSourceKey(original.name, original.reviewerName),
+      name: original.name,
+      reviewerName: original.reviewerName,
+      bottleId: bottle.id,
+      category: bottle.category,
+      nativeScoreValue: 91,
+      nativeScoreScale: 100,
+      nativeScoreDisplay: "91/100",
+      clip: "Fresh review summary.",
+      version: 2,
+      tags: ["smoke"],
+      hidden: true,
+    })
+    .returning();
+  if (!newer) throw new Error("Failed to create newer test review.");
+  await db.insert(externalReviewBodies).values([
+    {
+      externalReviewId: original.id,
+      body: "Older review body.",
+      fetchedAt: new Date("2026-08-01T00:00:00Z"),
+    },
+    {
+      externalReviewId: newer.id,
+      body: "Newer review body.",
+      fetchedAt: new Date("2026-09-01T00:00:00Z"),
+    },
+  ]);
+
+  const revision = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules,
+    author: "person",
+    createdById: user.id,
+  });
+  await recordScrapeSourcePreview({
+    revisionId: revision.id,
+    status: "passed",
+    result: { issues: [], pages: [] },
+  });
+  await activateScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    revisionId: revision.id,
+  });
+
+  expect(await db.select().from(externalReviews)).toEqual([
+    expect.objectContaining({
+      id: original.id,
+      sourceKey: reviewSourceKey(original.name, original.reviewerName),
+      bottleId: bottle.id,
+      category: bottle.category,
+      nativeScoreValue: 91,
+      nativeScoreScale: 100,
+      nativeScoreDisplay: "91/100",
+      clip: "Fresh review summary.",
+      version: 2,
+      tags: ["smoke"],
+      hidden: false,
+    }),
+  ]);
+  expect(await db.select().from(externalReviewBodies)).toEqual([
+    {
+      externalReviewId: original.id,
+      body: "Newer review body.",
+      fetchedAt: new Date("2026-09-01T00:00:00Z"),
+    },
+  ]);
+});
+
+test("refuses conflicting Bottle matches for the same review", async ({
+  fixtures,
+}) => {
+  const user = await createUser();
+  const originalBottle = await fixtures.Bottle();
+  const newerBottle = await fixtures.Bottle();
+  const { site, source } = await createSiteWithScrapeSource({
+    name: "Conflicting Reviews",
+    kind: "review",
+    websiteUrl: "https://conflicting.example/",
+    createdById: user.id,
+  });
+  const [article] = await db
+    .insert(externalReviewArticles)
+    .values({
+      externalSiteId: site.id,
+      canonicalUrl: "https://conflicting.example/review/one",
+    })
+    .returning();
+  if (!article) throw new Error("Failed to create test article.");
+  await db.insert(externalReviews).values([
+    {
+      articleId: article.id,
+      sourceKey: `${article.canonicalUrl}#review-1`,
+      name: "Example Whisky",
+      reviewerName: "Reviewer",
+      bottleId: originalBottle.id,
+    },
+    {
+      articleId: article.id,
+      sourceKey: reviewSourceKey("Example Whisky", "Reviewer"),
+      name: "Example Whisky",
+      reviewerName: "Reviewer",
+      bottleId: newerBottle.id,
+    },
+  ]);
+  const before = await db.select().from(externalReviews);
+  const revision = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules,
+    author: "person",
+    createdById: user.id,
+  });
+  await recordScrapeSourcePreview({
+    revisionId: revision.id,
+    status: "passed",
+    result: { issues: [], pages: [] },
+  });
+
+  await expect(
+    activateScrapeSourceRevision({
+      scrapeSourceId: source.id,
+      revisionId: revision.id,
+    }),
+  ).rejects.toThrow("Two copies of the same review point to different Bottles");
+  expect(await db.select().from(externalReviews)).toEqual(before);
+});
+
+test("refuses review identities that depend on page position", async () => {
+  const user = await createUser();
+  const { site, source } = await createSiteWithScrapeSource({
+    name: "Repeated Reviews",
+    kind: "review",
+    websiteUrl: "https://repeated.example/",
+    createdById: user.id,
+  });
+  const [article] = await db
+    .insert(externalReviewArticles)
+    .values({
+      externalSiteId: site.id,
+      canonicalUrl: "https://repeated.example/review/one",
+    })
+    .returning();
+  if (!article) throw new Error("Failed to create test article.");
+  await db.insert(externalReviews).values([
+    {
+      articleId: article.id,
+      sourceKey: `${article.canonicalUrl}#review-1`,
+      name: "Example Whisky",
+      reviewerName: "Reviewer",
+    },
+    {
+      articleId: article.id,
+      sourceKey: `${article.canonicalUrl}#review-2`,
+      name: "Example Whisky",
+      reviewerName: "Reviewer",
+    },
+  ]);
+  const before = await db.select().from(externalReviews);
+  const revision = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules,
+    author: "person",
+    createdById: user.id,
+  });
+  await recordScrapeSourcePreview({
+    revisionId: revision.id,
+    status: "passed",
+    result: { issues: [], pages: [] },
+  });
+
+  await expect(
+    activateScrapeSourceRevision({
+      scrapeSourceId: source.id,
+      revisionId: revision.id,
+    }),
+  ).rejects.toThrow(
+    "Each review in an article must have a unique name and writer combination",
+  );
+  expect(await db.select().from(externalReviews)).toEqual(before);
+  expect(await db.select().from(scrapeSources)).toEqual([
+    expect.objectContaining({ id: source.id, enabled: false }),
+  ]);
+});
+
+test("does not activate a revision while a run is active", async () => {
+  const user = await createUser();
+  const { site, source } = await createSiteWithScrapeSource({
+    name: "Busy Reviews",
+    kind: "review",
+    websiteUrl: "https://busy.example/",
+    createdById: user.id,
+  });
+  const revision = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules,
+    author: "person",
+    createdById: user.id,
+  });
+  await recordScrapeSourcePreview({
+    revisionId: revision.id,
+    status: "passed",
+    result: { issues: [], pages: [] },
+  });
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "queued",
+    trigger: "manual",
+    purpose: "collect",
+    requestLimit: 1,
+  });
+
+  await expect(
+    activateScrapeSourceRevision({
+      scrapeSourceId: source.id,
+      revisionId: revision.id,
+    }),
+  ).rejects.toThrow("Wait for the current run to finish");
 });
 
 test("database constraints keep source and revision identity valid", async () => {

--- a/apps/server/src/scraper/configured/service.ts
+++ b/apps/server/src/scraper/configured/service.ts
@@ -1,6 +1,9 @@
-import { db } from "@peated/server/db";
+import { type AnyDatabase, db } from "@peated/server/db";
 import {
+  externalReviewArticles,
+  externalReviewBodies,
   externalReviewPublications,
+  externalReviews,
   externalSiteRuns,
   externalSites,
   externalSiteScrapeTargets,
@@ -10,19 +13,21 @@ import {
   scrapeSources,
   scrapeTargets,
 } from "@peated/server/db/schema";
+import { dispatchBottleStatsRecomputes } from "@peated/server/lib/dispatchBottleStatsRecompute";
 import {
   ScrapeSourceCreateSchema,
   ScrapeSourceUrlSchema,
 } from "@peated/server/schemas";
 import { ExternalSiteKeySchema } from "@peated/server/schemas/externalSites";
 import slugify from "@sindresorhus/slugify";
-import { and, desc, eq, max } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, max } from "drizzle-orm";
 import { z } from "zod";
 import {
   DEFAULT_SCRAPER_SETTINGS,
   getHourlyRequestSettings,
 } from "../definitions";
 import type { ScrapeSourcePreviewResult } from "./preview";
+import { reviewSourceKey } from "./reviewSourceKey";
 import {
   SCRAPE_RULES_VERSION,
   type ScrapeRules,
@@ -50,6 +55,176 @@ export class ScrapeSourceValidationError extends Error {
 }
 
 const DatabaseErrorSchema = z.object({ code: z.string() });
+const ReviewSourceKeyPattern = /^review:[a-f0-9]{64}$/;
+
+/** Keeps the original ID and visibility while carrying over a later scrape. */
+async function keepOriginalReview(
+  tx: AnyDatabase,
+  original: typeof externalReviews.$inferSelect,
+  newer: typeof externalReviews.$inferSelect,
+) {
+  if (
+    original.bottleId !== null &&
+    newer.bottleId !== null &&
+    original.bottleId !== newer.bottleId
+  ) {
+    throw new ScrapeSourceValidationError(
+      "Two copies of the same review point to different Bottles. Fix them before activating this version.",
+    );
+  }
+  await tx
+    .update(externalReviews)
+    .set({
+      bottleId: original.bottleId ?? newer.bottleId,
+      name: newer.name,
+      category: newer.category,
+      reviewerName: newer.reviewerName,
+      nativeScoreValue: newer.nativeScoreValue,
+      nativeScoreScale: newer.nativeScoreScale,
+      nativeScoreDisplay: newer.nativeScoreDisplay,
+      clip: newer.clip,
+      version: newer.version,
+      tags: newer.tags,
+    })
+    .where(eq(externalReviews.id, original.id));
+
+  const bodies = await tx
+    .select()
+    .from(externalReviewBodies)
+    .where(
+      inArray(externalReviewBodies.externalReviewId, [original.id, newer.id]),
+    )
+    .for("update");
+  const originalBody = bodies.find(
+    ({ externalReviewId }) => externalReviewId === original.id,
+  );
+  const newerBody = bodies.find(
+    ({ externalReviewId }) => externalReviewId === newer.id,
+  );
+  if (
+    newerBody &&
+    (!originalBody || newerBody.fetchedAt >= originalBody.fetchedAt)
+  ) {
+    await tx
+      .insert(externalReviewBodies)
+      .values({ ...newerBody, externalReviewId: original.id })
+      .onConflictDoUpdate({
+        target: externalReviewBodies.externalReviewId,
+        set: { body: newerBody.body, fetchedAt: newerBody.fetchedAt },
+      });
+  }
+
+  return [original.bottleId, newer.bottleId].filter(
+    (id): id is number => id !== null,
+  );
+}
+
+/** Keeps original review IDs when new rules change how reviews are matched. */
+// TODO(scraper): Remove this repair after every review source uses version 10
+// and all saved reviews are matched by name and writer.
+async function prepareReviewKeysForActivation(
+  tx: AnyDatabase,
+  externalSiteId: number,
+) {
+  const changedBottleIds = new Set<number>();
+  const rows = await tx
+    .select({ review: externalReviews })
+    .from(externalReviews)
+    .innerJoin(
+      externalReviewArticles,
+      eq(externalReviewArticles.id, externalReviews.articleId),
+    )
+    .where(eq(externalReviewArticles.externalSiteId, externalSiteId))
+    .orderBy(asc(externalReviews.articleId), asc(externalReviews.id))
+    .for("update");
+  const reviewsByArticle = new Map<
+    number,
+    Array<(typeof rows)[number]["review"]>
+  >();
+  for (const { review } of rows) {
+    const reviews = reviewsByArticle.get(review.articleId) ?? [];
+    reviews.push(review);
+    reviewsByArticle.set(review.articleId, reviews);
+  }
+
+  for (const reviews of reviewsByArticle.values()) {
+    const oldKeyReviews = reviews.filter(
+      ({ sourceKey }) => !sourceKey || !ReviewSourceKeyPattern.test(sourceKey),
+    );
+    const currentKeyReviews = reviews.filter(
+      ({ sourceKey }) =>
+        sourceKey !== null && ReviewSourceKeyPattern.test(sourceKey),
+    );
+    const reviewsToKeep = oldKeyReviews.length
+      ? oldKeyReviews
+      : currentKeyReviews;
+    const expectedKeys = reviewsToKeep.map(({ name, reviewerName }) =>
+      reviewSourceKey(name, reviewerName),
+    );
+
+    if (new Set(expectedKeys).size !== expectedKeys.length) {
+      throw new ScrapeSourceValidationError(
+        "Each review in an article must have a unique name and writer combination before this version can be activated.",
+      );
+    }
+    if (
+      currentKeyReviews.some(
+        ({ sourceKey, name, reviewerName }) =>
+          sourceKey !== reviewSourceKey(name, reviewerName),
+      )
+    ) {
+      throw new ScrapeSourceValidationError(
+        "This site has reviews that cannot be matched safely. Check them before activating this version.",
+      );
+    }
+
+    if (oldKeyReviews.length && currentKeyReviews.length) {
+      const currentReviewsByKey = new Map(
+        currentKeyReviews.map((review) => [review.sourceKey, review]),
+      );
+      if (
+        currentKeyReviews.length !== oldKeyReviews.length ||
+        expectedKeys.some(
+          (key, index) =>
+            !currentReviewsByKey.has(key) ||
+            currentReviewsByKey.get(key)!.id <= oldKeyReviews[index]!.id,
+        )
+      ) {
+        throw new ScrapeSourceValidationError(
+          "This site has reviews that cannot be matched safely. Check them before activating this version.",
+        );
+      }
+      for (const [index, original] of oldKeyReviews.entries()) {
+        const sourceKey = expectedKeys[index];
+        const newer = sourceKey
+          ? currentReviewsByKey.get(sourceKey)
+          : undefined;
+        if (!newer) throw new Error("Failed to find the newer review.");
+        for (const bottleId of await keepOriginalReview(tx, original, newer)) {
+          changedBottleIds.add(bottleId);
+        }
+      }
+      await tx.delete(externalReviews).where(
+        inArray(
+          externalReviews.id,
+          currentKeyReviews.map(({ id }) => id),
+        ),
+      );
+    } else if (!oldKeyReviews.length) {
+      continue;
+    }
+
+    for (const [index, review] of oldKeyReviews.entries()) {
+      const expectedKey = expectedKeys[index];
+      if (!expectedKey) throw new Error("Failed to prepare review keys.");
+      await tx
+        .update(externalReviews)
+        .set({ sourceKey: expectedKey, updatedAt: new Date() })
+        .where(eq(externalReviews.id, review.id));
+    }
+  }
+  return [...changedBottleIds];
+}
 
 function exactOrigin(url: URL) {
   if (url.username || url.password) {
@@ -262,7 +437,7 @@ export async function activateScrapeSourceRevision(input: {
   scrapeSourceId: number;
   revisionId: number;
 }) {
-  return await db.transaction(async (tx) => {
+  const activated = await db.transaction(async (tx) => {
     const [source] = await tx
       .select()
       .from(scrapeSources)
@@ -285,6 +460,32 @@ export async function activateScrapeSourceRevision(input: {
         "Preview this version successfully before you activate it.",
       );
     }
+
+    // Run creation locks this row too, so no run can start after the check below.
+    await tx
+      .select({ id: externalSites.id })
+      .from(externalSites)
+      .where(eq(externalSites.id, source.externalSiteId))
+      .for("update");
+    const [activeRun] = await tx
+      .select({ id: externalSiteRuns.id })
+      .from(externalSiteRuns)
+      .where(
+        and(
+          eq(externalSiteRuns.externalSiteId, source.externalSiteId),
+          inArray(externalSiteRuns.status, ["queued", "running"]),
+        ),
+      )
+      .limit(1);
+    if (activeRun) {
+      throw new ScrapeSourceValidationError(
+        "Wait for the current run to finish before activating this version.",
+      );
+    }
+    const changedBottleIds =
+      source.kind === "review" && revision.rulesVersion === SCRAPE_RULES_VERSION
+        ? await prepareReviewKeysForActivation(tx, source.externalSiteId)
+        : [];
 
     await tx
       .update(scrapeSourceRevisions)
@@ -312,8 +513,18 @@ export async function activateScrapeSourceRevision(input: {
       .where(eq(scrapeSources.id, source.id))
       .returning();
     if (!enabledSource) throw new ScrapeSourceNotFoundError();
-    return { source: enabledSource, revision: activeRevision };
+    return {
+      source: enabledSource,
+      revision: activeRevision,
+      changedBottleIds,
+    };
   });
+  await dispatchBottleStatsRecomputes(
+    "externalReview",
+    `scrapeSource:${input.scrapeSourceId}`,
+    activated.changedBottleIds,
+  );
+  return { source: activated.source, revision: activated.revision };
 }
 
 export async function pauseScrapeSource(scrapeSourceId: number) {

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -9,6 +9,11 @@ Once a site has a saved source, it stops using its old scraper. Collection stays
 stopped until the new rules pass preview and an admin enables them. Pausing the
 new source also stops collection.
 
+If an earlier attempt created a second copy of a review, activation keeps the
+original review ID and visibility. It carries over the later Bottle match and
+newest saved body before removing the copy. It stops when the two copies point
+to different Bottles, and it refreshes affected Bottle summaries after saving.
+
 ## Bourbon Culture
 
 Use `POST /v1/admin/scrape-sources/prepare` with an authenticated admin account
@@ -172,8 +177,9 @@ Before applying, save article URLs, review IDs and order, Bottle matches,
 visibility, scores, writers, publication settings, stored-body counts, and the
 current schedule. Stop the schedule and wait for active runs. Compare every
 record after applying; multi-Bottle and multi-writer articles must keep the
-same review order and IDs. Repeated reviews with the same Bottle name and writer
-keep separate keys in their original order.
+same review order and IDs. Each review in an article must have a unique name and
+writer combination. If a page repeats both, adjust the name rule to include the
+publisher's distinguishing text. Never identify a review by its page position.
 
 Version 8 rules must select up to 20 articles from the current review page. On
 detail pages, use the content column inside `article.h-entry`, then match


### PR DESCRIPTION
Version 10 review rules match each article by its URL and each review inside it by its normalized name and writer, never by page position. Preview and activation stop when that pair is repeated, so the rules must select a genuinely unique name before migration.

When older reviews move to this matching rule, Peated keeps their original IDs and visibility. If a failed switch already created second copies, activation carries over the later Bottle match, score, tags, summary, and newest saved body before removing those copies. It stops instead of guessing when two copies point to different Bottles, and it refreshes affected Bottle summaries after the database change commits. Activation also waits for any active scrape to finish.

Configured scrapers also clean up common product-page values found during migration checks: HTTP image links on HTTPS pages become HTTPS, labels such as `Volume (ml): 700` parse as 700 ml, and an age range such as `18-24 year old` uses 18 as the stated age. These cases stay in the existing value readers, so rules do not need source-specific workarounds.

Checks: focused parser, activation, runtime, and migration tests; lint; server typecheck.