### PR TITLE
fix(prices): recover interrupted retry runs

### DIFF
--- a/apps/server/src/agents/bottleClassifier/scrapedBottleReference.test.ts
+++ b/apps/server/src/agents/bottleClassifier/scrapedBottleReference.test.ts
@@ -18,15 +18,16 @@ test("keeps scraped classification on the isolated service capability", async ()
     artifacts: {},
   });
   const run = { result: classification, modelMetadata: null };
+  const signal = AbortSignal.timeout(1_000);
   classifyInService.mockResolvedValue(classification);
   runInService.mockResolvedValue(run);
 
   await expect(
     classifyScrapedBottleReference(input, classifyInService),
   ).resolves.toBe(classification);
-  await expect(runScrapedBottleReference(input, runInService)).resolves.toBe(
-    run,
-  );
+  await expect(
+    runScrapedBottleReference(input, { signal }, runInService),
+  ).resolves.toBe(run);
   expect(classifyInService).toHaveBeenCalledWith(input);
-  expect(runInService).toHaveBeenCalledWith(input);
+  expect(runInService).toHaveBeenCalledWith(input, { signal });
 });

--- a/apps/server/src/agents/bottleClassifier/scrapedBottleReference.ts
+++ b/apps/server/src/agents/bottleClassifier/scrapedBottleReference.ts
@@ -1,4 +1,5 @@
 import type { ClassifyBottleReferenceInput } from "@peated/bottle-classifier";
+import type { BottleClassifierRunOptions } from "@peated/bottle-classifier/internal/runtime";
 import {
   classifyScrapedBottleReference as classifyWithServerAdapters,
   runScrapedBottleReference as runWithServerAdapters,
@@ -14,7 +15,8 @@ export async function classifyScrapedBottleReference(
 
 export async function runScrapedBottleReference(
   input: ClassifyBottleReferenceInput,
+  options: BottleClassifierRunOptions = {},
   runReference: typeof runWithServerAdapters = runWithServerAdapters,
 ) {
-  return await runReference(input);
+  return await runReference(input, options);
 }

--- a/apps/server/src/agents/bottleClassifier/service.ts
+++ b/apps/server/src/agents/bottleClassifier/service.ts
@@ -4,7 +4,10 @@ import type {
   ClassifyBottleReferenceInput,
 } from "@peated/bottle-classifier/contract";
 import { AuditBottleInputSchema } from "@peated/bottle-classifier/contract";
-import type { RunBottleClassifierAgentInput } from "@peated/bottle-classifier/internal/runtime";
+import type {
+  BottleClassifierRunOptions,
+  RunBottleClassifierAgentInput,
+} from "@peated/bottle-classifier/internal/runtime";
 import { createBottleClassifier } from "@peated/bottle-classifier/internal/runtime";
 import {
   EntityResolutionSchema,
@@ -131,6 +134,7 @@ export function getBottleClassifier(
 async function runBottleReferenceForWorkload(
   input: ClassifyBottleReferenceInput,
   workload: AIGatewayWorkload,
+  options?: BottleClassifierRunOptions,
 ) {
   const reference = normalizeReferenceForClassifier(input.reference);
   const conversationId = buildReferenceConversationId(
@@ -149,11 +153,14 @@ async function runBottleReferenceForWorkload(
       return exactReferenceRun;
     }
 
-    return await getBottleClassifier(workload).runBottleReference({
-      ...input,
-      reference,
-      conversationId,
-    });
+    return await getBottleClassifier(workload).runBottleReference(
+      {
+        ...input,
+        reference,
+        conversationId,
+      },
+      options,
+    );
   });
 }
 
@@ -169,8 +176,9 @@ export async function runBottleReference(input: ClassifyBottleReferenceInput) {
 
 export async function runScrapedBottleReference(
   input: ClassifyBottleReferenceInput,
+  options?: BottleClassifierRunOptions,
 ) {
-  return await runBottleReferenceForWorkload(input, "scraper");
+  return await runBottleReferenceForWorkload(input, "scraper", options);
 }
 
 export async function classifyScrapedBottleReference(

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -1165,6 +1165,7 @@ export type StorePriceMatchResolverOptions = {
   force?: boolean;
   processingToken?: string;
   reuseExistingExtraction?: boolean;
+  signal?: AbortSignal;
 };
 
 export type StorePriceReferenceRunner = typeof runScrapedBottleReference;
@@ -1184,6 +1185,7 @@ export function createStorePriceMatchResolver({
       force = false,
       processingToken,
       reuseExistingExtraction = false,
+      signal,
     }: StorePriceMatchResolverOptions = {},
   ) {
     const price = await db.query.storePrices.findFirst({
@@ -1275,7 +1277,9 @@ export function createStorePriceMatchResolver({
           parseStoredExtractedLabel(existingProposal);
       }
 
-      const classificationRun = await runReference(classificationInput);
+      const classificationRun = signal
+        ? await runReference(classificationInput, { signal })
+        : await runReference(classificationInput);
       const classification = classificationRun.result;
       classificationModelMetadata = classificationRun.modelMetadata;
 

--- a/apps/server/src/lib/storePriceMatchRetryRuns.test.ts
+++ b/apps/server/src/lib/storePriceMatchRetryRuns.test.ts
@@ -82,6 +82,7 @@ describe("store price match retry runs", () => {
         force: true,
         processingToken: expect.any(String),
         reuseExistingExtraction: true,
+        signal: expect.any(AbortSignal),
       }),
     );
     expect(enqueueNext).toHaveBeenCalledWith({
@@ -109,6 +110,160 @@ describe("store price match retry runs", () => {
       processedCount: 2,
       reviewableCount: 2,
       status: "completed",
+    });
+  });
+
+  test("recovers an item abandoned by an interrupted worker", async ({
+    fixtures,
+  }) => {
+    const price = await fixtures.StorePrice({
+      name: "Retry Run Interrupted",
+    });
+    const exhaustedPrice = await fixtures.StorePrice({
+      name: "Retry Run Interrupted Repeatedly",
+    });
+    const [proposal, exhaustedProposal] = await db
+      .insert(storePriceMatchProposals)
+      .values([
+        {
+          priceId: price.id,
+          status: "pending_review",
+          proposalType: "match_existing",
+        },
+        {
+          priceId: exhaustedPrice.id,
+          status: "pending_review",
+          proposalType: "match_existing",
+        },
+      ])
+      .returning();
+    const [run] = await db
+      .insert(storePriceMatchRetryRuns)
+      .values({
+        matchedCount: 2,
+        status: "running",
+      })
+      .returning();
+    const [item, exhaustedItem] = await db
+      .insert(storePriceMatchRetryRunItems)
+      .values([
+        {
+          attempts: 1,
+          priceId: price.id,
+          proposalId: proposal!.id,
+          runId: run!.id,
+          startedAt: new Date(Date.now() - 60_000),
+          status: "processing",
+        },
+        {
+          attempts: 3,
+          priceId: exhaustedPrice.id,
+          proposalId: exhaustedProposal!.id,
+          runId: run!.id,
+          startedAt: new Date(Date.now() - 60_000),
+          status: "processing",
+        },
+      ])
+      .returning();
+    const resolveProposal = vi.fn(async () => proposal!);
+
+    await processStorePriceMatchRetryRun({
+      enqueueNext: vi.fn(async () => undefined),
+      resolveProposal,
+      runId: run!.id,
+      staleAfterMs: 0,
+    });
+
+    const [updatedRun, updatedItem, updatedExhaustedItem] = await Promise.all([
+      db.query.storePriceMatchRetryRuns.findFirst({
+        where: eq(storePriceMatchRetryRuns.id, run!.id),
+      }),
+      db.query.storePriceMatchRetryRunItems.findFirst({
+        where: eq(storePriceMatchRetryRunItems.id, item!.id),
+      }),
+      db.query.storePriceMatchRetryRunItems.findFirst({
+        where: eq(storePriceMatchRetryRunItems.id, exhaustedItem!.id),
+      }),
+    ]);
+    expect(resolveProposal).toHaveBeenCalledOnce();
+    expect(updatedRun).toMatchObject({
+      failedCount: 1,
+      processedCount: 2,
+      reviewableCount: 1,
+      status: "completed",
+    });
+    expect(updatedItem).toMatchObject({
+      attempts: 2,
+      resultStatus: "pending_review",
+      status: "completed",
+    });
+    expect(updatedExhaustedItem).toMatchObject({
+      attempts: 3,
+      status: "failed",
+    });
+  });
+
+  test("fails a classifier attempt that exceeds its time limit", async ({
+    fixtures,
+  }) => {
+    const price = await fixtures.StorePrice({
+      name: "Retry Run Timeout",
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "match_existing",
+      })
+      .returning();
+    const [run] = await db
+      .insert(storePriceMatchRetryRuns)
+      .values({ matchedCount: 1 })
+      .returning();
+    const [item] = await db
+      .insert(storePriceMatchRetryRunItems)
+      .values({
+        priceId: price.id,
+        proposalId: proposal!.id,
+        runId: run!.id,
+      })
+      .returning();
+    const resolveProposal = vi.fn(
+      async (_priceId: number, options?: { signal?: AbortSignal }) => {
+        const signal = options?.signal;
+        if (!signal) throw new Error("Missing retry timeout signal.");
+        await new Promise<void>((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          });
+        });
+        return proposal!;
+      },
+    );
+
+    await processStorePriceMatchRetryRun({
+      enqueueNext: vi.fn(async () => undefined),
+      itemTimeoutMs: 1,
+      resolveProposal,
+      runId: run!.id,
+    });
+
+    const [updatedRun, updatedItem] = await Promise.all([
+      db.query.storePriceMatchRetryRuns.findFirst({
+        where: eq(storePriceMatchRetryRuns.id, run!.id),
+      }),
+      db.query.storePriceMatchRetryRunItems.findFirst({
+        where: eq(storePriceMatchRetryRunItems.id, item!.id),
+      }),
+    ]);
+    expect(updatedRun).toMatchObject({
+      failedCount: 1,
+      processedCount: 1,
+      status: "completed",
+    });
+    expect(updatedItem).toMatchObject({
+      status: "failed",
     });
   });
 
@@ -203,6 +358,7 @@ describe("store price match retry runs", () => {
     });
 
     await vi.waitFor(() => expect(resolveProposal).toHaveBeenCalledOnce());
+    expect(enqueueNext).toHaveBeenCalledOnce();
     await cancelStorePriceMatchRetryRun(run!.id);
     finishResolution(proposal!);
     await processing;
@@ -225,6 +381,5 @@ describe("store price match retry runs", () => {
       resultStatus: null,
       status: "skipped",
     });
-    expect(enqueueNext).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/lib/storePriceMatchRetryRuns.ts
+++ b/apps/server/src/lib/storePriceMatchRetryRuns.ts
@@ -12,9 +12,29 @@ import {
 import {
   claimStorePriceMatchProposalProcessingLease,
   releaseStorePriceMatchProposalProcessingLease,
+  STORE_PRICE_MATCH_PROCESSING_LEASE_MS,
 } from "@peated/server/lib/priceMatchingProcessingLease";
 import { resolveStorePriceMatchProposal } from "@peated/server/lib/priceMatchingProposals";
-import { and, asc, eq, exists, inArray, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  exists,
+  gte,
+  inArray,
+  isNull,
+  lt,
+  lte,
+  or,
+  sql,
+} from "drizzle-orm";
+
+const RETRY_RUN_JOB_ATTEMPTS = 3;
+const RETRY_RUN_ITEM_MAX_ATTEMPTS = 3;
+const RETRY_RUN_ITEM_TIMEOUT_MS =
+  STORE_PRICE_MATCH_PROCESSING_LEASE_MS - 60_000;
+const RETRY_RUN_ITEM_STALE_AFTER_MS =
+  STORE_PRICE_MATCH_PROCESSING_LEASE_MS + 60_000;
 
 export const STORE_PRICE_MATCH_RETRY_RUN_TERMINAL_STATUSES = [
   "completed",
@@ -142,41 +162,96 @@ export async function enqueueStorePriceMatchRetryRunJob({
       runId,
     },
     {
+      attempts: RETRY_RUN_JOB_ATTEMPTS,
+      backoff: {
+        delay: 1_000,
+        type: "exponential",
+      },
       delay: delayMs,
       removeOnComplete: true,
+      removeOnFail: false,
     },
   );
 }
 
-async function claimRetryRunItems({
-  batchSize,
+function getStaleRetryRunItemWhere(runId: number, staleAfterMs: number) {
+  return and(
+    eq(storePriceMatchRetryRunItems.runId, runId),
+    eq(storePriceMatchRetryRunItems.status, "processing"),
+    or(
+      isNull(storePriceMatchRetryRunItems.startedAt),
+      lte(
+        storePriceMatchRetryRunItems.startedAt,
+        sql`NOW() - ${staleAfterMs} * interval '1 millisecond'`,
+      ),
+    ),
+  );
+}
+
+async function claimRetryRunItem({
   runId,
+  staleAfterMs,
 }: {
-  batchSize: number;
   runId: number;
+  staleAfterMs: number;
 }) {
   return await db.transaction(async (tx) => {
-    const pendingItems = await tx
+    // Retry-run worker owns stale-item recovery after the proposal lease can no
+    // longer belong to the interrupted attempt.
+    const exhaustedItems = await tx
+      .update(storePriceMatchRetryRunItems)
+      .set({
+        completedAt: sql`NOW()`,
+        error: "Retry item exceeded its recovery attempts.",
+        status: "failed",
+        updatedAt: sql`NOW()`,
+      })
+      .where(
+        and(
+          getStaleRetryRunItemWhere(runId, staleAfterMs),
+          gte(
+            storePriceMatchRetryRunItems.attempts,
+            RETRY_RUN_ITEM_MAX_ATTEMPTS,
+          ),
+        ),
+      )
+      .returning({ id: storePriceMatchRetryRunItems.id });
+
+    if (exhaustedItems.length) {
+      await tx
+        .update(storePriceMatchRetryRuns)
+        .set({
+          failedCount: sql`${storePriceMatchRetryRuns.failedCount} + ${exhaustedItems.length}`,
+          processedCount: sql`${storePriceMatchRetryRuns.processedCount} + ${exhaustedItems.length}`,
+          updatedAt: sql`NOW()`,
+        })
+        .where(
+          and(
+            eq(storePriceMatchRetryRuns.id, runId),
+            inArray(storePriceMatchRetryRuns.status, ["pending", "running"]),
+          ),
+        );
+    }
+
+    const claimableWhere = or(
+      eq(storePriceMatchRetryRunItems.status, "pending"),
+      and(
+        getStaleRetryRunItemWhere(runId, staleAfterMs),
+        lt(storePriceMatchRetryRunItems.attempts, RETRY_RUN_ITEM_MAX_ATTEMPTS),
+      ),
+    );
+    const [pendingItem] = await tx
       .select({
         id: storePriceMatchRetryRunItems.id,
       })
       .from(storePriceMatchRetryRunItems)
-      .where(
-        and(
-          eq(storePriceMatchRetryRunItems.runId, runId),
-          eq(storePriceMatchRetryRunItems.status, "pending"),
-        ),
-      )
+      .where(and(eq(storePriceMatchRetryRunItems.runId, runId), claimableWhere))
       .orderBy(asc(storePriceMatchRetryRunItems.id))
-      .limit(batchSize);
+      .limit(1);
 
-    const itemIds = pendingItems.map((item) => item.id);
-    if (!itemIds.length) {
-      const noItems: StorePriceMatchRetryRunItem[] = [];
-      return noItems;
-    }
+    if (!pendingItem) return null;
 
-    return await tx
+    const [item] = await tx
       .update(storePriceMatchRetryRunItems)
       .set({
         attempts: sql`${storePriceMatchRetryRunItems.attempts} + 1`,
@@ -186,11 +261,12 @@ async function claimRetryRunItems({
       })
       .where(
         and(
-          inArray(storePriceMatchRetryRunItems.id, itemIds),
-          eq(storePriceMatchRetryRunItems.status, "pending"),
+          eq(storePriceMatchRetryRunItems.id, pendingItem.id),
+          claimableWhere,
         ),
       )
       .returning();
+    return item ?? null;
   });
 }
 
@@ -429,10 +505,12 @@ async function completeRetryRunIfDone(runId: number) {
 }
 
 async function processRetryRunItem({
+  itemTimeoutMs,
   item,
   mode,
   resolveProposal,
 }: {
+  itemTimeoutMs: number;
   item: StorePriceMatchRetryRunItem;
   mode: StorePriceMatchRetryRunMode;
   resolveProposal: ResolveStorePriceMatchProposal;
@@ -450,9 +528,11 @@ async function processRetryRunItem({
   }
 
   try {
+    const signal = AbortSignal.timeout(itemTimeoutMs);
     const proposal = await resolveProposal(item.priceId, {
       force: true,
       processingToken: lease.processingToken,
+      signal,
       ...getRetryRunModeOptions(mode),
     });
     await markRetryRunItemCompleted({
@@ -476,14 +556,18 @@ export async function processStorePriceMatchRetryRun({
   batchSize = config.PRICE_MATCH_RETRY_RUN_BATCH_SIZE,
   delayMs = config.PRICE_MATCH_RETRY_RUN_DELAY_MS,
   enqueueNext = enqueueStorePriceMatchRetryRunJob,
+  itemTimeoutMs = RETRY_RUN_ITEM_TIMEOUT_MS,
   resolveProposal = resolveStorePriceMatchProposal,
   runId,
+  staleAfterMs = RETRY_RUN_ITEM_STALE_AFTER_MS,
 }: {
   batchSize?: number;
   delayMs?: number;
   enqueueNext?: (args: { delayMs?: number; runId: number }) => Promise<void>;
+  itemTimeoutMs?: number;
   resolveProposal?: ResolveStorePriceMatchProposal;
   runId: number;
+  staleAfterMs?: number;
 }) {
   const existingRun = await db.query.storePriceMatchRetryRuns.findFirst({
     where: eq(storePriceMatchRetryRuns.id, runId),
@@ -506,12 +590,19 @@ export async function processStorePriceMatchRetryRun({
     })
     .where(eq(storePriceMatchRetryRuns.id, runId));
 
-  const items = await claimRetryRunItems({ batchSize, runId });
-  if (!items.length) {
-    return await completeRetryRunIfDone(runId);
+  const completedRun = await completeRetryRunIfDone(runId);
+  if (completedRun) {
+    return completedRun;
   }
 
-  for (const item of items) {
+  // Retry-run worker owns durable continuation: queue before slow model work
+  // so a worker restart cannot strand the run.
+  await enqueueNext({ delayMs, runId });
+
+  for (let itemNumber = 0; itemNumber < batchSize; itemNumber += 1) {
+    const item = await claimRetryRunItem({ runId, staleAfterMs });
+    if (!item) break;
+
     const currentRun = await db.query.storePriceMatchRetryRuns.findFirst({
       where: eq(storePriceMatchRetryRuns.id, runId),
     });
@@ -521,18 +612,17 @@ export async function processStorePriceMatchRetryRun({
     }
 
     await processRetryRunItem({
+      itemTimeoutMs,
       item,
       mode: currentRun.mode,
       resolveProposal,
     });
   }
 
-  const completedRun = await completeRetryRunIfDone(runId);
-  if (completedRun) {
-    return completedRun;
+  const finishedRun = await completeRetryRunIfDone(runId);
+  if (finishedRun) {
+    return finishedRun;
   }
-
-  await enqueueNext({ delayMs, runId });
 
   return await db.query.storePriceMatchRetryRuns.findFirst({
     where: eq(storePriceMatchRetryRuns.id, runId),

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -4048,8 +4048,14 @@ describe("price match queue", () => {
         runId: result.id,
       },
       {
+        attempts: 3,
+        backoff: {
+          delay: 1_000,
+          type: "exponential",
+        },
         delay: 0,
         removeOnComplete: true,
+        removeOnFail: false,
       },
     );
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalledWith(

--- a/packages/bottle-classifier/src/classifierOutputBoundary.test.ts
+++ b/packages/bottle-classifier/src/classifierOutputBoundary.test.ts
@@ -353,6 +353,18 @@ describe("classifier output boundary", () => {
     });
   });
 
+  test("passes an abort signal to the reference agent run", async () => {
+    const signal = AbortSignal.timeout(1_000);
+    const prepared = await prepareBottleClassifierAgentRun(classifierOptions, {
+      reference: { name: "Example Single Malt" },
+      extractedIdentity: null,
+      initialCandidates: [],
+      signal,
+    });
+
+    expect(prepared.runOptions.signal).toBe(signal);
+  });
+
   test("rejects operation fields in the strict reference result", async () => {
     const prepared = await prepareBottleClassifierAgentRun(classifierOptions, {
       reference: { name: "Laphroaig Cairdeas 2022" },

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -268,6 +268,11 @@ export type RunBottleClassifierAgentInput = {
   resolvedEntities?: EntityResolution[];
   identityAnchor?: BottleClassificationDecision | null;
   webSearchBudget?: BottleWebSearchBudget;
+  signal?: AbortSignal;
+};
+
+export type BottleClassifierRunOptions = {
+  signal?: AbortSignal;
 };
 
 export type BottleClassifierAdapters = BottleClassifierDataSource;
@@ -332,6 +337,7 @@ export type CreateBottleClassifierOptions = BaseCreateBottleClassifierOptions &
 export type BottleClassifier = {
   runBottleReference: (
     input: ClassifyBottleReferenceInput,
+    options?: BottleClassifierRunOptions,
   ) => Promise<BottleReferenceRun>;
   classifyBottleReference: (
     input: ClassifyBottleReferenceInput,
@@ -592,6 +598,7 @@ export async function prepareBottleClassifierAgentRun(
     identityAnchor = null,
     webSearchBudget: inputWebSearchBudget,
     conversationId,
+    signal,
   }: RunBottleClassifierAgentInput,
 ): Promise<PreparedBottleClassifierAgentRun> {
   const dataSource = getBottleClassifierDataSource(options);
@@ -708,6 +715,11 @@ export async function prepareBottleClassifierAgentRun(
       imageEvidence: normalizedImageEvidence,
       state,
     });
+  const runOptions: PreparedBottleClassifierAgentRun["runOptions"] = {
+    maxTurns: REFERENCE_CLASSIFIER_MAX_TURNS,
+    stream: false,
+  };
+  if (signal) runOptions.signal = signal;
 
   return {
     agent,
@@ -725,10 +737,7 @@ export async function prepareBottleClassifierAgentRun(
           ? "none"
           : `${reference.currentBottleId}`,
     },
-    runOptions: {
-      maxTurns: REFERENCE_CLASSIFIER_MAX_TURNS,
-      stream: false,
-    },
+    runOptions,
     webSearchBudget,
     getArtifacts,
     getAgentResult: (result) => {
@@ -1465,6 +1474,7 @@ export function createBottleClassifier(
 
   const runBottleReference = async (
     input: ClassifyBottleReferenceInput,
+    runOptions: BottleClassifierRunOptions = {},
   ): Promise<BottleReferenceRun> => {
     const parsedInput = ClassifyBottleReferenceInputSchema.parse(input);
     const conversationId = buildClassifierConversationId(
@@ -1494,7 +1504,7 @@ export function createBottleClassifier(
         };
       }
 
-      const agentRun = await runBottleClassifierAgentWithBudget({
+      const agentInput: RunBottleClassifierAgentInput = {
         reference: parsedInput.reference,
         conversationId,
         extractedIdentity: artifacts.extractedIdentity,
@@ -1505,7 +1515,9 @@ export function createBottleClassifier(
         resolvedEntities: artifacts.resolvedEntities,
         identityAnchor: preparedEvidence.deterministicDecision,
         webSearchBudget: preparedEvidence.webSearchBudget,
-      });
+      };
+      if (runOptions.signal) agentInput.signal = runOptions.signal;
+      const agentRun = await runBottleClassifierAgentWithBudget(agentInput);
       const agentResult = {
         ...agentRun.agentResult,
         // Extraction provenance is runtime-owned. Agent output cannot replace it.

--- a/packages/bottle-classifier/src/internal/runtime.ts
+++ b/packages/bottle-classifier/src/internal/runtime.ts
@@ -4,6 +4,7 @@ export {
   type BottleClassifier,
   type BottleClassifierAdapters,
   type BottleClassifierDataSource,
+  type BottleClassifierRunOptions,
   type BottleReferenceRun,
   type CreateBottleClassifierOptions,
   type RunBottleAuditAgentInput,


### PR DESCRIPTION
Price-match retry runs now keep a continuation queued before slow classifier work, stop an individual classifier attempt before its processing window expires, and safely reclaim an item left behind by a worker restart. Items are claimed only when they are about to run, and repeated interruptions become recorded failures instead of leaving the whole run permanently marked as running.

This keeps the existing queue, run records, and UI behavior unchanged. Regression coverage exercises normal progress, timeouts, stale-item recovery, repeated interruptions, cancellation, queue retry settings, and cancellation-signal propagation. The focused server suites, classifier suite, typechecks, lint, and formatting pass.
