### PR TITLE
fix(series): show only direct distillery releases

### DIFF
--- a/apps/server/src/orpc/routes/bottleSeries/list.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/list.test.ts
@@ -1,5 +1,3 @@
-import { db } from "@peated/server/db";
-import { bottleTombstones } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { describe, expect, it } from "vitest";
@@ -49,68 +47,42 @@ describe("GET /bottle-series", () => {
     );
   });
 
-  it("lists a distillery's series by matching bottle count", async function ({
+  it("lists only series released by the distillery", async function ({
     fixtures,
   }) {
     const distillery = await fixtures.Entity({
       kind: "distillery",
       name: "Port Ellen",
     });
-    const otherDistillery = await fixtures.Entity({
-      kind: "distillery",
-      name: "Brora",
+    const independentBrand = await fixtures.Entity({
+      kind: "brand",
+      name: "Rare Malts",
     });
-    const brand = await fixtures.Entity({ kind: "brand", name: "Rare Malts" });
     const seriesWithTwoBottles = await fixtures.BottleSeries({
-      brandId: brand.id,
+      brandId: distillery.id,
       name: "Rare Series",
+      numReleases: 2,
     });
     const seriesWithOneBottle = await fixtures.BottleSeries({
-      brandId: brand.id,
+      brandId: distillery.id,
       name: "Special Releases",
+      numReleases: 1,
     });
-    const unrelatedSeries = await fixtures.BottleSeries({
-      brandId: brand.id,
-      name: "Other Distillery",
+    const emptySeries = await fixtures.BottleSeries({
+      brandId: distillery.id,
+      name: "Unreleased Series",
+      numReleases: 0,
+    });
+    const independentSeries = await fixtures.BottleSeries({
+      brandId: independentBrand.id,
+      name: "Independent Bottler Series",
+      numReleases: 9,
     });
 
     await fixtures.Bottle({
-      brandId: brand.id,
+      brandId: independentBrand.id,
       distillerIds: [distillery.id],
-      seriesId: seriesWithTwoBottles.id,
-    });
-    await fixtures.Bottle({
-      brandId: brand.id,
-      distillerIds: [distillery.id],
-      seriesId: seriesWithTwoBottles.id,
-    });
-    await fixtures.Bottle({
-      brandId: brand.id,
-      distillerIds: [distillery.id],
-      seriesId: seriesWithOneBottle.id,
-    });
-    await fixtures.Bottle({
-      brandId: brand.id,
-      distillerIds: [otherDistillery.id],
-      seriesId: unrelatedSeries.id,
-    });
-    await fixtures.LegacyBottle({
-      brandId: brand.id,
-      distillerIds: [distillery.id],
-      seriesId: seriesWithTwoBottles.id,
-    });
-    const retiredBottle = await fixtures.Bottle({
-      brandId: brand.id,
-      distillerIds: [distillery.id],
-      seriesId: seriesWithTwoBottles.id,
-    });
-    const replacementBottle = await fixtures.Bottle({
-      brandId: brand.id,
-      distillerIds: [otherDistillery.id],
-    });
-    await db.insert(bottleTombstones).values({
-      bottleId: retiredBottle.id,
-      newBottleId: replacementBottle.id,
+      seriesId: independentSeries.id,
     });
 
     const result = await routerClient.bottleSeries.list({
@@ -122,15 +94,21 @@ describe("GET /bottle-series", () => {
     expect(result.results).toMatchObject([
       {
         id: seriesWithTwoBottles.id,
-        brand: { id: brand.id, name: brand.name },
+        brand: { id: distillery.id, name: distillery.name },
         numBottles: 2,
       },
       {
         id: seriesWithOneBottle.id,
-        brand: { id: brand.id, name: brand.name },
+        brand: { id: distillery.id, name: distillery.name },
         numBottles: 1,
       },
     ]);
+    expect(result.results).not.toContainEqual(
+      expect.objectContaining({ id: independentSeries.id }),
+    );
+    expect(result.results).not.toContainEqual(
+      expect.objectContaining({ id: emptySeries.id }),
+    );
   });
 
   it("rejects an unsupported sort", async function () {

--- a/apps/server/src/orpc/routes/bottleSeries/list.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/list.ts
@@ -1,11 +1,5 @@
 import { db } from "@peated/server/db";
-import {
-  bottles,
-  bottleSeries,
-  bottlesToDistillers,
-  bottleTombstones,
-  entities,
-} from "@peated/server/db/schema";
+import { bottleSeries, entities } from "@peated/server/db/schema";
 import { formatPeatedId } from "@peated/server/lib/peatedId";
 import { plainTextSearchQuery } from "@peated/server/lib/search";
 import { procedure } from "@peated/server/orpc";
@@ -16,16 +10,7 @@ import {
 import { serialize } from "@peated/server/serializers";
 import { BottleSeriesSerializer } from "@peated/server/serializers/bottleSeries";
 import type { SQL } from "drizzle-orm";
-import {
-  and,
-  asc,
-  desc,
-  eq,
-  getTableColumns,
-  isNotNull,
-  isNull,
-  sql,
-} from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, gt, sql } from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -53,9 +38,7 @@ export default procedure
         .int()
         .positive()
         .optional()
-        .describe(
-          "Filter to bottle series with active bottles from this distillery ID.",
-        ),
+        .describe("Filter to bottle series released by this distillery ID."),
       cursor: z.coerce.number().gte(1).default(1),
       limit: z.coerce.number().gte(1).lte(100).default(25),
       sort: z
@@ -80,6 +63,12 @@ export default procedure
     const where: (SQL<unknown> | undefined)[] = [];
 
     if (brand) where.push(eq(bottleSeries.brandId, brand));
+    if (distillery) {
+      where.push(
+        eq(bottleSeries.brandId, distillery),
+        gt(bottleSeries.numReleases, 0),
+      );
+    }
 
     if (query) {
       where.push(
@@ -87,114 +76,42 @@ export default procedure
       );
     }
 
-    const totalCount = sql<number>`count(*) over()::int`.as("total_count");
-    let total = 0;
-    let results;
+    const matchingBottleCount = bottleSeries.numReleases;
+    const orderBy =
+      sort === "-bottles"
+        ? [
+            desc(matchingBottleCount),
+            asc(bottleSeries.name),
+            asc(bottleSeries.id),
+          ]
+        : [asc(bottleSeries.name), asc(bottleSeries.id)];
 
-    if (distillery) {
-      // Count this distillery's active bottles once, before joining their Series.
-      const matchingBottleCounts = db
-        .select({
-          seriesId: bottles.seriesId,
-          numBottles: sql<number>`count(*)::int`.as("num_bottles"),
-        })
-        .from(bottlesToDistillers)
-        .innerJoin(bottles, eq(bottlesToDistillers.bottleId, bottles.id))
-        .leftJoin(bottleTombstones, eq(bottleTombstones.bottleId, bottles.id))
-        .where(
-          and(
-            eq(bottlesToDistillers.distillerId, distillery),
-            isNotNull(bottles.seriesId),
-            isNotNull(bottles.groupId),
-            isNull(bottleTombstones.bottleId),
-          ),
-        )
-        .groupBy(bottles.seriesId)
-        .as("matching_bottle_counts");
+    const results = await db
+      .select({
+        series: getTableColumns(bottleSeries),
+        brand: {
+          id: entities.id,
+          name: entities.name,
+          shortName: entities.shortName,
+          kind: entities.kind,
+        },
+        numBottles: matchingBottleCount,
+        total: sql<number>`count(*) over()::int`.as("total_count"),
+      })
+      .from(bottleSeries)
+      .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
+      .where(where.length ? and(...where) : undefined)
+      .orderBy(...orderBy)
+      .limit(limit + 1)
+      .offset(offset);
 
-      const matchingBottleCount = matchingBottleCounts.numBottles;
-      const orderBy =
-        sort === "-bottles"
-          ? [
-              desc(matchingBottleCount),
-              asc(bottleSeries.name),
-              asc(bottleSeries.id),
-            ]
-          : [asc(bottleSeries.name), asc(bottleSeries.id)];
-
-      results = await db
-        .select({
-          series: getTableColumns(bottleSeries),
-          brand: {
-            id: entities.id,
-            name: entities.name,
-            shortName: entities.shortName,
-            kind: entities.kind,
-          },
-          numBottles: matchingBottleCount,
-          total: totalCount,
-        })
+    let total = Number(results[0]?.total ?? 0);
+    if (!results.length && offset > 0) {
+      const [countResult] = await db
+        .select({ total: sql<number>`count(*)::int` })
         .from(bottleSeries)
-        .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
-        .innerJoin(
-          matchingBottleCounts,
-          eq(matchingBottleCounts.seriesId, bottleSeries.id),
-        )
-        .where(where.length ? and(...where) : undefined)
-        .orderBy(...orderBy)
-        .limit(limit + 1)
-        .offset(offset);
-
-      total = Number(results[0]?.total ?? 0);
-      if (!results.length && offset > 0) {
-        const [countResult] = await db
-          .select({ total: sql<number>`count(*)::int` })
-          .from(bottleSeries)
-          .innerJoin(
-            matchingBottleCounts,
-            eq(matchingBottleCounts.seriesId, bottleSeries.id),
-          )
-          .where(where.length ? and(...where) : undefined);
-        total = Number(countResult?.total ?? 0);
-      }
-    } else {
-      const matchingBottleCount = bottleSeries.numReleases;
-      const orderBy =
-        sort === "-bottles"
-          ? [
-              desc(matchingBottleCount),
-              asc(bottleSeries.name),
-              asc(bottleSeries.id),
-            ]
-          : [asc(bottleSeries.name), asc(bottleSeries.id)];
-
-      results = await db
-        .select({
-          series: getTableColumns(bottleSeries),
-          brand: {
-            id: entities.id,
-            name: entities.name,
-            shortName: entities.shortName,
-            kind: entities.kind,
-          },
-          numBottles: matchingBottleCount,
-          total: totalCount,
-        })
-        .from(bottleSeries)
-        .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
-        .where(where.length ? and(...where) : undefined)
-        .orderBy(...orderBy)
-        .limit(limit + 1)
-        .offset(offset);
-
-      total = Number(results[0]?.total ?? 0);
-      if (!results.length && offset > 0) {
-        const [countResult] = await db
-          .select({ total: sql<number>`count(*)::int` })
-          .from(bottleSeries)
-          .where(where.length ? and(...where) : undefined);
-        total = Number(countResult?.total ?? 0);
-      }
+        .where(where.length ? and(...where) : undefined);
+      total = Number(countResult?.total ?? 0);
     }
 
     const page = results.slice(0, limit);


### PR DESCRIPTION
Distillery overviews and Series tabs now list only non-empty Bottle Series whose `brand_id` is the distillery Entity. A Series from an independent bottler or another Brand no longer appears merely because one of its Bottles names that distillery. Bottle counts and ordering use the Series' maintained `num_releases` value, preserving the existing API response and UI labels.

This corrects the feature boundary and replaces the broader Bottle-to-distillery aggregation introduced in #1230 with a direct indexed lookup. A read-only production plan for the largest matching distillery completed in 0.416 ms using `bottle_series_brand_idx`; no schema migration is required.
