### PR TITLE
fix(moderation): hide handled catalog failures

### DIFF
--- a/apps/server/src/orpc/routes/admin/moderation/automation.test.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/automation.test.ts
@@ -93,6 +93,7 @@ describe("admin moderation automation", () => {
           key: `operation:${operation!.id}`,
           status: "failed",
           title: `Catalog change #${operation!.id}`,
+          href: `/admin/moderation/history/operation/${operation!.id}`,
         }),
         expect.objectContaining({
           key: `retry_run:${run!.id}`,
@@ -102,6 +103,53 @@ describe("admin moderation automation", () => {
       ]),
     );
     expect(getQueueCounts).toHaveBeenCalledOnce();
+  });
+
+  test("omits catalog failures after their audit is closed", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const bottle = await fixtures.Bottle();
+    const [check] = await db
+      .insert(bottleChecks)
+      .values({
+        intent: "audit_bottle",
+        origin: "moderator",
+        bottleId: bottle.id,
+        subjectKey: `audit:${bottle.id}:closed-automation-test`,
+        schemaVersion: BOTTLE_CHECK_SCHEMA_VERSION,
+        inputSnapshot: {},
+        output: { summary: "Execution stopped", findings: [] },
+        closedAt: new Date(),
+        closedById: admin.id,
+        closeReason: "dismissed",
+      })
+      .returning();
+    const [operation] = await db
+      .insert(bottleOperations)
+      .values({
+        checkId: check!.id,
+        proposal: {
+          type: "update_entity",
+          input: { entityId: bottle.brandId, patch: { name: "Stale brand" } },
+          rationale: "Execution test.",
+          evidenceRefs: [],
+        },
+        status: "stale",
+        error: "Catalog state changed.",
+      })
+      .returning();
+
+    const automationClient = createRouterClient(
+      { automation: createModerationAutomationProcedure(getQueueCounts) },
+      { context: { user: admin } },
+    );
+    const result = await automationClient.automation();
+
+    expect(result.counts.failed).toBe(1);
+    expect(result.needsAttention).not.toContainEqual(
+      expect.objectContaining({ key: `operation:${operation!.id}` }),
+    );
   });
 
   test("counts retry health beyond the ten most recent runs", async ({

--- a/apps/server/src/orpc/routes/admin/moderation/automation.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/automation.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
 import {
+  bottleChecks,
   bottleOperations,
   incomingBottleDecisionLogs,
   storePriceMatchAttempts,
@@ -9,7 +10,16 @@ import {
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import { getQueue } from "@peated/server/worker/queue";
-import { desc, eq, gte, inArray, isNotNull, sql } from "drizzle-orm";
+import {
+  and,
+  desc,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  sql,
+} from "drizzle-orm";
 import { ModerationAutomationResponseSchema } from "./schemas";
 
 const LISTING_AUTOMATION_SAMPLE_SIZE = 100;
@@ -108,6 +118,7 @@ export function createModerationAutomationProcedure(
       startOfToday.setHours(0, 0, 0, 0);
 
       // Health totals cover all durable work; limits apply only to rendered lists.
+      // Moderation owns open audit failures; closed audit records remain in History.
       const [
         proposalCounts,
         operationCounts,
@@ -124,11 +135,15 @@ export function createModerationAutomationProcedure(
           .from(storePriceMatchProposals),
         db
           .select({
-            processing: sql<number>`count(*) filter (where ${bottleOperations.status} = 'applying')::int`,
-            failed: sql<number>`count(*) filter (where ${bottleOperations.status} IN ('stale', 'failed'))::int`,
+            processing: sql<number>`count(*) filter (where ${bottleChecks.closedAt} IS NULL AND ${bottleOperations.status} = 'applying')::int`,
+            failed: sql<number>`count(*) filter (where ${bottleChecks.closedAt} IS NULL AND ${bottleOperations.status} IN ('stale', 'failed'))::int`,
             clearedToday: sql<number>`count(*) filter (where ${bottleOperations.executionCompletedAt} >= ${startOfToday} OR (${bottleOperations.reviewedAt} >= ${startOfToday} AND ${bottleOperations.status} = 'rejected'))::int`,
           })
-          .from(bottleOperations),
+          .from(bottleOperations)
+          .innerJoin(
+            bottleChecks,
+            eq(bottleChecks.id, bottleOperations.checkId),
+          ),
         db
           .select({ count: sql<number>`count(*)::int` })
           .from(incomingBottleDecisionLogs)
@@ -165,9 +180,15 @@ export function createModerationAutomationProcedure(
       ]);
 
       const failedOperations = await db
-        .select()
+        .select({ operation: bottleOperations })
         .from(bottleOperations)
-        .where(inArray(bottleOperations.status, ["stale", "failed"]))
+        .innerJoin(bottleChecks, eq(bottleChecks.id, bottleOperations.checkId))
+        .where(
+          and(
+            inArray(bottleOperations.status, ["stale", "failed"]),
+            isNull(bottleChecks.closedAt),
+          ),
+        )
         .orderBy(desc(bottleOperations.updatedAt))
         .limit(25);
       return {
@@ -190,13 +211,13 @@ export function createModerationAutomationProcedure(
         },
         listingAutomation: summarizeListingAutomation(recentListingAttempts),
         needsAttention: [
-          ...failedOperations.map((operation) => ({
+          ...failedOperations.map(({ operation }) => ({
             key: `operation:${operation.id}`,
             kind: "operation" as const,
             title: `Catalog change #${operation.id}`,
             status: operation.status,
             detail: operation.error,
-            href: "/admin/moderation/automation",
+            href: `/admin/moderation/history/operation/${operation.id}`,
             occurredAt: operation.updatedAt.toISOString(),
           })),
           ...failedRetries.map((run) => ({

--- a/apps/server/src/orpc/routes/admin/moderation/history-details.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/history-details.ts
@@ -53,7 +53,7 @@ export default procedure
     path: "/admin/moderation/history/{key}",
     summary: "Get moderation history details",
     description:
-      "Get the recorded evidence, decision, and activity for a completed moderation event. Requires administrator privileges.",
+      "Get the recorded evidence, status, and activity for a moderation event. Requires administrator privileges.",
     operationId: "getModerationHistoryDetails",
   })
   .input(InputSchema)
@@ -112,21 +112,28 @@ export default procedure
         .leftJoin(users, eq(users.id, bottleOperations.reviewedById))
         .where(eq(bottleOperations.id, id))
         .limit(1);
-      if (!row?.operation.reviewedAt) {
+      if (
+        !row ||
+        (!row.operation.reviewedAt &&
+          row.operation.status !== "stale" &&
+          row.operation.status !== "failed")
+      ) {
         throw errors.NOT_FOUND({ message: "History event not found." });
       }
       const { operation, actor } = row;
-      const reviewedAt = operation.reviewedAt!;
+      const occurredAt = operation.reviewedAt ?? operation.updatedAt;
       const activity = [
         {
           label: "Suggestion created",
           occurredAt: operation.createdAt.toISOString(),
         },
-        {
-          label: "Review recorded",
-          occurredAt: reviewedAt.toISOString(),
-        },
       ];
+      if (operation.reviewedAt) {
+        activity.push({
+          label: "Review recorded",
+          occurredAt: operation.reviewedAt.toISOString(),
+        });
+      }
       if (operation.executionCompletedAt) {
         activity.push({
           label: "Execution finished",
@@ -141,7 +148,7 @@ export default procedure
           title: operationTitle(operation.proposal),
           outcome: operation.status.replaceAll("_", " "),
           actor,
-          occurredAt: reviewedAt.toISOString(),
+          occurredAt: occurredAt.toISOString(),
         },
         sourceUrl: null,
         resourceUrl: operationResourceUrl(operation.proposal),

--- a/apps/server/src/orpc/routes/admin/moderation/history.test.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/history.test.ts
@@ -124,4 +124,84 @@ describe("admin moderation history", () => {
       "Review recorded",
     ]);
   });
+
+  test("returns details for a stale operation without a recorded review", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const bottle = await fixtures.Bottle();
+    const [check] = await db
+      .insert(bottleChecks)
+      .values({
+        intent: "audit_bottle",
+        origin: "moderator",
+        bottleId: bottle.id,
+        subjectKey: `audit:${bottle.id}:stale-history-test`,
+        schemaVersion: BOTTLE_CHECK_SCHEMA_VERSION,
+        inputSnapshot: {},
+        output: { summary: "History", findings: [] },
+      })
+      .returning();
+    const updatedAt = new Date("2026-02-05T00:00:00.000Z");
+    const [operation] = await db
+      .insert(bottleOperations)
+      .values({
+        checkId: check!.id,
+        proposal: {
+          type: "update_entity",
+          input: {
+            entityId: bottle.brandId,
+            patch: { name: "Stale brand" },
+          },
+          rationale: "A stale proposal.",
+          evidenceRefs: [],
+        },
+        status: "stale",
+        error: "Catalog state changed.",
+        updatedAt,
+      })
+      .returning();
+
+    const details = await routerClient.admin.moderation.historyDetails(
+      { key: `operation:${operation!.id}` },
+      { context: { user: admin } },
+    );
+
+    expect(details).toMatchObject({
+      event: {
+        actor: null,
+        occurredAt: updatedAt.toISOString(),
+        outcome: "stale",
+      },
+      details: {
+        checkId: check!.id,
+        error: "Catalog state changed.",
+      },
+    });
+    expect(details.activity.map(({ label }) => label)).toEqual([
+      "Suggestion created",
+    ]);
+
+    const [pendingOperation] = await db
+      .insert(bottleOperations)
+      .values({
+        checkId: check!.id,
+        proposal: {
+          type: "update_entity",
+          input: {
+            entityId: bottle.brandId,
+            patch: { name: "Pending brand" },
+          },
+          rationale: "A pending proposal.",
+          evidenceRefs: [],
+        },
+      })
+      .returning();
+    await expect(
+      routerClient.admin.moderation.historyDetails(
+        { key: `operation:${pendingOperation!.id}` },
+        { context: { user: admin } },
+      ),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
 });


### PR DESCRIPTION
Background work now treats a stopped catalog change as needing attention only while its audit remains open. Changes from closed audits stay recorded in History, no longer inflate the actionable failure count, and open failures link directly to their recorded details instead of reloading the overview.

A stopped operation can be inspected even when it became stale before a review timestamp was recorded; its last update is used as the event time and no review activity is invented. Ordinary pending suggestions remain excluded from History.
