### PR TITLE
perf(bottles): use relationship indexes for entity lists

### DIFF
--- a/apps/server/src/lib/entityBottleIds.ts
+++ b/apps/server/src/lib/entityBottleIds.ts
@@ -1,0 +1,22 @@
+import { db } from "@peated/server/db";
+import { bottles, bottlesToDistillers } from "@peated/server/db/schema";
+import { eq } from "drizzle-orm";
+import { union } from "drizzle-orm/pg-core";
+
+/** Uses each Bottle relationship index independently and removes role overlaps. */
+export function bottleIdsForEntity(entityId: number) {
+  return union(
+    db
+      .select({ id: bottles.id })
+      .from(bottles)
+      .where(eq(bottles.brandId, entityId)),
+    db
+      .select({ id: bottles.id })
+      .from(bottles)
+      .where(eq(bottles.bottlerId, entityId)),
+    db
+      .select({ id: bottlesToDistillers.bottleId })
+      .from(bottlesToDistillers)
+      .where(eq(bottlesToDistillers.distillerId, entityId)),
+  );
+}

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -18,6 +18,7 @@ import { bottleProducedIn } from "@peated/server/lib/bottleProductionLocation";
 import { companyBottleEntityIds } from "@peated/server/lib/companyPortfolio";
 import { getReservedCollection } from "@peated/server/lib/db";
 import { bottlesForDistilleryView } from "@peated/server/lib/distilleryBottleView";
+import { bottleIdsForEntity } from "@peated/server/lib/entityBottleIds";
 import {
   plainTextSearchQuery,
   prefixTextSearchQuery,
@@ -280,13 +281,7 @@ export default implement(bottleListContract).handler(async function ({
     }
     where.push(bottlesForDistilleryView(rest.entity, rest.distilleryView));
   } else if (rest.entity) {
-    where.push(
-      or(
-        eq(bottles.brandId, rest.entity),
-        eq(bottles.bottlerId, rest.entity),
-        sql`EXISTS(SELECT FROM ${bottlesToDistillers} WHERE ${bottlesToDistillers.distillerId} = ${rest.entity} AND ${bottlesToDistillers.bottleId} = ${bottles.id})`,
-      ),
-    );
+    where.push(inArray(bottles.id, bottleIdsForEntity(rest.entity)));
   }
   if (rest.series) {
     where.push(eq(bottles.seriesId, rest.series));

--- a/apps/server/src/orpc/routes/entities/catalog.ts
+++ b/apps/server/src/orpc/routes/entities/catalog.ts
@@ -5,33 +5,16 @@ import {
   bottlesToDistillers,
   entities,
 } from "@peated/server/db/schema";
+import { bottleIdsForEntity } from "@peated/server/lib/entityBottleIds";
 import { implement } from "@peated/server/orpc";
 import entityCatalogContract from "@peated/server/orpc/contracts/entities/catalog";
 import { and, asc, desc, eq, inArray, isNotNull, ne, sql } from "drizzle-orm";
-import { union } from "drizzle-orm/pg-core";
 
 const activeBottleWhere = (entityId: number) => {
-  // Catalog reads use the role indexes independently instead of scanning every
-  // Bottle through one OR expression. The UNION also removes role overlaps.
-  const associatedBottleIds = union(
-    db
-      .select({ id: bottles.id })
-      .from(bottles)
-      .where(eq(bottles.brandId, entityId)),
-    db
-      .select({ id: bottles.id })
-      .from(bottles)
-      .where(eq(bottles.bottlerId, entityId)),
-    db
-      .select({ id: bottlesToDistillers.bottleId })
-      .from(bottlesToDistillers)
-      .where(eq(bottlesToDistillers.distillerId, entityId)),
-  );
-
   return and(
     isNotNull(bottles.groupId),
     sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
-    inArray(bottles.id, associatedBottleIds),
+    inArray(bottles.id, bottleIdsForEntity(entityId)),
   );
 };
 


### PR DESCRIPTION
Entity-filtered Bottle lists and counts now build their candidate IDs from separate brand, bottler, and distiller index scans, then apply the existing active-Bottle filters and sorting. The entity catalog endpoint now shares the same helper, preserving the existing behavior where a Bottle can be related through any role without appearing more than once.

This removes the broad `brand OR bottler OR distiller` scan behind several top slow queries. On production data, an entity with one related Bottle dropped from 74.8 ms to 0.47 ms for the count and from 48.7 ms to 0.37 ms for the release list. A large entity's count dropped from 226 ms to 6.3 ms; its already-cheap first page moved from 1.9 ms to 5.8 ms, trading a few milliseconds on dense catalogs for a much smaller and more predictable long tail.
