### PR TITLE
fix(scraper): stop configured runs when paused

### DIFF
--- a/.agents/skills/deslop
+++ b/.agents/skills/deslop
@@ -1,0 +1,1 @@
+../../skills/deslop

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/pause.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/pause.test.ts
@@ -1,7 +1,16 @@
+import { db } from "@peated/server/db";
+import { externalSiteRuns, externalSites } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
+import { createPinnedScrapeSourceRun } from "@peated/server/scraper/configured/runs";
+import {
+  activateScrapeSourceRevision,
+  recordScrapeSourcePreview,
+  SCRAPE_SOURCE_PAUSED_ERROR,
+} from "@peated/server/scraper/configured/service";
+import { eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
-import { createTestSource } from "./testUtils";
+import { createTestRevision, createTestSource } from "./testUtils";
 
 describe("POST /admin/scrape-sources/:id/pause", () => {
   test("requires an administrator", async ({ defaults }) => {
@@ -37,5 +46,75 @@ describe("POST /admin/scrape-sources/:id/pause", () => {
         { context: { user: admin } },
       ),
     ).resolves.toEqual({ enabled: false });
+  });
+
+  test("stops queued collection without reviving it later", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const { site, source } = await createTestSource(admin.id);
+    const revision = await createTestRevision(source.id, admin.id);
+    await recordScrapeSourcePreview({
+      revisionId: revision.id,
+      status: "passed",
+      result: { issues: [], pages: [] },
+    });
+    await activateScrapeSourceRevision({
+      scrapeSourceId: source.id,
+      revisionId: revision.id,
+    });
+    const stopped = await createPinnedScrapeSourceRun(db, {
+      externalSiteId: site.id,
+      requestedById: admin.id,
+      trigger: "manual",
+      purpose: "collect",
+    });
+
+    await routerClient.externalSites.scrapeSources.pause(
+      { id: source.id },
+      { context: { user: admin } },
+    );
+
+    const [stoppedRun] = await db
+      .select()
+      .from(externalSiteRuns)
+      .where(eq(externalSiteRuns.id, stopped.run.id));
+    const [storedSite] = await db
+      .select()
+      .from(externalSites)
+      .where(eq(externalSites.id, site.id));
+    expect(stoppedRun).toMatchObject({
+      status: "failed",
+      error: SCRAPE_SOURCE_PAUSED_ERROR,
+      nextAttemptAt: null,
+      executionToken: null,
+      executionExpiresAt: null,
+    });
+    expect(stoppedRun?.completedAt).toBeInstanceOf(Date);
+    expect(storedSite).toMatchObject({
+      lastRunAt: stoppedRun?.completedAt,
+      lastRunId: stopped.run.id,
+    });
+
+    await activateScrapeSourceRevision({
+      scrapeSourceId: source.id,
+      revisionId: revision.id,
+    });
+    const later = await createPinnedScrapeSourceRun(db, {
+      externalSiteId: site.id,
+      requestedById: admin.id,
+      trigger: "manual",
+      purpose: "collect",
+    });
+    expect(later.run).toMatchObject({ status: "queued" });
+    expect(later.run.id).not.toBe(stopped.run.id);
+    const [stillStopped] = await db
+      .select()
+      .from(externalSiteRuns)
+      .where(eq(externalSiteRuns.id, stopped.run.id));
+    expect(stillStopped).toMatchObject({
+      status: "failed",
+      error: SCRAPE_SOURCE_PAUSED_ERROR,
+    });
   });
 });

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -78,8 +78,9 @@ The database stores each source and its rules. A saved version cannot be edited.
 A preview checks sample pages and saves only the fields it found and any errors.
 It does not save downloaded HTML, review text, or full product records. Only a
 version that passes its preview can be used. An admin can return to any older
-version that passed. Pausing a source stops collection but keeps its saved
-versions and run history.
+version that passed. Pausing a source fails queued collection runs and stops
+active work at the next request, save, or checkpoint. Saved versions and run
+history stay. Preview and AI setup still work.
 
 Older rule versions remain supported so saved sources keep working. New
 sources use version 10. Each rule is a CSS selector. `list.links` finds article

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -3,8 +3,8 @@ import {
   bottleGroups,
   bottleObservations,
   bottleReferences,
-  bottleSeries,
   bottles,
+  bottleSeries,
   catalogListings,
   externalReviewArticles,
   externalReviewBodies,
@@ -32,7 +32,9 @@ import {
   activateScrapeSourceRevision,
   createScrapeSourceRevision,
   createSiteWithScrapeSource,
+  pauseScrapeSource,
   recordScrapeSourcePreview,
+  SCRAPE_SOURCE_PAUSED_ERROR,
 } from "./service";
 
 type TestClock = ScraperHttpClock & { advanceTo(value: Date): void };
@@ -160,6 +162,26 @@ async function setupCatalogSource(
     })
     .where(eq(scrapeOrigins.origin, "https://catalog.example"));
   return { revision, site, source, user };
+}
+
+async function setupCatalogCollection() {
+  const created = await setupCatalogSource();
+  await recordScrapeSourcePreview({
+    revisionId: created.revision.id,
+    status: "passed",
+    result: { issues: [], pages: [] },
+  });
+  await activateScrapeSourceRevision({
+    scrapeSourceId: created.source.id,
+    revisionId: created.revision.id,
+  });
+  const pinned = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: created.site.id,
+    requestedById: created.user.id,
+    trigger: "manual",
+    purpose: "collect",
+  });
+  return { ...created, pinned };
 }
 
 function catalogFetch(name = "Official Release") {
@@ -431,6 +453,86 @@ test("fails a configured source before requesting a reserved destination", async
     .from(externalSiteRuns)
     .where(eq(externalSiteRuns.id, pinned.run.id));
   expect(run).toMatchObject({ status: "failed", requestCount: 0 });
+});
+
+test("does not request a queued collection after its source is paused", async () => {
+  const { site, source, pinned } = await setupCatalogCollection();
+  await pauseScrapeSource(source.id);
+  const fetchImpl = vi.fn<typeof fetch>();
+
+  await expect(
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl,
+      executionToken: "paused-before-claim",
+    }),
+  ).resolves.toEqual({ status: "completed" });
+
+  expect(fetchImpl).not.toHaveBeenCalled();
+  const [run] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, pinned.run.id));
+  expect(run).toMatchObject({
+    status: "failed",
+    requestCount: 0,
+    emittedItemCount: 0,
+    error: SCRAPE_SOURCE_PAUSED_ERROR,
+  });
+});
+
+test("stops an active collection before saving later observations", async () => {
+  const { site, source, pinned } = await setupCatalogCollection();
+  const secondRequest = Promise.withResolvers<void>();
+  const continueRequest = Promise.withResolvers<void>();
+  const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.pathname === "/whisky") {
+      return new Response(
+        '<article class="product"><a href="/whisky/one">One</a></article><article class="product"><a href="/whisky/two">Two</a></article>',
+      );
+    }
+    if (url.pathname === "/whisky/one") {
+      return new Response(
+        '<main data-product-id="official-1"><h1>First Release</h1></main>',
+      );
+    }
+    if (url.pathname === "/whisky/two") {
+      secondRequest.resolve();
+      await continueRequest.promise;
+      return new Response(
+        '<main data-product-id="official-2"><h1>Second Release</h1></main>',
+      );
+    }
+    throw new Error(`Unexpected URL: ${url.toString()}`);
+  });
+
+  const execution = runToCompletion({
+    runId: pinned.run.id,
+    fetchImpl,
+    executionToken: "paused-during-run",
+  });
+  await secondRequest.promise;
+  await pauseScrapeSource(source.id);
+  continueRequest.resolve();
+
+  await expect(execution).resolves.toEqual({ status: "completed" });
+  expect(await db.select().from(catalogListings)).toMatchObject([
+    {
+      externalSiteId: site.id,
+      externalProductId: "official-1",
+      name: "First Release",
+    },
+  ]);
+  const [run] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, pinned.run.id));
+  expect(run).toMatchObject({
+    status: "failed",
+    emittedItemCount: 1,
+    error: SCRAPE_SOURCE_PAUSED_ERROR,
+  });
 });
 
 test("collects and updates only catalog listings", async () => {

--- a/apps/server/src/scraper/configured/service.ts
+++ b/apps/server/src/scraper/configured/service.ts
@@ -54,6 +54,8 @@ export class ScrapeSourceValidationError extends Error {
   override name = "ScrapeSourceValidationError";
 }
 
+export const SCRAPE_SOURCE_PAUSED_ERROR = "The source was paused.";
+
 const DatabaseErrorSchema = z.object({ code: z.string() });
 const ReviewSourceKeyPattern = /^review:[a-f0-9]{64}$/;
 
@@ -528,11 +530,63 @@ export async function activateScrapeSourceRevision(input: {
 }
 
 export async function pauseScrapeSource(scrapeSourceId: number) {
-  const [source] = await db
-    .update(scrapeSources)
-    .set({ enabled: false, updatedAt: new Date() })
-    .where(eq(scrapeSources.id, scrapeSourceId))
-    .returning();
-  if (!source) throw new ScrapeSourceNotFoundError();
-  return source;
+  return await db.transaction(async (tx) => {
+    // Lifecycle and Pause lock the site before touching collection runs. This
+    // prevents a new run from being saved after Pause stops the current one.
+    const [site] = await tx
+      .select({ id: externalSites.id })
+      .from(scrapeSources)
+      .innerJoin(
+        externalSites,
+        eq(externalSites.id, scrapeSources.externalSiteId),
+      )
+      .where(eq(scrapeSources.id, scrapeSourceId))
+      .for("update", { of: externalSites });
+    if (!site) throw new ScrapeSourceNotFoundError();
+
+    const completedAt = new Date();
+    const [source] = await tx
+      .update(scrapeSources)
+      .set({ enabled: false, updatedAt: completedAt })
+      .where(eq(scrapeSources.id, scrapeSourceId))
+      .returning();
+    if (!source) throw new ScrapeSourceNotFoundError();
+
+    const [activeRun] = await tx
+      .select({ id: externalSiteRuns.id })
+      .from(externalSiteRuns)
+      .innerJoin(
+        scrapeSourceRuns,
+        eq(scrapeSourceRuns.externalSiteRunId, externalSiteRuns.id),
+      )
+      .where(
+        and(
+          eq(scrapeSourceRuns.scrapeSourceId, source.id),
+          eq(scrapeSourceRuns.purpose, "collect"),
+          inArray(externalSiteRuns.status, ["queued", "running"]),
+        ),
+      )
+      .for("update", { of: externalSiteRuns });
+    if (!activeRun) return source;
+
+    const [stoppedRun] = await tx
+      .update(externalSiteRuns)
+      .set({
+        status: "failed",
+        error: SCRAPE_SOURCE_PAUSED_ERROR,
+        completedAt,
+        nextAttemptAt: null,
+        executionToken: null,
+        executionExpiresAt: null,
+      })
+      .where(eq(externalSiteRuns.id, activeRun.id))
+      .returning({ id: externalSiteRuns.id });
+    if (!stoppedRun) throw new Error("Failed to stop the active scraper run.");
+
+    await tx
+      .update(externalSites)
+      .set({ lastRunAt: completedAt, lastRunId: stoppedRun.id })
+      .where(eq(externalSites.id, site.id));
+    return source;
+  });
 }

--- a/apps/server/src/scraper/runs.ts
+++ b/apps/server/src/scraper/runs.ts
@@ -10,6 +10,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { resolveScrapeSourceRunRegistry } from "./configured/runtime";
+import { SCRAPE_SOURCE_PAUSED_ERROR } from "./configured/service";
 import { ScrapeSourceSetupError } from "./configured/setupError";
 import { ScraperCoordinationError } from "./coordinator";
 import {
@@ -105,7 +106,8 @@ async function claimScraperRun({
         eq(externalSites.id, externalSiteRuns.externalSiteId),
       )
       .where(eq(externalSiteRuns.id, runId))
-      .for("update");
+      // Lifecycle and Pause own site locks. A worker owns only its run.
+      .for("update", { of: externalSiteRuns });
     if (!candidate) throw new Error(`Scraper run ${runId} not found.`);
     if (
       candidate.run.status === "succeeded" ||
@@ -183,6 +185,14 @@ async function claimScraperRun({
       executionToken,
     };
   });
+}
+
+async function isScraperRunPaused(runId: number) {
+  const [run] = await db
+    .select({ error: externalSiteRuns.error, status: externalSiteRuns.status })
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, runId));
+  return run?.status === "failed" && run.error === SCRAPE_SOURCE_PAUSED_ERROR;
 }
 
 async function completeRun(claim: ClaimedRun, completedAt: Date) {
@@ -339,6 +349,14 @@ export async function executeScraperRun(
     await completeRun(claimed, clock.now());
     return { status: "completed" };
   } catch (error) {
+    if (
+      (error instanceof ScraperRunOwnershipError ||
+        (error instanceof ScraperRequestError &&
+          error.category === "invalid_request")) &&
+      (await isScraperRunPaused(claimed.run.id))
+    ) {
+      return { status: "completed" };
+    }
     if (
       error instanceof ScraperRequestWaitError ||
       error instanceof ScraperCoordinationError

--- a/skills/deslop/SKILL.md
+++ b/skills/deslop/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: deslop
+description: Simplifies existing Peated code, docs, prompts, plans, or explanations without changing required behavior. Use when asked to deslop, simplify, remove jargon, trim, or reduce overengineering. Do not use for unrelated feature work or broad cleanup.
+---
+
+# Deslop
+
+Remove words and structure the current task does not need. Keep its behavior and
+safeguards.
+
+## Set Scope
+
+Read the root `AGENTS.md`, the nearest scoped `AGENTS.md`, and the code, tests,
+or docs that own the behavior. State what must remain true before changing it.
+
+Treat the user's target as the boundary. Fix affected callers, tests, examples,
+and docs, but do not turn a focused simplification into a repository-wide
+cleanup.
+
+## Remove Slop
+
+Look for complexity that has no current use or requirement:
+
+- jargon, vague or inflated prose, and unfamiliar words where common words are
+  exact;
+- wrappers that only rename or forward arguments;
+- generic managers, services, registries, factories, and configuration layers
+  that serve one known case;
+- options, extension points, fallbacks, compatibility paths, and abstractions
+  justified only by a possible future need;
+- duplicate names, types, state, validation, comments, or documentation;
+- helpers that hide a short operation or split one concern across many files;
+- broad error handling, retries, or logging that obscures the real owner;
+- plans, TODOs, and transitional code whose work is complete.
+
+Prefer familiar domain names, short sentences, active voice, small functions and
+modules, plain objects, and simple types. Prefer deleting a concept over renaming
+it when nothing still needs it.
+
+## Preserve Necessary Structure
+
+Do not remove structure that enforces behavior. Keep:
+
+- stored IDs, links, ownership, history, evidence, and source relationships;
+- permission, privacy, validation, identity, idempotency, transaction, and
+  concurrency boundaries;
+- stable public or saved contracts unless the task includes a safe migration;
+- domain terms that are more exact than a simpler-sounding substitute;
+- tests for required behavior and comments that explain a non-obvious rule or
+  owner;
+- accessibility, logs, traces, failure reporting, and operational safeguards
+  that have a current use.
+
+Do not call code overengineered merely because it has layers. Show which layer,
+option, or concept is unused, duplicated, or owned elsewhere. When evidence is
+weak, leave the design alone or present the tradeoff instead of guessing.
+
+## Follow Peated Policies
+
+Peated's policies still apply. Read those relevant to the target:
+
+- [Policy scope](../../docs/policies/README.md): Keep durable rules with a clear
+  concern and an enforceable owner.
+- [Agent design](../../docs/policies/agent-design.md): Use ordinary code for
+  fixed rules. Keep model workflows small, bounded, checked, and measurable.
+- [Background work](../../docs/policies/background-work.md): Persist durable
+  state first. Make retries bounded, owned, and safe to repeat.
+- [Code comments](../../docs/policies/code-comments.md): Explain non-obvious
+  rules and tradeoffs. Remove narration and completed transition notes.
+- [Data and permissions](../../docs/policies/data-and-permissions.md): Validate
+  every boundary and keep identity, ownership, authority, and retry state
+  explicit.
+- [Database correctness](../../docs/policies/database-correctness.md): Preserve
+  identity and relationships. Use constraints, locks, versions, and
+  transactions for concurrent writes.
+- [Error handling](../../docs/policies/error-handling.md): Let unexpected errors
+  reach their owner. Catch only to recover, translate, or clean up.
+- [Interfaces](../../docs/policies/interfaces.md): Expose the smallest useful
+  action. Do not add wrappers or broad dependency objects without real
+  behavior.
+- [Logs and traces](../../docs/policies/logs-and-traces.md): Record stable events
+  and safe context once at the boundary that owns the failure.
+- [Naming](../../docs/policies/naming.md): Use one Peated domain name for one
+  concept. Treat generic architecture words as warning signs.
+- [Sensitive data](../../docs/policies/sensitive-data.md): Keep credentials,
+  private content, direct identifiers, and unrestricted payloads out of logs,
+  tools, models, and errors.
+
+Use the relevant development testing guide too. Backend tests are
+integration-first, frontend tests cover behavior rather than appearance, and
+live model checks stay separate from deterministic tests.
+
+For customer-facing Peated copy, also follow `skills/peated-writing/SKILL.md`.
+
+## Finish
+
+Search for every affected use. Remove code and prose made obsolete by the
+change. Preserve compatibility only when a current caller, saved value, or
+published contract requires it.
+
+Run focused tests, typechecks, lint, and formatting. Use manual QA where those
+checks cannot prove behavior. Report what became simpler, what behavior stayed
+the same, and any check that could not run.
+
+Finish when the target has fewer unnecessary words, concepts, or paths, every
+remaining abstraction has a current reason, and required checks pass.

--- a/skills/deslop/agents/openai.yaml
+++ b/skills/deslop/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Deslop"
+  short_description: "Remove jargon and needless complexity"
+  default_prompt: "Use $deslop to simplify this area while preserving its behavior and safeguards."


### PR DESCRIPTION
Pausing a configured source now disables collection and fails its queued or running collection run in the same transaction. Site-level locking prevents manual or scheduled run creation from racing with Pause, while existing run ownership checks stop active workers at the next request, save, or checkpoint.

Reactivating a revision starts new work and never revives the stopped run. Preview and AI setup remain available. Database-backed coverage exercises pause before claim and during an in-flight request.

The branch also adds the repository-local `$deslop` skill for bounded simplification work, with Peated's policy index and safeguards kept explicit.

Fixes #1194
