### PR TITLE
perf(web): reduce shared client bundle

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/badges/[badgeId]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/badges/[badgeId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { use } from "react";
 
-import { BadgeImage } from "@peated/web/components";
 import { AdminButton as Button } from "@peated/web/components/admin/adminButton.stylex";
 import {
   AdminBreadcrumbs,
@@ -12,6 +11,7 @@ import {
   AdminSection,
 } from "@peated/web/components/admin/adminContent.stylex";
 import { AdminDefinitionList as DefinitionList } from "@peated/web/components/admin/adminUtility.stylex";
+import { BadgeImage } from "@peated/web/components/badgeImage.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
 

--- a/apps/web/src/app/(admin)/admin/(default)/events/[eventId]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/events/[eventId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { use } from "react";
 
-import { TextLink } from "@peated/web/components";
 import { AdminButton as Button } from "@peated/web/components/admin/adminButton.stylex";
 import {
   AdminActions,
@@ -14,6 +13,7 @@ import {
 import { AdminDefinitionList as DefinitionList } from "@peated/web/components/admin/adminUtility.stylex";
 import DateRange from "@peated/web/components/dateRange";
 import Markdown from "@peated/web/components/markdown";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
 

--- a/apps/web/src/app/(admin)/admin/(default)/locations/[countrySlug]/(tabs)/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/locations/[countrySlug]/(tabs)/layout.tsx
@@ -2,7 +2,6 @@
 
 import { use, type ReactNode } from "react";
 
-import { PageTabs } from "@peated/web/components";
 import { AdminButton as Button } from "@peated/web/components/admin/adminButton.stylex";
 import {
   AdminActions,
@@ -10,6 +9,7 @@ import {
   AdminPage,
   AdminPageHeader,
 } from "@peated/web/components/admin/adminContent.stylex";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
 

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/catalog/catalogListingTable.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/catalog/catalogListingTable.tsx
@@ -1,6 +1,6 @@
 import type { Outputs } from "@peated/server/orpc/router";
-import { TextLink } from "@peated/web/components";
 import { AdminTable } from "@peated/web/components/admin/adminTable.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import TimeSince from "@peated/web/components/timeSince";
 import * as stylex from "@stylexjs/stylex";
 import { styles } from "./catalogListingTable.stylex";

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
@@ -4,7 +4,6 @@ import { use, useState, type ReactNode } from "react";
 
 import type { Outputs } from "@peated/server/orpc/router";
 import { ExternalSiteKeySchema } from "@peated/server/schemas/externalSites";
-import { PageTabs } from "@peated/web/components";
 import { AdminButton as Button } from "@peated/web/components/admin/adminButton.stylex";
 import {
   AdminActions,
@@ -17,6 +16,7 @@ import {
 import { ExternalSiteIdentity } from "@peated/web/components/admin/externalSiteIcon.stylex";
 import ExternalSiteRunStatus from "@peated/web/components/admin/externalSiteRunStatus";
 import { getScraperRunAvailability } from "@peated/web/components/admin/scraperRunAvailability";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import {
   useMutation,

--- a/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
@@ -8,7 +8,8 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useOptimistic, useTransition } from "react";
 
-import { ButtonLink, PageTabs } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
 import { CatalogPage } from "@peated/web/components/pages/catalogPage.stylex";
 import {
   EntityCatalogFilters,

--- a/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
@@ -1,6 +1,9 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
-import { SiteFooter, type SiteFooterProps } from "@peated/web/components";
+import {
+  SiteFooter,
+  type SiteFooterProps,
+} from "@peated/web/components/siteFooter.stylex";
 
 const groups = [
   {

--- a/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
@@ -5,11 +5,9 @@ import { CircleUserRound } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useTransition, type ReactNode } from "react";
 
-import {
-  ApplicationHeader,
-  ButtonLink,
-  MemberAvatar,
-} from "@peated/web/components";
+import { ApplicationHeader } from "@peated/web/components/applicationHeader.stylex";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { MemberAvatar } from "@peated/web/components/memberAvatar";
 import { PageFrame } from "@peated/web/components/pages/pageLayout.stylex";
 import { Search } from "@peated/web/components/search/search.stylex";
 import useAuth from "@peated/web/hooks/useAuth";

--- a/apps/web/src/app/(app)/_components/home/homeEventCallout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/homeEventCallout.stylex.tsx
@@ -2,8 +2,8 @@ import type { Event } from "@peated/server/types";
 import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import * as stylex from "@stylexjs/stylex";
 
-import { TextLink } from "@peated/web/components";
 import DateRange from "@peated/web/components/dateRange";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { formatEventLocation } from "@peated/web/lib/eventLocation";
 import { foundationStyles } from "../../../../styles/foundations.stylex";
 import { colors, space } from "../../../../styles/tokens.stylex";

--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -7,8 +7,9 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 
-import { ButtonLink, SectionError } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
+import { SectionError } from "@peated/web/components/feedback.stylex";
 import {
   HomeActivityFeed,
   HomeActivityFeedLoading,

--- a/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
@@ -2,12 +2,15 @@ import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { TextLink, type TextLinkProps } from "@peated/web/components";
 import {
   PageColumns,
   PageHeader,
   TabbedPage,
 } from "@peated/web/components/pages/pageLayout.stylex";
+import {
+  TextLink,
+  type TextLinkProps,
+} from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../../styles/foundations.stylex";
 import { colors, space } from "../../../styles/tokens.stylex";
 

--- a/apps/web/src/app/(app)/about/api/page.tsx
+++ b/apps/web/src/app/(app)/about/api/page.tsx
@@ -1,4 +1,4 @@
-import { RailList, RailListItem } from "@peated/web/components";
+import { RailList, RailListItem } from "@peated/web/components/lists.stylex";
 import {
   PageSection,
   RailSection,

--- a/apps/web/src/app/(app)/about/brand/brandVoicePage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/brand/brandVoicePage.stylex.tsx
@@ -1,7 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { PeatedId, SectionHeading } from "@peated/web/components";
+import { PeatedId } from "@peated/web/components/catalogDetails.stylex";
+import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import { foundationStyles } from "../../../../styles/foundations.stylex";
 import {
   colors,

--- a/apps/web/src/app/(app)/about/categories/page.tsx
+++ b/apps/web/src/app/(app)/about/categories/page.tsx
@@ -1,9 +1,8 @@
 import {
   DataTable,
-  RailList,
-  RailListItem,
   type DataTableColumn,
-} from "@peated/web/components";
+} from "@peated/web/components/dataTable.stylex";
+import { RailList, RailListItem } from "@peated/web/components/lists.stylex";
 import {
   PageSection,
   RailSection,

--- a/apps/web/src/app/(app)/about/page.tsx
+++ b/apps/web/src/app/(app)/about/page.tsx
@@ -1,4 +1,5 @@
-import { FactList, RailList, RailListItem } from "@peated/web/components";
+import { FactList } from "@peated/web/components/factList.stylex";
+import { RailList, RailListItem } from "@peated/web/components/lists.stylex";
 import {
   PageSection,
   RailSection,

--- a/apps/web/src/app/(app)/about/ratings/page.tsx
+++ b/apps/web/src/app/(app)/about/ratings/page.tsx
@@ -1,14 +1,13 @@
 import {
   DataTable,
-  RailList,
-  RailListItem,
-  RATING_BANDS,
   type DataTableColumn,
-} from "@peated/web/components";
+} from "@peated/web/components/dataTable.stylex";
+import { RailList, RailListItem } from "@peated/web/components/lists.stylex";
 import {
   PageSection,
   RailSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
+import { RATING_BANDS } from "@peated/web/components/scoring.stylex";
 import type { Metadata } from "next";
 import {
   AboutPage,

--- a/apps/web/src/app/(app)/about/tasting-wheel/page.tsx
+++ b/apps/web/src/app/(app)/about/tasting-wheel/page.tsx
@@ -1,4 +1,4 @@
-import { RailList, RailListItem } from "@peated/web/components";
+import { RailList, RailListItem } from "@peated/web/components/lists.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import type { Metadata } from "next";
 import { AboutPage, AboutText, AboutTextStack } from "../aboutPage.stylex";

--- a/apps/web/src/app/(app)/activity/loading.tsx
+++ b/apps/web/src/app/(app)/activity/loading.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PageTabs } from "@peated/web/components";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
 import { ActivityPage } from "@peated/web/components/pages/activityPage.stylex";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";

--- a/apps/web/src/app/(app)/activity/page.tsx
+++ b/apps/web/src/app/(app)/activity/page.tsx
@@ -1,4 +1,5 @@
-import { CursorPager, PageTabs } from "@peated/web/components";
+import { CursorPager } from "@peated/web/components/lists.stylex";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
 import { ActivityPage } from "@peated/web/components/pages/activityPage.stylex";
 import { redirectToAuth } from "@peated/web/lib/auth";
 import { getCurrentUser } from "@peated/web/lib/auth.server";

--- a/apps/web/src/app/(app)/badges/[badgeId]/badgePage.stylex.tsx
+++ b/apps/web/src/app/(app)/badges/[badgeId]/badgePage.stylex.tsx
@@ -2,13 +2,10 @@ import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import {
-  BadgeImage,
-  CursorPager,
-  ItemList,
-  ItemRow,
-  LoadingPlaceholder,
-} from "@peated/web/components";
+import { BadgeImage } from "@peated/web/components/badgeImage.stylex";
+import { LoadingPlaceholder } from "@peated/web/components/feedback.stylex";
+import { ItemList, ItemRow } from "@peated/web/components/itemList.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import {
   PageHeader,
   PageSection,

--- a/apps/web/src/app/(app)/badges/[badgeId]/loading.tsx
+++ b/apps/web/src/app/(app)/badges/[badgeId]/loading.tsx
@@ -1,4 +1,4 @@
-import { LoadingPlaceholder } from "@peated/web/components";
+import { LoadingPlaceholder } from "@peated/web/components/feedback.stylex";
 import {
   PageHeader,
   PageSection,

--- a/apps/web/src/app/(app)/bot/page.tsx
+++ b/apps/web/src/app/(app)/bot/page.tsx
@@ -1,5 +1,5 @@
 import { BOT_USER_AGENT } from "@peated/server/constants";
-import { FactList } from "@peated/web/components";
+import { FactList } from "@peated/web/components/factList.stylex";
 import {
   ContentLink,
   ContentList,

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
@@ -2,7 +2,8 @@
 
 import * as stylex from "@stylexjs/stylex";
 
-import { PageTabs, TextLink } from "@peated/web/components";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../../../styles/foundations.stylex";
 import { colors, space } from "../../../../styles/tokens.stylex";
 

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -7,8 +7,8 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useOptimistic, useTransition } from "react";
 
-import { ButtonLink } from "@peated/web/components";
 import { addBottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import {
   BottleCatalogFilters,
   BottleCatalogList,

--- a/apps/web/src/app/(app)/bottles/[bottleId]/aliases/aliasList.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/aliases/aliasList.stylex.tsx
@@ -4,7 +4,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { AliasManager } from "@peated/web/components";
+import { AliasManager } from "@peated/web/components/aliasManager.stylex";
 import TimeSince from "@peated/web/components/timeSince";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -8,25 +8,28 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
 import { createContext, useContext, useState, type ReactNode } from "react";
 
-import {
-  Button,
-  ButtonLink,
-  EmptyState,
-  ExpandableDescription,
-  LoadingList,
-  PageTabs,
-  RowMenu,
-  SectionError,
-  TextLink,
-  type FactListItem,
-  type PageTabItem,
-  type RowMenuItem,
-} from "@peated/web/components";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
 import { EntityLinks } from "@peated/web/components/entityLinks";
+import { ExpandableDescription } from "@peated/web/components/expandableDescription.stylex";
+import type { FactListItem } from "@peated/web/components/factList.stylex";
+import {
+  EmptyState,
+  LoadingList,
+  SectionError,
+} from "@peated/web/components/feedback.stylex";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
 import { BottleOverview } from "@peated/web/components/pages/bottleOverview.stylex";
 import { BottlePageHeader } from "@peated/web/components/pages/bottlePageHeader.stylex";
 import { BottleRailSection } from "@peated/web/components/pages/bottleRailSection.stylex";
+import {
+  PageTabs,
+  type PageTabItem,
+} from "@peated/web/components/pageTabs.stylex";
+import {
+  RowMenu,
+  type RowMenuItem,
+} from "@peated/web/components/rowMenu.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { FlavorProfileSection } from "@peated/web/features/flavorProfile/flavorProfileSection";
 import useAuth from "@peated/web/hooks/useAuth";
 import {

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottleSection.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottleSection.stylex.tsx
@@ -1,7 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { SectionHeading } from "@peated/web/components";
+import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import { space } from "../../../../styles/tokens.stylex";
 
 export function BottleSection({

--- a/apps/web/src/app/(app)/bottles/[bottleId]/loading.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/loading.tsx
@@ -1,4 +1,4 @@
-import { LoadingList } from "@peated/web/components";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
 
 export default function Loading() {
   return <LoadingList label="Loading bottle details" rows={4} />;

--- a/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
@@ -1,4 +1,4 @@
-import { EmptyState } from "@peated/web/components";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";

--- a/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
@@ -1,12 +1,11 @@
+import { BottleIdentityRow } from "@peated/web/components/bottleIdentityRow.stylex";
 import {
-  BottleIdentityRow,
-  BottleRatings,
-  CursorPager,
   EmptyState,
-  ItemList,
-  ItemListItem,
   LoadingList,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { ItemList, ItemListItem } from "@peated/web/components/itemList.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
+import { BottleRatings } from "@peated/web/components/scoring.stylex";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";

--- a/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
@@ -1,10 +1,10 @@
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
 import {
-  ButtonLink,
-  CursorPager,
   EmptyState,
   LoadingList,
-} from "@peated/web/components";
-import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
+} from "@peated/web/components/feedback.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";

--- a/apps/web/src/app/(app)/entities/[entityId]/aliases/entityAliasList.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/aliases/entityAliasList.stylex.tsx
@@ -4,7 +4,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { AliasManager } from "@peated/web/components";
+import { AliasManager } from "@peated/web/components/aliasManager.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import TimeSince from "@peated/web/components/timeSince";
 import useAuth from "@peated/web/hooks/useAuth";

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
@@ -6,7 +6,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useOptimistic, useTransition, type ReactNode } from "react";
 
-import { PageTabs } from "@peated/web/components";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import {

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
@@ -1,4 +1,4 @@
-import { ButtonLink } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import {
   BOTTLE_CATALOG_ALLOWED_VALUES,

--- a/apps/web/src/app/(app)/entities/[entityId]/codes/entityCodes.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/codes/entityCodes.stylex.tsx
@@ -1,8 +1,10 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { Card, EntityIdentityRow, TextLink } from "@peated/web/components";
+import { Card } from "@peated/web/components/card.stylex";
 import { CatalogTable } from "@peated/web/components/catalogTable.stylex";
+import { EntityIdentityRow } from "@peated/web/components/entityIdentityRow.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../../../../styles/foundations.stylex";
 import { colors, space } from "../../../../../styles/tokens.stylex";
 

--- a/apps/web/src/app/(app)/entities/[entityId]/companyOwnedList.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/companyOwnedList.tsx
@@ -1,15 +1,15 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 
+import { EntityIdentityRow } from "@peated/web/components/entityIdentityRow.stylex";
 import {
-  EntityIdentityRow,
-  ItemListItem,
   LoadingList,
-  RailList,
   SectionError,
-  TextLink,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { ItemListItem } from "@peated/web/components/itemList.stylex";
+import { RailList } from "@peated/web/components/lists.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
 import { type Entity } from "./entityPageData";

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
@@ -1,14 +1,14 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
+import { BottleList } from "@peated/web/components/bottleList.stylex";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import {
-  BottleList,
-  ButtonLink,
   EmptyState,
   LoadingList,
   SectionError,
-  TextLink,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getEntityUrl } from "@peated/web/lib/urls";
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
@@ -1,13 +1,13 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 
+import { EntityIdentityRow } from "@peated/web/components/entityIdentityRow.stylex";
 import {
-  EntityIdentityRow,
-  ItemListItem,
   LoadingList,
-  RailList,
   SectionError,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { ItemListItem } from "@peated/web/components/itemList.stylex";
+import { RailList } from "@peated/web/components/lists.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -1,9 +1,9 @@
 import {
   FactList,
-  TextLink,
   hasVisibleFacts,
   type FactListItem,
-} from "@peated/web/components";
+} from "@peated/web/components/factList.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { getEntityUrl, parseDomain } from "@peated/web/lib/urls";
 
 import type { Entity } from "./entityPageData";

--- a/apps/web/src/app/(app)/entities/[entityId]/entityHistoryData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityHistoryData.ts
@@ -1,6 +1,9 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
-import type { HistoryEvent, HistoryState } from "@peated/web/components";
+import type {
+  HistoryEvent,
+  HistoryState,
+} from "@peated/web/components/historyTimeline.stylex";
 
 type EntityEvent = Outputs["entities"]["events"]["list"]["results"][number];
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityHistoryOverview.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityHistoryOverview.stylex.tsx
@@ -2,10 +2,10 @@ import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 
 import {
-  HistoryTimeline,
   LoadingList,
   SectionError,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { HistoryTimeline } from "@peated/web/components/historyTimeline.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 
 import { getEntityHistoryEvents } from "./entityHistoryData";

--- a/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
@@ -4,7 +4,8 @@ import * as stylex from "@stylexjs/stylex";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useState } from "react";
 
-import { ImageAttribution, ImageViewer } from "@peated/web/components";
+import { ImageAttribution } from "@peated/web/components/imageAttribution.stylex";
+import { ImageViewer } from "@peated/web/components/imageViewer.stylex";
 import {
   colors,
   controlMetrics,

--- a/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
@@ -1,7 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { Card, TextLink } from "@peated/web/components";
+import { Card } from "@peated/web/components/card.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { colors, space } from "../../../../styles/tokens.stylex";
 
 import { foundationStyles } from "../../../../styles/foundations.stylex";

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewLayout.stylex.tsx
@@ -1,7 +1,10 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { LoadingList, LoadingPlaceholder } from "@peated/web/components";
+import {
+  LoadingList,
+  LoadingPlaceholder,
+} from "@peated/web/components/feedback.stylex";
 import { colors, space } from "../../../../styles/tokens.stylex";
 
 const NARROW = "@media (max-width: 759px)";

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -1,5 +1,5 @@
 import type { Outputs } from "@peated/server/orpc/router";
-import type { PageTabItem } from "@peated/web/components";
+import type { PageTabItem } from "@peated/web/components/pageTabs.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
 export type Entity = Outputs["entities"]["details"];

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -5,17 +5,16 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
 import { createContext, useContext, type ReactNode } from "react";
 
-import {
-  Button,
-  ButtonLink,
-  ExpandableDescription,
-  PageTabs,
-  RowMenu,
-  SectionError,
-  type RowMenuItem,
-} from "@peated/web/components";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
+import { ExpandableDescription } from "@peated/web/components/expandableDescription.stylex";
+import { SectionError } from "@peated/web/components/feedback.stylex";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
 import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
+import {
+  RowMenu,
+  type RowMenuItem,
+} from "@peated/web/components/rowMenu.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import useEntityFollowing from "@peated/web/hooks/useEntityFollowing";
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";

--- a/apps/web/src/app/(app)/entities/[entityId]/entityReleaseOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityReleaseOverview.tsx
@@ -1,12 +1,12 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
+import { BottleList } from "@peated/web/components/bottleList.stylex";
 import {
-  BottleList,
   LoadingList,
   SectionError,
-  TextLink,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getEntityUrl } from "@peated/web/lib/urls";
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityReviewsAndTastingsOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityReviewsAndTastingsOverview.tsx
@@ -1,8 +1,12 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
-import { LoadingList, SectionError, TextLink } from "@peated/web/components";
 import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
+import {
+  LoadingList,
+  SectionError,
+} from "@peated/web/components/feedback.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { getReviewAndTastingFeedItems } from "@peated/web/lib/communityFeed";
 import { getEntityUrl } from "@peated/web/lib/urls";
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySeriesOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySeriesOverview.tsx
@@ -1,14 +1,13 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
 import {
-  ItemList,
-  ItemListItem,
   LoadingList,
   SectionError,
-  SeriesIdentityRow,
-  TextLink,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { ItemList, ItemListItem } from "@peated/web/components/itemList.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { SeriesIdentityRow } from "@peated/web/components/seriesIdentityRow.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { getBottleSeriesUrl, getEntityUrl } from "@peated/web/lib/urls";
 
 import type { Entity } from "./entityPageData";

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
@@ -1,15 +1,15 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 
+import { EntityIdentityRow } from "@peated/web/components/entityIdentityRow.stylex";
 import {
-  EntityIdentityRow,
-  ItemListItem,
   LoadingList,
-  RailList,
   SectionError,
-  TextLink,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { ItemListItem } from "@peated/web/components/itemList.stylex";
+import { RailList } from "@peated/web/components/lists.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
 import { type Entity } from "./entityPageData";

--- a/apps/web/src/app/(app)/entities/[entityId]/entityTabLoading.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityTabLoading.stylex.tsx
@@ -1,6 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { LoadingList } from "@peated/web/components";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
 import { space } from "../../../../styles/tokens.stylex";
 
 export function EntityTabLoading({

--- a/apps/web/src/app/(app)/entities/[entityId]/portfolio/companyPortfolioClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/portfolio/companyPortfolioClient.stylex.tsx
@@ -6,7 +6,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useOptimistic, useTransition } from "react";
 
-import { PageTabs } from "@peated/web/components";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
 import { EntityCatalogList } from "@peated/web/components/pages/entityCatalog.stylex";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { toEntityCatalogItem } from "@peated/web/lib/entityCatalogItem";

--- a/apps/web/src/app/(app)/entities/[entityId]/series/entitySeriesListClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/series/entitySeriesListClient.stylex.tsx
@@ -6,14 +6,10 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useOptimistic, useTransition } from "react";
 
-import {
-  CursorPager,
-  EmptyState,
-  ItemList,
-  ItemListItem,
-  ListToolbar,
-  SeriesIdentityRow,
-} from "@peated/web/components";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
+import { ItemList, ItemListItem } from "@peated/web/components/itemList.stylex";
+import { CursorPager, ListToolbar } from "@peated/web/components/lists.stylex";
+import { SeriesIdentityRow } from "@peated/web/components/seriesIdentityRow.stylex";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getBottleSeriesUrl } from "@peated/web/lib/urls";

--- a/apps/web/src/app/(app)/entities/[entityId]/tastings/entityTastingListClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/tastings/entityTastingListClient.stylex.tsx
@@ -5,8 +5,10 @@ import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useSearchParams } from "next/navigation";
 
-import { ButtonLink, CursorPager, EmptyState } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import { getReviewAndTastingFeedItems } from "@peated/web/lib/communityFeed";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";

--- a/apps/web/src/app/(app)/events/eventList.stylex.tsx
+++ b/apps/web/src/app/(app)/events/eventList.stylex.tsx
@@ -1,12 +1,10 @@
 import type { Event } from "@peated/server/types";
 import * as stylex from "@stylexjs/stylex";
 
-import {
-  ButtonLink,
-  LoadingPlaceholder,
-  TextLink,
-} from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import DateRange from "@peated/web/components/dateRange";
+import { LoadingPlaceholder } from "@peated/web/components/feedback.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../../styles/foundations.stylex";
 import { colors, controlMetrics, space } from "../../../styles/tokens.stylex";
 

--- a/apps/web/src/app/(app)/events/eventRegionFilter.stylex.tsx
+++ b/apps/web/src/app/(app)/events/eventRegionFilter.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { ButtonLink, LoadingPlaceholder } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { LoadingPlaceholder } from "@peated/web/components/feedback.stylex";
 import { foundationStyles } from "../../../styles/foundations.stylex";
 import { colors, space } from "../../../styles/tokens.stylex";
 import type { EventRegion, EventRegionOption } from "./eventRegionData";

--- a/apps/web/src/app/(app)/events/page.tsx
+++ b/apps/web/src/app/(app)/events/page.tsx
@@ -1,4 +1,5 @@
-import { ButtonLink, EmptyState } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
 import {
   PageHeader,
   PageSection,

--- a/apps/web/src/app/(app)/flights/[flightId]/flightActions.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/flightActions.tsx
@@ -4,7 +4,7 @@ import type { Flight } from "@peated/server/types";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
-import { RowMenu } from "@peated/web/components";
+import { RowMenu } from "@peated/web/components/rowMenu.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";
 

--- a/apps/web/src/app/(app)/flights/[flightId]/loading.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/loading.tsx
@@ -1,9 +1,8 @@
+import { Button, IconButton } from "@peated/web/components/button.stylex";
 import {
-  Button,
-  IconButton,
   LoadingList,
   LoadingPlaceholder,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
 import {
   PageHeader,
   PageSection,

--- a/apps/web/src/app/(app)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/page.tsx
@@ -1,10 +1,7 @@
-import {
-  BottleIdentityRow,
-  ButtonLink,
-  EmptyState,
-  ItemList,
-  ItemListItem,
-} from "@peated/web/components";
+import { BottleIdentityRow } from "@peated/web/components/bottleIdentityRow.stylex";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
+import { ItemList, ItemListItem } from "@peated/web/components/itemList.stylex";
 import {
   PageHeader,
   PageSection,

--- a/apps/web/src/app/(app)/flights/flightList.tsx
+++ b/apps/web/src/app/(app)/flights/flightList.tsx
@@ -1,11 +1,8 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
-import {
-  CursorPager,
-  ItemList,
-  ItemRow,
-  LoadingPlaceholder,
-} from "@peated/web/components";
+import { LoadingPlaceholder } from "@peated/web/components/feedback.stylex";
+import { ItemList, ItemRow } from "@peated/web/components/itemList.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 
 type FlightListResult = Outputs["flights"]["list"];

--- a/apps/web/src/app/(app)/flights/page.tsx
+++ b/apps/web/src/app/(app)/flights/page.tsx
@@ -1,4 +1,5 @@
-import { ButtonLink, EmptyState } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
 import {
   PageHeader,
   PageSection,

--- a/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
@@ -5,12 +5,12 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useOptimistic, useTransition } from "react";
 
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import {
-  ButtonLink,
   FacetGroup,
   FilterPanel,
-  PageTabs,
-} from "@peated/web/components";
+} from "@peated/web/components/filterPanel.stylex";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
 import { CatalogPage } from "@peated/web/components/pages/catalogPage.stylex";
 import { EntityCatalogList } from "@peated/web/components/pages/entityCatalog.stylex";
 import useEntityFollowing from "@peated/web/hooks/useEntityFollowing";

--- a/apps/web/src/app/(app)/friends/friendsPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/friends/friendsPageClient.stylex.tsx
@@ -7,17 +7,16 @@ import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useState, type ReactNode } from "react";
 
+import { Avatar } from "@peated/web/components/avatar.stylex";
 import {
-  Avatar,
-  CursorPager,
   EmptyState,
-  ItemList,
-  ItemRow,
   LoadingPlaceholder,
-  MemberAvatar,
-  RowMenu,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { ItemList, ItemRow } from "@peated/web/components/itemList.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
+import { MemberAvatar } from "@peated/web/components/memberAvatar";
 import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
+import { RowMenu } from "@peated/web/components/rowMenu.stylex";
 import { Search } from "@peated/web/components/search/search.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import { getCursorHref } from "@peated/web/lib/cursorHref";

--- a/apps/web/src/app/(app)/locations/(index)/all-regions/page.tsx
+++ b/apps/web/src/app/(app)/locations/(index)/all-regions/page.tsx
@@ -1,4 +1,4 @@
-import { CursorPager } from "@peated/web/components";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";

--- a/apps/web/src/app/(app)/locations/(index)/loading.tsx
+++ b/apps/web/src/app/(app)/locations/(index)/loading.tsx
@@ -1,4 +1,5 @@
-import { CardGrid, LocationCardLoading } from "@peated/web/components";
+import { CardGrid } from "@peated/web/components/card.stylex";
+import { LocationCardLoading } from "@peated/web/components/locationCard.stylex";
 
 export default function Loading() {
   return (

--- a/apps/web/src/app/(app)/locations/(index)/page.tsx
+++ b/apps/web/src/app/(app)/locations/(index)/page.tsx
@@ -1,4 +1,5 @@
-import { CardGrid, LocationCard } from "@peated/web/components";
+import { CardGrid } from "@peated/web/components/card.stylex";
+import { LocationCard } from "@peated/web/components/locationCard.stylex";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 import { getCatalogSeoMetadata } from "@peated/web/lib/seoMetadata";
 

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
@@ -1,4 +1,5 @@
-import { ButtonLink, ExpandableDescription } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { ExpandableDescription } from "@peated/web/components/expandableDescription.stylex";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { getCountryPage } from "@peated/web/lib/locationPage.server";
 import type { ReactNode } from "react";

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/regions/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/regions/page.tsx
@@ -1,4 +1,5 @@
-import { CursorPager, EmptyState } from "@peated/web/components";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { getCountryPage } from "@peated/web/lib/locationPage.server";

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/layout.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/layout.tsx
@@ -1,4 +1,5 @@
-import { ButtonLink, ExpandableDescription } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { ExpandableDescription } from "@peated/web/components/expandableDescription.stylex";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { getRegionPage } from "@peated/web/lib/locationPage.server";
 import type { ReactNode } from "react";

--- a/apps/web/src/app/(app)/locations/locationBottleListLoading.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationBottleListLoading.stylex.tsx
@@ -1,6 +1,9 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { LoadingList, LoadingPlaceholder } from "@peated/web/components";
+import {
+  LoadingList,
+  LoadingPlaceholder,
+} from "@peated/web/components/feedback.stylex";
 import { colors, controlMetrics, space } from "../../../styles/tokens.stylex";
 
 const COMPACT = "@media (max-width: 639px)";

--- a/apps/web/src/app/(app)/locations/locationLists.tsx
+++ b/apps/web/src/app/(app)/locations/locationLists.tsx
@@ -1,12 +1,14 @@
 import type { Entity } from "@peated/server/types";
 
 import {
-  CursorPager,
   DataTable,
+  type DataTableColumn,
+} from "@peated/web/components/dataTable.stylex";
+import {
   EmptyState,
   LoadingPlaceholder,
-  type DataTableColumn,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
 type LocationListItem = {

--- a/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
@@ -5,26 +5,34 @@ import type { ReactNode } from "react";
 import {
   BottleList,
   type BottleListItem,
+} from "@peated/web/components/bottleList.stylex";
+import {
   DistributionList,
   DistributionListLoading,
+} from "@peated/web/components/distributionList.stylex";
+import {
   EntityIdentityRow,
   type EntityListItem,
-  FactList,
-  ItemListItem,
+} from "@peated/web/components/entityIdentityRow.stylex";
+import { FactList } from "@peated/web/components/factList.stylex";
+import {
   LoadingList,
   LoadingPlaceholder,
-  LocationIdentityRow,
+} from "@peated/web/components/feedback.stylex";
+import { ItemListItem } from "@peated/web/components/itemList.stylex";
+import { RailList } from "@peated/web/components/lists.stylex";
+import { LocationIdentityRow } from "@peated/web/components/locationIdentityRow.stylex";
+import {
   type LocationPreviewItem,
-  RailList,
   RegionPreviewGrid,
   RegionPreviewGridLoading,
-  TextLink,
-} from "@peated/web/components";
+} from "@peated/web/components/locationPreviewCard.stylex";
 import {
   PageColumns,
   PageSection,
   RailSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { colors, space } from "../../../styles/tokens.stylex";
 
 import { foundationStyles } from "../../../styles/foundations.stylex";

--- a/apps/web/src/app/(app)/locations/locationPage.ts
+++ b/apps/web/src/app/(app)/locations/locationPage.ts
@@ -1,6 +1,7 @@
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
-import type { LocationPreviewItem, PageTabItem } from "@peated/web/components";
+import type { LocationPreviewItem } from "@peated/web/components/locationPreviewCard.stylex";
+import type { PageTabItem } from "@peated/web/components/pageTabs.stylex";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import { getRegionMap } from "@peated/web/lib/locationMap";

--- a/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
@@ -4,13 +4,17 @@ import * as stylex from "@stylexjs/stylex";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
-import { PageTabs, TextLink, type PageTabItem } from "@peated/web/components";
 import { LocationMapIcon } from "@peated/web/components/locationMapIcon";
 import { RegionMapCredit } from "@peated/web/components/locationMapIcon/credit.stylex";
 import {
   PageHeader,
   TabbedPage,
 } from "@peated/web/components/pages/pageLayout.stylex";
+import {
+  PageTabs,
+  type PageTabItem,
+} from "@peated/web/components/pageTabs.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import {
   needsRegionMapCredit,
   type LocationMap,

--- a/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
+++ b/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
@@ -7,18 +7,16 @@ import { X } from "lucide-react";
 import { useState } from "react";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import {
-  Button,
-  CursorPager,
-  EmptyState,
-  IconButton,
-  ItemList,
-  ItemListItem,
-  LoadingPlaceholder,
-  TextLink,
-} from "@peated/web/components";
 import { Avatar } from "@peated/web/components/avatar.stylex";
+import { Button, IconButton } from "@peated/web/components/button.stylex";
+import {
+  EmptyState,
+  LoadingPlaceholder,
+} from "@peated/web/components/feedback.stylex";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import { ItemList, ItemListItem } from "@peated/web/components/itemList.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import TimeSince from "@peated/web/components/timeSince";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { logError } from "@peated/web/lib/log";

--- a/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
@@ -5,7 +5,10 @@ import * as stylex from "@stylexjs/stylex";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useOptimistic, useTransition } from "react";
 
-import { LoadingList, LoadingPlaceholder } from "@peated/web/components";
+import {
+  LoadingList,
+  LoadingPlaceholder,
+} from "@peated/web/components/feedback.stylex";
 import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
 import {
   Search,

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -4,8 +4,11 @@ import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useOptimistic, useTransition } from "react";
 
-import { Button, Chip, FactList, SectionError } from "@peated/web/components";
 import { addBottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
+import { Button } from "@peated/web/components/button.stylex";
+import { Chip } from "@peated/web/components/chip.stylex";
+import { FactList } from "@peated/web/components/factList.stylex";
+import { SectionError } from "@peated/web/components/feedback.stylex";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
 import useBottleRowActions from "@peated/web/hooks/useBottleRowActions";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageFrame.stylex.tsx
@@ -5,21 +5,21 @@ import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import * as stylex from "@stylexjs/stylex";
 import { createContext, useContext, useState, type ReactNode } from "react";
 
+import { EntityIdentityRow } from "@peated/web/components/entityIdentityRow.stylex";
+import { FactList } from "@peated/web/components/factList.stylex";
 import {
-  EntityIdentityRow,
-  FactList,
-  ItemListItem,
   LoadingList,
   LoadingPlaceholder,
-  RailList,
-  TextLink,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { ItemListItem } from "@peated/web/components/itemList.stylex";
+import { RailList } from "@peated/web/components/lists.stylex";
 import Markdown from "@peated/web/components/markdown";
 import {
   PageColumns,
   PageHeader,
 } from "@peated/web/components/pages/pageLayout.stylex";
 import { RailListSection } from "@peated/web/components/pages/railListSection.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { FlavorProfileSection } from "@peated/web/features/flavorProfile/flavorProfileSection";
 import { getEntityUrl } from "@peated/web/lib/urls";
 import { space } from "../../../../styles/tokens.stylex";

--- a/apps/web/src/app/(app)/settings/profile/page.tsx
+++ b/apps/web/src/app/(app)/settings/profile/page.tsx
@@ -1,18 +1,20 @@
 "use client";
 
 import { UserInputSchema } from "@peated/server/schemas";
+import { Button } from "@peated/web/components/button.stylex";
 import {
-  Button,
   Field,
   FieldGroup,
+  TextInput,
+} from "@peated/web/components/field.stylex";
+import { Switch } from "@peated/web/components/formControls.stylex";
+import {
   FormActions,
   FormNotice,
   FormSection,
   FormStack,
-  PictureInput,
-  Switch,
-  TextInput,
-} from "@peated/web/components";
+} from "@peated/web/components/formLayout.stylex";
+import { PictureInput } from "@peated/web/components/tastingInputs.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import {
   acceptTosForm,

--- a/apps/web/src/app/(app)/settings/security/page.tsx
+++ b/apps/web/src/app/(app)/settings/security/page.tsx
@@ -1,14 +1,13 @@
 "use client";
 
+import { Button } from "@peated/web/components/button.stylex";
+import { Field, TextInput } from "@peated/web/components/field.stylex";
 import {
-  Button,
-  Field,
   FormActions,
   FormNotice,
   FormSection,
   FormStack,
-  TextInput,
-} from "@peated/web/components";
+} from "@peated/web/components/formLayout.stylex";
 import PasskeyManager from "@peated/web/components/passkeyManager";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useMutation } from "@tanstack/react-query";

--- a/apps/web/src/app/(app)/settings/settingsPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/settings/settingsPageFrame.stylex.tsx
@@ -5,11 +5,13 @@ import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
 import {
-  FormSection,
-  FormStack,
   LoadingList,
   LoadingPlaceholder,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import {
+  FormSection,
+  FormStack,
+} from "@peated/web/components/formLayout.stylex";
 import {
   PageHeader,
   TabbedPage,

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingActions.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingActions.tsx
@@ -4,8 +4,8 @@ import type { Outputs } from "@peated/server/orpc/router";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
-import { RowMenu } from "@peated/web/components";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import { RowMenu } from "@peated/web/components/rowMenu.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";
 

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingComments.stylex.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingComments.stylex.tsx
@@ -6,19 +6,19 @@ import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
 import {
-  Button,
-  ButtonLink,
-  Field,
-  ItemList,
-  ItemRow,
   LoadingList,
-  MemberAvatar,
-  RowMenu,
   SectionError,
+} from "@peated/web/components/feedback.stylex";
+import {
+  Field,
   Textarea,
   ValidationMessage,
-} from "@peated/web/components";
+} from "@peated/web/components/field.stylex";
+import { ItemList, ItemRow } from "@peated/web/components/itemList.stylex";
+import { MemberAvatar } from "@peated/web/components/memberAvatar";
+import { RowMenu } from "@peated/web/components/rowMenu.stylex";
 import TimeSince from "@peated/web/components/timeSince";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
@@ -1,8 +1,8 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
-import { TastingToastSummary } from "@peated/web/components";
 import { TastingReviewDetail } from "@peated/web/components/pages/tastingReviewDetail.stylex";
 import { TastingReviewRail } from "@peated/web/components/pages/tastingReviewRail.stylex";
+import { TastingToastSummary } from "@peated/web/components/tastingToastButton.stylex";
 
 import { TastingActions } from "./tastingActions";
 

--- a/apps/web/src/app/(app)/updates/page.tsx
+++ b/apps/web/src/app/(app)/updates/page.tsx
@@ -1,4 +1,4 @@
-import { EmptyState } from "@peated/web/components";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
 import {
   PageHeader,
   PageSection,

--- a/apps/web/src/app/(app)/updates/updateList.stylex.tsx
+++ b/apps/web/src/app/(app)/updates/updateList.stylex.tsx
@@ -1,13 +1,10 @@
 import type { Change, PagingRel } from "@peated/server/types";
 
-import {
-  Avatar,
-  CursorPager,
-  ItemList,
-  ItemRow,
-  LoadingPlaceholder,
-  TextLink,
-} from "@peated/web/components";
+import { Avatar } from "@peated/web/components/avatar.stylex";
+import { LoadingPlaceholder } from "@peated/web/components/feedback.stylex";
+import { ItemList, ItemRow } from "@peated/web/components/itemList.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import TimeSince from "@peated/web/components/timeSince";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 

--- a/apps/web/src/app/(app)/users/[username]/activity/profileActivityLayout.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/profileActivityLayout.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 
-import { LoadingList } from "@peated/web/components";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
 import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
 import { useProfile } from "../profileContext";
 import { getProfileLoadingRows } from "../profileLoading";

--- a/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
@@ -4,13 +4,13 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
+import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
 import {
-  CursorPager,
   EmptyState,
   LoadingList,
   SectionError,
-} from "@peated/web/components";
-import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
+} from "@peated/web/components/feedback.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import { getCommunityFeedItems } from "@peated/web/lib/communityFeed";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryLayout.stylex.tsx
@@ -3,7 +3,10 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { LoadingList, LoadingPlaceholder } from "@peated/web/components";
+import {
+  LoadingList,
+  LoadingPlaceholder,
+} from "@peated/web/components/feedback.stylex";
 import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
 import { foundationStyles } from "../../../../../styles/foundations.stylex";
 import { colors, space } from "../../../../../styles/tokens.stylex";

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -6,7 +6,11 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useOptimistic, useState, useTransition } from "react";
 
-import { ButtonLink, LoadingList, SectionError } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import {
+  LoadingList,
+  SectionError,
+} from "@peated/web/components/feedback.stylex";
 import {
   MemberLibraryFilters,
   MemberLibraryList,

--- a/apps/web/src/app/(app)/users/[username]/profileLayoutClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileLayoutClient.stylex.tsx
@@ -5,14 +5,11 @@ import { useMutation } from "@tanstack/react-query";
 import { usePathname } from "next/navigation";
 import { useState, type ReactNode } from "react";
 
-import {
-  Button,
-  ButtonLink,
-  EmptyState,
-  PageTabs,
-  RowMenu,
-} from "@peated/web/components";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
 import { MemberProfileHeader } from "@peated/web/components/pages/memberProfileHeader.stylex";
+import { PageTabs } from "@peated/web/components/pageTabs.stylex";
+import { RowMenu } from "@peated/web/components/rowMenu.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { space } from "../../../../styles/tokens.stylex";
 import { ProfileProvider, type ProfileUser } from "./profileContext";

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewLayout.stylex.tsx
@@ -6,15 +6,17 @@ import type { ReactNode } from "react";
 import {
   FactList,
   type FactListItem,
+} from "@peated/web/components/factList.stylex";
+import {
   LoadingList,
   LoadingPlaceholder,
-  SectionHeading,
-  TextLink,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
 import {
   PageColumns,
   RailSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
+import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { colors, space } from "../../../../styles/tokens.stylex";
 import { useProfile } from "./profileContext";
 

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
@@ -5,20 +5,24 @@ import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 
+import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
+import { EntityIdentityRow } from "@peated/web/components/entityIdentityRow.stylex";
+import {
+  FactList,
+  type FactListItem,
+} from "@peated/web/components/factList.stylex";
 import {
   EmptyState,
-  EntityIdentityRow,
-  FactList,
-  ItemListItem,
   LoadingPlaceholder,
-  RailList,
-  TastingRatingDistribution,
-  Timestamp,
-  type FactListItem,
-  type TastingRatingCounts,
-} from "@peated/web/components";
-import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
+} from "@peated/web/components/feedback.stylex";
+import { ItemListItem } from "@peated/web/components/itemList.stylex";
+import { RailList } from "@peated/web/components/lists.stylex";
 import { RailSection } from "@peated/web/components/pages/pageLayout.stylex";
+import {
+  TastingRatingDistribution,
+  type TastingRatingCounts,
+} from "@peated/web/components/scoring.stylex";
+import { Timestamp } from "@peated/web/components/timestamp";
 import { getCommunityFeedItems } from "@peated/web/lib/communityFeed";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";

--- a/apps/web/src/app/(app)/users/[username]/profilePassport.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profilePassport.stylex.tsx
@@ -1,7 +1,8 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 
-import { AppLink, BadgeImage } from "@peated/web/components";
+import { AppLink } from "@peated/web/components/appLink";
+import { BadgeImage } from "@peated/web/components/badgeImage.stylex";
 import { foundationStyles } from "../../../../styles/foundations.stylex";
 import { colors, space } from "../../../../styles/tokens.stylex";
 

--- a/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsLayout.tsx
+++ b/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsLayout.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from "react";
 
-import { LoadingList } from "@peated/web/components";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
 import {
   PageColumns,
   RailSection,

--- a/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsPageClient.stylex.tsx
@@ -4,17 +4,16 @@ import type { Outputs } from "@peated/server/orpc/router";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useSearchParams } from "next/navigation";
 
-import {
-  ButtonLink,
-  CursorPager,
-  EmptyState,
-  ItemListItem,
-  LoadingList,
-  LocationIdentityRow,
-  RailList,
-  SectionError,
-} from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
+import {
+  EmptyState,
+  LoadingList,
+  SectionError,
+} from "@peated/web/components/feedback.stylex";
+import { ItemListItem } from "@peated/web/components/itemList.stylex";
+import { CursorPager, RailList } from "@peated/web/components/lists.stylex";
+import { LocationIdentityRow } from "@peated/web/components/locationIdentityRow.stylex";
 import { RailSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { getTastingFeedItems } from "@peated/web/lib/communityFeed";
 import { getCursorHref } from "@peated/web/lib/cursorHref";

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -1,18 +1,6 @@
 "use client";
 
 import type { Outputs } from "@peated/server/orpc/router";
-import {
-  Button,
-  ButtonLink,
-  CollectionBottleStatusInput,
-  FieldGroup,
-  FormGrid,
-  FormNotice,
-  FormStack,
-  LoadingList,
-  SelectedBottleSummary,
-  type CollectionBottleStatusValue,
-} from "@peated/web/components";
 import BottleResolver, {
   type BottleResolverAction,
   type BottleResolverCreateProposalActionsProps,
@@ -21,10 +9,23 @@ import BottleResolver, {
   type PendingImageRef,
 } from "@peated/web/components/bottleResolver";
 import { PhotoIdentificationTraceFootnote } from "@peated/web/components/bottleResolver/panels";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
+import {
+  CollectionBottleStatusInput,
+  type CollectionBottleStatusValue,
+} from "@peated/web/components/collectionBottleStatus.stylex";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
+import { FieldGroup } from "@peated/web/components/field.stylex";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import {
+  FormGrid,
+  FormNotice,
+  FormStack,
+} from "@peated/web/components/formLayout.stylex";
 import type { CreateBottlePrefill } from "@peated/web/components/search/createBottleHref";
 import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
 import { Search as BottleSearch } from "@peated/web/components/search/search.stylex";
+import { SelectedBottleSummary } from "@peated/web/components/selectedBottleSummary.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import TastingForm, {
   TastingFormLoading,

--- a/apps/web/src/app/(layout-free)/addBottle/badgeAwardMessage.stylex.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/badgeAwardMessage.stylex.tsx
@@ -1,5 +1,5 @@
 import type { Badge } from "@peated/server/types";
-import { BadgeImage } from "@peated/web/components";
+import { BadgeImage } from "@peated/web/components/badgeImage.stylex";
 import * as stylex from "@stylexjs/stylex";
 import Link from "next/link";
 

--- a/apps/web/src/app/(layout-free)/auth/tos-required/actions.tsx
+++ b/apps/web/src/app/(layout-free)/auth/tos-required/actions.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Button, Checkbox } from "@peated/web/components";
+import { Button } from "@peated/web/components/button.stylex";
+import { Checkbox } from "@peated/web/components/checkbox.stylex";
 import {
   AuthenticationActions,
   AuthenticationCard,

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
@@ -2,15 +2,14 @@
 
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 
+import { moderationHrefForAudit } from "@peated/web/components/admin/moderation/auditHref";
+import { Field, Textarea } from "@peated/web/components/field.stylex";
 import {
-  Field,
   FormNotice,
   FormSection,
   FormStack,
-  SelectedBottleSummary,
-  Textarea,
-} from "@peated/web/components";
-import { moderationHrefForAudit } from "@peated/web/components/admin/moderation/auditHref";
+} from "@peated/web/components/formLayout.stylex";
+import { SelectedBottleSummary } from "@peated/web/components/selectedBottleSummary.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
@@ -5,17 +5,19 @@ import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { formatPeatedId } from "@peated/server/lib/peatedId";
 import { BottleMergeSchema } from "@peated/server/schemas";
+import { FieldGroup } from "@peated/web/components/field.stylex";
+import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import { ChoiceList } from "@peated/web/components/formControls.stylex";
 import {
-  ChoiceList,
-  FieldGroup,
   FormNotice,
   FormSection,
   FormStack,
+} from "@peated/web/components/formLayout.stylex";
+import {
   SearchSelect,
-  SelectedBottleSummary,
   type SearchPickerOption,
-} from "@peated/web/components";
-import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+} from "@peated/web/components/searchPicker.stylex";
+import { SelectedBottleSummary } from "@peated/web/components/selectedBottleSummary.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { toBottlePickerOption } from "@peated/web/lib/bottleListItem";

--- a/apps/web/src/app/(layout-free)/browser-not-supported/page.tsx
+++ b/apps/web/src/app/(layout-free)/browser-not-supported/page.tsx
@@ -1,5 +1,5 @@
-import { ButtonLink } from "@peated/web/components";
 import { AuthenticationPage } from "@peated/web/components/auth/authenticationPage.stylex";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import {
   AuthenticationActions,
   AuthenticationCard,

--- a/apps/web/src/app/(layout-free)/entities/[entityId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/entities/[entityId]/merge/page.tsx
@@ -2,17 +2,19 @@
 
 import { toTitleCase } from "@peated/server/lib/strings";
 import { EntityMergeSchema } from "@peated/server/schemas";
+import { Checkbox } from "@peated/web/components/checkbox.stylex";
+import { FieldGroup } from "@peated/web/components/field.stylex";
+import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import { ChoiceList } from "@peated/web/components/formControls.stylex";
 import {
-  Checkbox,
-  ChoiceList,
-  FieldGroup,
   FormNotice,
   FormSection,
   FormStack,
+} from "@peated/web/components/formLayout.stylex";
+import {
   SearchSelect,
   type SearchPickerOption,
-} from "@peated/web/components";
-import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+} from "@peated/web/components/searchPicker.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";

--- a/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
+++ b/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import type { Bottle } from "@peated/server/types";
-import {
-  BottleIdentityRow,
-  Card,
-  ItemList,
-  ItemListItem,
-} from "@peated/web/components";
+import { BottleIdentityRow } from "@peated/web/components/bottleIdentityRow.stylex";
+import { Card } from "@peated/web/components/card.stylex";
 import { ClientOnly } from "@peated/web/components/clientOnly";
+import { ItemList, ItemListItem } from "@peated/web/components/itemList.stylex";
 import QRCodeClient from "@peated/web/components/qrcode.client.stylex";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import * as stylex from "@stylexjs/stylex";

--- a/apps/web/src/app/(layout-free)/oauth/authorize/authorizationForm.tsx
+++ b/apps/web/src/app/(layout-free)/oauth/authorize/authorizationForm.tsx
@@ -1,5 +1,5 @@
 import type { OAuthAuthorizationRequest } from "@peated/server/schemas";
-import { Button } from "@peated/web/components";
+import { Button } from "@peated/web/components/button.stylex";
 import { AuthenticationActions } from "@peated/web/components/pages/authentication.stylex";
 import { approveOAuthAuthorization, denyOAuthAuthorization } from "./actions";
 

--- a/apps/web/src/app/(layout-free)/verify/page.tsx
+++ b/apps/web/src/app/(layout-free)/verify/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { ButtonLink } from "@peated/web/components";
 import { AuthenticationPage } from "@peated/web/components/auth/authenticationPage.stylex";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import {
   AuthenticationNotice,
   AuthenticationPanel,

--- a/apps/web/src/app/(layout-free)/verify/resendForm.tsx
+++ b/apps/web/src/app/(layout-free)/verify/resendForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@peated/web/components";
+import { Button } from "@peated/web/components/button.stylex";
 import { AuthenticationNotice } from "@peated/web/components/pages/authentication.stylex";
 import { resendVerificationForm } from "@peated/web/lib/auth.actions";
 import { useActionState } from "react";

--- a/apps/web/src/app/providers/providers.tsx
+++ b/apps/web/src/app/providers/providers.tsx
@@ -11,7 +11,6 @@ import {
 } from "@peated/web/lib/auth.actions";
 import ORPCProvider from "@peated/web/lib/orpc/provider";
 import { type SessionData } from "@peated/web/lib/session.server";
-import { GoogleOAuthProvider } from "@react-oauth/google";
 import { setUser } from "@sentry/nextjs";
 import { ReactQueryStreamedHydration } from "@tanstack/react-query-next-experimental";
 import { useRouter } from "next/navigation";
@@ -90,20 +89,18 @@ export default function Providers({
   );
 
   return (
-    <GoogleOAuthProvider clientId={config.GOOGLE_CLIENT_ID}>
-      <ORPCProvider
-        apiServer={config.API_SERVER}
-        accessToken={session.accessToken}
-        onUnauthorized={handleUnauthorized}
-      >
-        <ReactQueryStreamedHydration>
-          <OnlineStatusProvider>
-            <AuthProvider user={session.user}>
-              <FlashMessages>{children}</FlashMessages>
-            </AuthProvider>
-          </OnlineStatusProvider>
-        </ReactQueryStreamedHydration>
-      </ORPCProvider>
-    </GoogleOAuthProvider>
+    <ORPCProvider
+      apiServer={config.API_SERVER}
+      accessToken={session.accessToken}
+      onUnauthorized={handleUnauthorized}
+    >
+      <ReactQueryStreamedHydration>
+        <OnlineStatusProvider>
+          <AuthProvider user={session.user}>
+            <FlashMessages>{children}</FlashMessages>
+          </AuthProvider>
+        </OnlineStatusProvider>
+      </ReactQueryStreamedHydration>
+    </ORPCProvider>
   );
 }

--- a/apps/web/src/components/admin/adminButton.stylex.tsx
+++ b/apps/web/src/components/admin/adminButton.stylex.tsx
@@ -1,5 +1,10 @@
+import {
+  Button,
+  ButtonLink,
+  type ButtonSize,
+  type ButtonVariant,
+} from "@peated/web/components/button.stylex";
 import { forwardRef, type ReactNode } from "react";
-import { Button, ButtonLink, type ButtonSize, type ButtonVariant } from "..";
 
 type BaseProps = {
   "aria-label"?: string;

--- a/apps/web/src/components/admin/adminContent.stylex.tsx
+++ b/apps/web/src/components/admin/adminContent.stylex.tsx
@@ -5,7 +5,11 @@ import { ChevronRight, Home } from "lucide-react";
 import type { HTMLAttributes, ReactNode } from "react";
 import { SectionHeading } from "../sectionHeading.stylex";
 
-import { AppLink, LoadingList, LoadingPlaceholder } from "..";
+import { AppLink } from "@peated/web/components/appLink";
+import {
+  LoadingList,
+  LoadingPlaceholder,
+} from "@peated/web/components/feedback.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import {
   colors,

--- a/apps/web/src/components/admin/adminForm.stylex.tsx
+++ b/apps/web/src/components/admin/adminForm.stylex.tsx
@@ -8,15 +8,16 @@ import { useController } from "react-hook-form";
 
 import {
   Field,
+  Textarea,
+  TextInput,
+} from "@peated/web/components/field.stylex";
+import { Select, Switch } from "@peated/web/components/formControls.stylex";
+import {
   FormActions,
   FormGrid,
   FormSection,
   FormStack,
-  Select,
-  Switch,
-  Textarea,
-  TextInput,
-} from "..";
+} from "@peated/web/components/formLayout.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, fonts, space, zIndices } from "../../styles/tokens.stylex";
 import { WorkflowScreen } from "../workflowScreen.stylex";

--- a/apps/web/src/components/admin/adminUtility.stylex.tsx
+++ b/apps/web/src/components/admin/adminUtility.stylex.tsx
@@ -6,7 +6,8 @@ import { AlertTriangle } from "lucide-react";
 import { usePathname, useSearchParams } from "next/navigation";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
-import { AppLink, CursorPager } from "..";
+import { AppLink } from "@peated/web/components/appLink";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import { buildQueryString } from "../../lib/urls";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, effects, space } from "../../styles/tokens.stylex";

--- a/apps/web/src/components/admin/badgeTable.tsx
+++ b/apps/web/src/components/admin/badgeTable.tsx
@@ -1,5 +1,5 @@
 import type { Badge, PagingRel } from "@peated/server/types";
-import { BadgeImage } from "..";
+import { BadgeImage } from "@peated/web/components/badgeImage.stylex";
 import { AdminTable } from "./adminTable.stylex";
 
 export default function BadgeTable({

--- a/apps/web/src/components/admin/moderation/automationPage.tsx
+++ b/apps/web/src/components/admin/moderation/automationPage.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 
-import { TextLink } from "@peated/web/components";
 import { AdminButton as Button } from "@peated/web/components/admin/adminButton.stylex";
 import {
   AdminActions,
@@ -13,6 +12,7 @@ import {
 } from "@peated/web/components/admin/adminContent.stylex";
 import { AdminTable } from "@peated/web/components/admin/adminTable.stylex";
 import { AdminAlert as Alert } from "@peated/web/components/admin/adminUtility.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import TimeSince from "@peated/web/components/timeSince";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import {

--- a/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
@@ -15,14 +15,12 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useDebounceCallback } from "usehooks-ts";
 import { SectionHeading } from "../../sectionHeading.stylex";
 
+import { AppLink } from "@peated/web/components/appLink";
+import { BottleIdentityRow } from "@peated/web/components/bottleIdentityRow.stylex";
+import { IconButton } from "@peated/web/components/button.stylex";
+import { TextInput } from "@peated/web/components/field.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { toBottlePickerOption } from "@peated/web/lib/bottleListItem";
-import {
-  AppLink,
-  BottleIdentityRow,
-  IconButton,
-  TextInput,
-  TextLink,
-} from "../..";
 import { useORPC } from "../../../lib/orpc/context";
 import { foundationStyles } from "../../../styles/foundations.stylex";
 import {

--- a/apps/web/src/components/admin/moderation/moderationInbox.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationInbox.stylex.tsx
@@ -8,14 +8,14 @@ import * as stylex from "@stylexjs/stylex";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
+import { AppLink } from "@peated/web/components/appLink";
+import { Button } from "@peated/web/components/button.stylex";
 import {
-  AppLink,
-  Button,
-  CursorPager,
   LoadingList,
   LoadingPlaceholder,
-  TextInput,
-} from "../..";
+} from "@peated/web/components/feedback.stylex";
+import { TextInput } from "@peated/web/components/field.stylex";
+import { CursorPager } from "@peated/web/components/lists.stylex";
 import { foundationStyles } from "../../../styles/foundations.stylex";
 import {
   colors,

--- a/apps/web/src/components/admin/moderation/taskDetail.tsx
+++ b/apps/web/src/components/admin/moderation/taskDetail.tsx
@@ -4,7 +4,6 @@ import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { BottleCreateInputSchema } from "@peated/server/lib/bottleSchemas";
 import type { Inputs, Outputs } from "@peated/server/orpc/router";
 import type { Bottle } from "@peated/server/types";
-import { TextLink } from "@peated/web/components";
 import { AdminButton as Button } from "@peated/web/components/admin/adminButton.stylex";
 import {
   AdminCodeBlock,
@@ -23,6 +22,7 @@ import CheckResult from "@peated/web/components/bottleChecks/checkResult.stylex"
 import type { ExcludedOperationField } from "@peated/web/components/bottleChecks/operationCard.stylex";
 import OperationCard from "@peated/web/components/bottleChecks/operationCard.stylex";
 import { BottleIdentityRow } from "@peated/web/components/bottleIdentityRow.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { copyTextToClipboard } from "@peated/web/lib/clipboard";
 import { useORPC } from "@peated/web/lib/orpc/context";

--- a/apps/web/src/components/admin/operationsOverview.stylex.tsx
+++ b/apps/web/src/components/admin/operationsOverview.stylex.tsx
@@ -3,7 +3,7 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 
-import { TextLink } from "..";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import {
   colors,

--- a/apps/web/src/components/admin/reviewTable.stylex.tsx
+++ b/apps/web/src/components/admin/reviewTable.stylex.tsx
@@ -4,7 +4,7 @@ import * as stylex from "@stylexjs/stylex";
 import { BottleIdentityRow } from "../bottleIdentityRow.stylex";
 import { Timestamp } from "../timestamp";
 
-import { TextLink } from "..";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 import { AdminTable } from "./adminTable.stylex";

--- a/apps/web/src/components/admin/scraperActivity.stylex.tsx
+++ b/apps/web/src/components/admin/scraperActivity.stylex.tsx
@@ -3,7 +3,7 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 
-import { TextLink } from "..";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, fonts, space } from "../../styles/tokens.stylex";
 import { SectionHeading } from "../sectionHeading.stylex";

--- a/apps/web/src/components/admin/storePriceTable.tsx
+++ b/apps/web/src/components/admin/storePriceTable.tsx
@@ -4,7 +4,7 @@ import TimeSince from "@peated/web/components/timeSince";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { BottleIdentityRow } from "../bottleIdentityRow.stylex";
 
-import { TextLink } from "..";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { AdminTable } from "./adminTable.stylex";
 
 export default function StorePriceTable({

--- a/apps/web/src/components/bottleChecks/checkSummary.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/checkSummary.stylex.tsx
@@ -1,6 +1,6 @@
 import type { Finding } from "@peated/bottle-classifier";
 import type { Outputs } from "@peated/server/orpc/router";
-import { TextLink } from "@peated/web/components";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import * as stylex from "@stylexjs/stylex";
 import { colors } from "../../styles/tokens.stylex";
 

--- a/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
@@ -2,8 +2,8 @@
 
 import type { Inputs, Outputs } from "@peated/server/orpc/router";
 import { BottleOperationFieldPathSchema } from "@peated/server/schemas/bottleOperationFields";
-import { AppLink as Link } from "@peated/web/components";
 import { AdminButton as Button } from "@peated/web/components/admin/adminButton.stylex";
+import { AppLink as Link } from "@peated/web/components/appLink";
 import * as stylex from "@stylexjs/stylex";
 import { ArrowRight, Copy } from "lucide-react";
 import { useEffect, useRef, useState, type ReactNode } from "react";

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -18,11 +18,22 @@ import type { Entity, EntityKind } from "@peated/server/types";
 import {
   BottleCreateCandidates,
   BottleCreateCandidateSummary,
-  BottleIdentityRow,
-  Button,
+  type BottleCreateCandidate,
+} from "@peated/web/components/bottleCreateCandidates.stylex";
+import { BottleIdentityRow } from "@peated/web/components/bottleIdentityRow.stylex";
+import { Button } from "@peated/web/components/button.stylex";
+import {
   EntityPicker,
+  type EntityPickerOption,
+} from "@peated/web/components/entityPicker.stylex";
+import {
   Field,
   FieldGroup,
+  Textarea,
+  TextInput,
+} from "@peated/web/components/field.stylex";
+import { Select, Switch } from "@peated/web/components/formControls.stylex";
+import {
   FormActions,
   FormDesktopOnly,
   FormDetails,
@@ -32,19 +43,17 @@ import {
   FormStack,
   FormStep,
   FormSteps,
-  PictureInput,
+} from "@peated/web/components/formLayout.stylex";
+import {
   SearchPicker,
-  Select,
-  SeriesPicker,
-  Switch,
-  Textarea,
-  TextInput,
-  UnitInput,
-  type BottleCreateCandidate,
-  type EntityPickerOption,
   type SearchPickerOption,
+} from "@peated/web/components/searchPicker.stylex";
+import {
+  SeriesPicker,
   type SeriesPickerOption,
-} from "@peated/web/components";
+} from "@peated/web/components/seriesPicker.stylex";
+import { PictureInput } from "@peated/web/components/tastingInputs.stylex";
+import { UnitInput } from "@peated/web/components/unitInput.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";

--- a/apps/web/src/components/bottleResolver/bottleResolver.stories.tsx
+++ b/apps/web/src/components/bottleResolver/bottleResolver.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { useState } from "react";
 
-import { SearchBox } from "..";
+import { SearchBox } from "@peated/web/components/searchBox.stylex";
 import BottleImage from "../../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import {

--- a/apps/web/src/components/bottleResolver/index.tsx
+++ b/apps/web/src/components/bottleResolver/index.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { Button } from "@peated/web/components/button.stylex";
 import {
-  Button,
   FormDetails,
   FormNotice,
   FormStack,
-} from "@peated/web/components";
+} from "@peated/web/components/formLayout.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";

--- a/apps/web/src/components/bottleResolver/layout.stylex.tsx
+++ b/apps/web/src/components/bottleResolver/layout.stylex.tsx
@@ -3,7 +3,7 @@ import { Camera } from "lucide-react";
 import type { ReactNode } from "react";
 import { SectionHeading } from "../sectionHeading.stylex";
 
-import { Button } from "..";
+import { Button } from "@peated/web/components/button.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 

--- a/apps/web/src/components/bottleResolver/panels.tsx
+++ b/apps/web/src/components/bottleResolver/panels.tsx
@@ -1,11 +1,10 @@
 import {
   Button,
   ButtonLink,
-  FactList,
-  FormGrid,
-  FormNotice,
   IconButton,
-} from "@peated/web/components";
+} from "@peated/web/components/button.stylex";
+import { FactList } from "@peated/web/components/factList.stylex";
+import { FormGrid, FormNotice } from "@peated/web/components/formLayout.stylex";
 import { copyTextToClipboard } from "@peated/web/lib/clipboard";
 import { logError } from "@peated/web/lib/log";
 import { Copy, Plus, RotateCcw, Search } from "lucide-react";

--- a/apps/web/src/components/bottleResolver/states.tsx
+++ b/apps/web/src/components/bottleResolver/states.tsx
@@ -1,12 +1,11 @@
 import type { Bottle } from "@peated/server/types";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
 import {
-  Button,
-  ButtonLink,
   FormDetails,
   FormNotice,
   FormStack,
-  SelectedBottleSummary,
-} from "@peated/web/components";
+} from "@peated/web/components/formLayout.stylex";
+import { SelectedBottleSummary } from "@peated/web/components/selectedBottleSummary.stylex";
 import { Plus, Search } from "lucide-react";
 import type { ReactNode } from "react";
 

--- a/apps/web/src/components/confirmationDialog.stylex.tsx
+++ b/apps/web/src/components/confirmationDialog.stylex.tsx
@@ -10,7 +10,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 import { SectionHeading } from "./sectionHeading.stylex";
 
-import { Button } from ".";
+import { Button } from "@peated/web/components/button.stylex";
 import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, effects, space, zIndices } from "../styles/tokens.stylex";
 

--- a/apps/web/src/components/entityForm.tsx
+++ b/apps/web/src/components/entityForm.tsx
@@ -3,23 +3,27 @@
 import { toTitleCase } from "@peated/server/lib/strings";
 import { EntityInputSchema, EntityKindEnum } from "@peated/server/schemas";
 import type { Entity } from "@peated/server/types";
-import {
-  Button,
-  EntityPicker,
-  Field,
-  FormNotice,
-  FormSection,
-  FormStack,
-  Select,
-  Textarea,
-  TextInput,
-  type EntityPickerOption,
-} from "@peated/web/components";
+import { Button } from "@peated/web/components/button.stylex";
 import {
   entityImageDrafts,
   EntityImageEditor,
   type EntityImageDraft,
 } from "@peated/web/components/entityImageEditor.stylex";
+import {
+  EntityPicker,
+  type EntityPickerOption,
+} from "@peated/web/components/entityPicker.stylex";
+import {
+  Field,
+  Textarea,
+  TextInput,
+} from "@peated/web/components/field.stylex";
+import { Select } from "@peated/web/components/formControls.stylex";
+import {
+  FormNotice,
+  FormSection,
+  FormStack,
+} from "@peated/web/components/formLayout.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";

--- a/apps/web/src/components/entityImageEditor.stylex.tsx
+++ b/apps/web/src/components/entityImageEditor.stylex.tsx
@@ -5,7 +5,12 @@ import * as stylex from "@stylexjs/stylex";
 import { ImagePlus } from "lucide-react";
 import { useEffect, useRef } from "react";
 
-import { Button, Field, FieldGroup, TextInput } from ".";
+import { Button } from "@peated/web/components/button.stylex";
+import {
+  Field,
+  FieldGroup,
+  TextInput,
+} from "@peated/web/components/field.stylex";
 import { colors, space } from "../styles/tokens.stylex";
 import { ImageViewer } from "./imageViewer.stylex";
 

--- a/apps/web/src/components/entityLinks.tsx
+++ b/apps/web/src/components/entityLinks.tsx
@@ -1,6 +1,6 @@
 import type { EntityKind } from "@peated/server/types";
 
-import { TextLink } from "@peated/web/components";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
 import Join from "./join";

--- a/apps/web/src/components/flightForm.tsx
+++ b/apps/web/src/components/flightForm.tsx
@@ -4,15 +4,19 @@ import { FlightInputSchema } from "@peated/server/schemas";
 import type { Bottle } from "@peated/server/types";
 import {
   Field,
+  Textarea,
+  TextInput,
+} from "@peated/web/components/field.stylex";
+import { Switch } from "@peated/web/components/formControls.stylex";
+import {
   FormNotice,
   FormSection,
   FormStack,
+} from "@peated/web/components/formLayout.stylex";
+import {
   SearchPicker,
-  Switch,
-  Textarea,
-  TextInput,
   type SearchPickerOption,
-} from "@peated/web/components";
+} from "@peated/web/components/searchPicker.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import { toBottlePickerOption } from "@peated/web/lib/bottleListItem";
 import {

--- a/apps/web/src/components/googleLoginButton.tsx
+++ b/apps/web/src/components/googleLoginButton.tsx
@@ -1,20 +1,23 @@
 "use client";
 
-import { useGoogleLogin } from "@react-oauth/google";
+import config from "@peated/web/config";
+import { GoogleOAuthProvider, useGoogleLogin } from "@react-oauth/google";
 import { useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { logWarn } from "../lib/log";
 import { Button, type ButtonVariant } from "./button.stylex";
 
-export default function GoogleLoginButton({
-  action,
-  title = "Continue with Google",
-  variant = "tonal",
-}: {
+type GoogleLoginButtonProps = {
   action: (formData: FormData) => Promise<any>;
   title?: string;
   variant?: ButtonVariant;
-}) {
+};
+
+function GoogleLoginButtonContent({
+  action,
+  title = "Continue with Google",
+  variant = "tonal",
+}: GoogleLoginButtonProps) {
   const [loading, setLoading] = useState(false);
   const searchParams = useSearchParams();
 
@@ -65,5 +68,13 @@ export default function GoogleLoginButton({
       </svg>
       {title}
     </Button>
+  );
+}
+
+export default function GoogleLoginButton(props: GoogleLoginButtonProps) {
+  return (
+    <GoogleOAuthProvider clientId={config.GOOGLE_CLIENT_ID}>
+      <GoogleLoginButtonContent {...props} />
+    </GoogleOAuthProvider>
   );
 }

--- a/apps/web/src/components/imageField.stylex.tsx
+++ b/apps/web/src/components/imageField.stylex.tsx
@@ -20,7 +20,8 @@ import AvatarEditor from "react-avatar-editor";
 import { z } from "zod";
 import { SectionHeading } from "./sectionHeading.stylex";
 
-import { Button, Field } from ".";
+import { Button } from "@peated/web/components/button.stylex";
+import { Field } from "@peated/web/components/field.stylex";
 import setRef from "../lib/setRef";
 import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, effects, space, zIndices } from "../styles/tokens.stylex";

--- a/apps/web/src/components/loginForm.tsx
+++ b/apps/web/src/components/loginForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Button, Field, TextInput } from "@peated/web/components";
+import { Button } from "@peated/web/components/button.stylex";
+import { Field, TextInput } from "@peated/web/components/field.stylex";
 import GoogleLoginButton from "@peated/web/components/googleLoginButton";
 import {
   AuthenticationActions,

--- a/apps/web/src/components/pages/activeCriticRailSection.stylex.tsx
+++ b/apps/web/src/components/pages/activeCriticRailSection.stylex.tsx
@@ -1,9 +1,6 @@
-import {
-  Avatar,
-  RailList,
-  RailListItem,
-  Timestamp,
-} from "@peated/web/components";
+import { Avatar } from "@peated/web/components/avatar.stylex";
+import { RailList, RailListItem } from "@peated/web/components/lists.stylex";
+import { Timestamp } from "@peated/web/components/timestamp";
 
 import { RailListSection } from "./railListSection.stylex";
 

--- a/apps/web/src/components/pages/activityPage.stylex.tsx
+++ b/apps/web/src/components/pages/activityPage.stylex.tsx
@@ -1,13 +1,13 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
+import type { BottleListItem } from "@peated/web/components/bottleList.stylex";
+import { ButtonLink } from "@peated/web/components/button.stylex";
 import {
-  ButtonLink,
   EmptyState,
   LoadingList,
-  TextLink,
-  type BottleListItem,
-} from "..";
+} from "@peated/web/components/feedback.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 import { CommunityFeed, type CommunityFeedItem } from "../communityFeed.stylex";

--- a/apps/web/src/components/pages/authentication.stylex.tsx
+++ b/apps/web/src/components/pages/authentication.stylex.tsx
@@ -3,7 +3,10 @@ import NextLink from "next/link";
 import type { ComponentProps, ReactNode } from "react";
 import { SectionHeading } from "../sectionHeading.stylex";
 
-import { TextLink, type TextLinkProps } from "..";
+import {
+  TextLink,
+  type TextLinkProps,
+} from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import {
   colors,

--- a/apps/web/src/components/pages/authenticationLayout.stories.tsx
+++ b/apps/web/src/components/pages/authenticationLayout.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { Button, ButtonLink } from "..";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
 import {
   AuthenticationActions,
   AuthenticationDivider,

--- a/apps/web/src/components/pages/authenticationPanel.stories.tsx
+++ b/apps/web/src/components/pages/authenticationPanel.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { Button, ButtonLink, Checkbox, Field, TextInput } from "..";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
+import { Checkbox } from "@peated/web/components/checkbox.stylex";
+import { Field, TextInput } from "@peated/web/components/field.stylex";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import {
   AuthenticationActions,

--- a/apps/web/src/components/pages/bottleCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/bottleCatalog.stylex.tsx
@@ -5,17 +5,20 @@ import type { ReactNode } from "react";
 
 import {
   BottleList,
-  Button,
-  ButtonLink,
-  CursorPager,
-  EmptyState,
+  type BottleListItem,
+} from "@peated/web/components/bottleList.stylex";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
+import {
   FacetGroup,
   FilterPanel,
   FilterQuery,
+} from "@peated/web/components/filterPanel.stylex";
+import {
+  CursorPager,
   ListToolbar,
-  type BottleListItem,
   type ListSortOption,
-} from "..";
+} from "@peated/web/components/lists.stylex";
 import { space } from "../../styles/tokens.stylex";
 import { CatalogPageLoading } from "./catalogPage.stylex";
 

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -1,17 +1,20 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import type { BottleListItem, FactListItem } from "..";
+import { AppLink } from "@peated/web/components/appLink";
+import type { BottleListItem } from "@peated/web/components/bottleList.stylex";
+import { BottleVisual } from "@peated/web/components/bottleVisual.stylex";
+import type { FactListItem } from "@peated/web/components/factList.stylex";
 import {
-  AppLink,
-  BottleVisual,
   FactList,
   hasVisibleFacts,
-  ImageAttribution,
+} from "@peated/web/components/factList.stylex";
+import {
   LoadingList,
   LoadingPlaceholder,
-  SectionHeading,
-} from "..";
+} from "@peated/web/components/feedback.stylex";
+import { ImageAttribution } from "@peated/web/components/imageAttribution.stylex";
+import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, effects, space } from "../../styles/tokens.stylex";
 import { CommunityFeed, type CommunityFeedItem } from "../communityFeed.stylex";

--- a/apps/web/src/components/pages/bottlePageHeader.stories.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { Button, ButtonLink, RowMenu } from "..";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
+import { RowMenu } from "@peated/web/components/rowMenu.stylex";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import { BottlePageHeader } from "./bottlePageHeader.stylex";
 

--- a/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
@@ -1,8 +1,9 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import type { BottleRatingSummaryProps } from "..";
-import { AppLink, BottleRatingSummary } from "..";
+import { AppLink } from "@peated/web/components/appLink";
+import type { BottleRatingSummaryProps } from "@peated/web/components/scoring.stylex";
+import { BottleRatingSummary } from "@peated/web/components/scoring.stylex";
 import { colors, effects, space } from "../../styles/tokens.stylex";
 import { PageHeader } from "./pageLayout.stylex";
 

--- a/apps/web/src/components/pages/bottleRailSection.stylex.tsx
+++ b/apps/web/src/components/pages/bottleRailSection.stylex.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from "react";
 
-import { BottleList, type BottleListItem } from "@peated/web/components";
+import {
+  BottleList,
+  type BottleListItem,
+} from "@peated/web/components/bottleList.stylex";
 import { RailListSection } from "./railListSection.stylex";
 
 /** Uses the compact sidebar identity; build items with toBottleListItem. */

--- a/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
+++ b/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
@@ -2,7 +2,9 @@ import { mockBottles } from "@peated/server/orpc/mock/fixtures";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { BottleList, DistributionList, FactList } from "..";
+import { BottleList } from "@peated/web/components/bottleList.stylex";
+import { DistributionList } from "@peated/web/components/distributionList.stylex";
+import { FactList } from "@peated/web/components/factList.stylex";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import {
   PageColumns,

--- a/apps/web/src/components/pages/catalogPage.stylex.tsx
+++ b/apps/web/src/components/pages/catalogPage.stylex.tsx
@@ -1,7 +1,10 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { LoadingList, LoadingPlaceholder } from "..";
+import {
+  LoadingList,
+  LoadingPlaceholder,
+} from "@peated/web/components/feedback.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, controlMetrics, space } from "../../styles/tokens.stylex";
 

--- a/apps/web/src/components/pages/contentPage.stylex.tsx
+++ b/apps/web/src/components/pages/contentPage.stylex.tsx
@@ -2,7 +2,10 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 import { SectionHeading } from "../sectionHeading.stylex";
 
-import { TextLink, type TextLinkProps } from "..";
+import {
+  TextLink,
+  type TextLinkProps,
+} from "@peated/web/components/textLink.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -3,20 +3,25 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
 import {
-  Button,
-  ButtonLink,
-  CursorPager,
-  EmptyState,
   EntityIdentityRow,
+  type EntityListItem,
+} from "@peated/web/components/entityIdentityRow.stylex";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
+import {
   FacetGroup,
   FilterPanel,
+} from "@peated/web/components/filterPanel.stylex";
+import {
+  CursorPager,
   ListToolbar,
-  RowMenu,
-  type EntityListItem,
   type ListSortOption,
+} from "@peated/web/components/lists.stylex";
+import {
+  RowMenu,
   type RowMenuItem,
-} from "..";
+} from "@peated/web/components/rowMenu.stylex";
 import { CatalogTable, type CatalogTableColumn } from "../catalogTable.stylex";
 import { CatalogPageLoading } from "./catalogPage.stylex";
 

--- a/apps/web/src/components/pages/entityPageHeader.stories.tsx
+++ b/apps/web/src/components/pages/entityPageHeader.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { Button, RowMenu } from "..";
+import { Button } from "@peated/web/components/button.stylex";
+import { RowMenu } from "@peated/web/components/rowMenu.stylex";
 import { EntityPageHeader } from "./entityPageHeader.stylex";
 
 const meta = {

--- a/apps/web/src/components/pages/entityPageHeader.stylex.tsx
+++ b/apps/web/src/components/pages/entityPageHeader.stylex.tsx
@@ -1,7 +1,12 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { KeyFacts, PeatedId, hasVisibleKeyFacts, type KeyFactList } from "..";
+import {
+  KeyFacts,
+  PeatedId,
+  hasVisibleKeyFacts,
+  type KeyFactList,
+} from "@peated/web/components/catalogDetails.stylex";
 import { space } from "../../styles/tokens.stylex";
 import { PageHeader } from "./pageLayout.stylex";
 

--- a/apps/web/src/components/pages/errorPage.stories.tsx
+++ b/apps/web/src/components/pages/errorPage.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { Copy } from "lucide-react";
 
-import { Button, ButtonLink, IconButton } from "..";
+import {
+  Button,
+  ButtonLink,
+  IconButton,
+} from "@peated/web/components/button.stylex";
 import {
   ErrorPage,
   ErrorPageLayout,

--- a/apps/web/src/components/pages/memberProfileContent.stylex.tsx
+++ b/apps/web/src/components/pages/memberProfileContent.stylex.tsx
@@ -5,20 +5,25 @@ import type { ReactNode } from "react";
 
 import {
   BottleIdentityRow,
-  Button,
-  Chip,
-  CursorPager,
-  EmptyState,
+  type BottleIdentityRowProps,
+} from "@peated/web/components/bottleIdentityRow.stylex";
+import { Button } from "@peated/web/components/button.stylex";
+import { Chip } from "@peated/web/components/chip.stylex";
+import { EmptyState } from "@peated/web/components/feedback.stylex";
+import {
   FacetGroup,
   FilterQuery,
-  ItemList,
-  ItemListItem,
+} from "@peated/web/components/filterPanel.stylex";
+import { ItemList, ItemListItem } from "@peated/web/components/itemList.stylex";
+import {
+  CursorPager,
   ListToolbar,
-  RowMenu,
-  type BottleIdentityRowProps,
   type ListSortOption,
+} from "@peated/web/components/lists.stylex";
+import {
+  RowMenu,
   type RowMenuGroup,
-} from "..";
+} from "@peated/web/components/rowMenu.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, effects, space } from "../../styles/tokens.stylex";
 

--- a/apps/web/src/components/pages/memberProfileHeader.stories.tsx
+++ b/apps/web/src/components/pages/memberProfileHeader.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { Button, ButtonLink } from "..";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import {
   MemberProfileHeader,

--- a/apps/web/src/components/pages/memberProfileHeader.stylex.tsx
+++ b/apps/web/src/components/pages/memberProfileHeader.stylex.tsx
@@ -1,7 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { Chip } from "..";
+import { Chip } from "@peated/web/components/chip.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import {
   colors,

--- a/apps/web/src/components/pages/pageLayout.stylex.tsx
+++ b/apps/web/src/components/pages/pageLayout.stylex.tsx
@@ -1,7 +1,11 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { PageTabs, SectionHeading, type PageTabItem } from "..";
+import {
+  PageTabs,
+  type PageTabItem,
+} from "@peated/web/components/pageTabs.stylex";
+import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 

--- a/apps/web/src/components/pages/railListSection.stories.tsx
+++ b/apps/web/src/components/pages/railListSection.stories.tsx
@@ -6,7 +6,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import * as stylex from "@stylexjs/stylex";
 import { useState } from "react";
 
-import { RailList, RailListItem } from "..";
+import { RailList, RailListItem } from "@peated/web/components/lists.stylex";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import { BottleRailSection } from "./bottleRailSection.stylex";
 import { RailListSection } from "./railListSection.stylex";

--- a/apps/web/src/components/pages/tastingReviewBottleSummary.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewBottleSummary.stylex.tsx
@@ -3,7 +3,9 @@ import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { BottleList, BottleVisual, LoadingList } from "@peated/web/components";
+import { BottleList } from "@peated/web/components/bottleList.stylex";
+import { BottleVisual } from "@peated/web/components/bottleVisual.stylex";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { colors, controlMetrics, space } from "../../styles/tokens.stylex";
 

--- a/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
@@ -5,16 +5,16 @@ import type { TagCategory } from "@peated/server/types";
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
+import { FactList } from "@peated/web/components/factList.stylex";
+import { LoadingPlaceholder } from "@peated/web/components/feedback.stylex";
+import { MemberAvatar } from "@peated/web/components/memberAvatar";
 import {
-  FactList,
-  LoadingPlaceholder,
-  MemberAvatar,
   ReviewScore,
   TastingRating,
-  TextLink,
-  Timestamp,
   type RatingBand,
-} from "@peated/web/components";
+} from "@peated/web/components/scoring.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
+import { Timestamp } from "@peated/web/components/timestamp";
 import { TastingNoteTag } from "@peated/web/features/tastingWheel/tastingNoteTag.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";

--- a/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
@@ -2,14 +2,11 @@ import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import {
-  type BottleListItem,
-  LoadingList,
-  RailList,
-  RailListItem,
-  TastingRating,
-  Timestamp,
-} from "@peated/web/components";
+import type { BottleListItem } from "@peated/web/components/bottleList.stylex";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
+import { RailList, RailListItem } from "@peated/web/components/lists.stylex";
+import { TastingRating } from "@peated/web/components/scoring.stylex";
+import { Timestamp } from "@peated/web/components/timestamp";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getMemberReviewUrl, getTastingUrl } from "@peated/web/lib/urls";
 import { foundationStyles } from "../../styles/foundations.stylex";

--- a/apps/web/src/components/passkeyLoginButton.tsx
+++ b/apps/web/src/components/passkeyLoginButton.tsx
@@ -3,8 +3,8 @@
 import {
   Button,
   type ButtonVariant,
-  ValidationMessage,
-} from "@peated/web/components";
+} from "@peated/web/components/button.stylex";
+import { ValidationMessage } from "@peated/web/components/field.stylex";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { startAuthentication } from "@simplewebauthn/browser";

--- a/apps/web/src/components/passkeyManager.tsx
+++ b/apps/web/src/components/passkeyManager.tsx
@@ -1,16 +1,14 @@
 "use client";
 
+import { Button, IconButton } from "@peated/web/components/button.stylex";
+import { TextInput } from "@peated/web/components/field.stylex";
 import {
-  Button,
   FormActions,
   FormNotice,
   FormStack,
-  IconButton,
-  ItemList,
-  ItemRow,
-  TextInput,
-  Timestamp,
-} from "@peated/web/components";
+} from "@peated/web/components/formLayout.stylex";
+import { ItemList, ItemRow } from "@peated/web/components/itemList.stylex";
+import { Timestamp } from "@peated/web/components/timestamp";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { startRegistration } from "@simplewebauthn/browser";

--- a/apps/web/src/components/passkeyRegisterButton.tsx
+++ b/apps/web/src/components/passkeyRegisterButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@peated/web/components";
+import { Button } from "@peated/web/components/button.stylex";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import {

--- a/apps/web/src/components/passwordResetChangeForm.tsx
+++ b/apps/web/src/components/passwordResetChangeForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Button, ButtonLink, Field, TextInput } from "@peated/web/components";
+import { Button, ButtonLink } from "@peated/web/components/button.stylex";
+import { Field, TextInput } from "@peated/web/components/field.stylex";
 import {
   AuthenticationActions,
   AuthenticationCard,

--- a/apps/web/src/components/passwordResetForm.tsx
+++ b/apps/web/src/components/passwordResetForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Button, Field, TextInput } from "@peated/web/components";
+import { Button } from "@peated/web/components/button.stylex";
+import { Field, TextInput } from "@peated/web/components/field.stylex";
 import {
   AuthenticationActions,
   AuthenticationCard,

--- a/apps/web/src/components/registerForm.tsx
+++ b/apps/web/src/components/registerForm.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { ButtonLink, Checkbox, Field, TextInput } from "@peated/web/components";
+import { ButtonLink } from "@peated/web/components/button.stylex";
+import { Checkbox } from "@peated/web/components/checkbox.stylex";
+import { Field, TextInput } from "@peated/web/components/field.stylex";
 import GoogleLoginButton from "@peated/web/components/googleLoginButton";
 import {
   AuthenticationActions,

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import type { Outputs } from "@peated/server/orpc/router";
+import { Button } from "@peated/web/components/button.stylex";
+import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
+import { SearchBox } from "@peated/web/components/searchBox.stylex";
 import type {
   SearchResultGroup,
   SearchResultItem,
-} from "@peated/web/components";
-import { Button, SearchBox } from "@peated/web/components";
-import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
+} from "@peated/web/components/searchResults.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
 import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";

--- a/apps/web/src/components/selectField/index.tsx
+++ b/apps/web/src/components/selectField/index.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { SearchPicker, type SearchPickerOption } from "@peated/web/components";
+import {
+  SearchPicker,
+  type SearchPickerOption,
+} from "@peated/web/components/searchPicker.stylex";
 import { useEffect, useMemo, useState } from "react";
 
 import type { OnQuery, Option } from "./types";

--- a/apps/web/src/components/workflowScreen.stylex.tsx
+++ b/apps/web/src/components/workflowScreen.stylex.tsx
@@ -6,7 +6,8 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import type { FormEvent, ReactNode } from "react";
 
-import { Button, IconButton, LoadingList } from "@peated/web/components";
+import { Button, IconButton } from "@peated/web/components/button.stylex";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
 import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,

--- a/apps/web/src/features/flavorProfile/flavorProfileSection.tsx
+++ b/apps/web/src/features/flavorProfile/flavorProfileSection.tsx
@@ -5,12 +5,12 @@ import type {
   FlavorProfile,
 } from "@peated/server/schemas/flavorProfile";
 import {
-  FlavorWheel,
   LoadingPlaceholder,
   SectionError,
-  TextLink,
-} from "@peated/web/components";
+} from "@peated/web/components/feedback.stylex";
+import { FlavorWheel } from "@peated/web/components/flavorWheel.stylex";
 import { RailSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { TextLink } from "@peated/web/components/textLink.stylex";
 import {
   TastingWheelProvider,
   useTastingWheel,

--- a/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
+++ b/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import type { TagCategory } from "@peated/server/types";
-import { BottleList, Button, Slideout } from "@peated/web/components";
+import { BottleList } from "@peated/web/components/bottleList.stylex";
+import { Button } from "@peated/web/components/button.stylex";
 import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
+import { Slideout } from "@peated/web/components/slideout.stylex";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import * as stylex from "@stylexjs/stylex";

--- a/apps/web/src/features/tastings/tastingForm.tsx
+++ b/apps/web/src/features/tastings/tastingForm.tsx
@@ -3,17 +3,17 @@
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { TastingSchema } from "@peated/server/schemas";
 import type { User } from "@peated/server/types";
+import { Button } from "@peated/web/components/button.stylex";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
 import {
-  Button,
   FormNotice,
   FormSection,
   FormStack,
   FormSteps,
-  LoadingList,
-  SelectedBottleSummary,
-  type MemberPickerOption,
-  type NotePickerOption,
-} from "@peated/web/components";
+} from "@peated/web/components/formLayout.stylex";
+import type { MemberPickerOption } from "@peated/web/components/memberPicker.stylex";
+import type { NotePickerOption } from "@peated/web/components/notePicker.stylex";
+import { SelectedBottleSummary } from "@peated/web/components/selectedBottleSummary.stylex";
 import {
   TastingFormModeChoice,
   type TastingFormMode,

--- a/apps/web/src/hooks/useAuthRequired.tsx
+++ b/apps/web/src/hooks/useAuthRequired.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LoadingList } from "@peated/web/components";
+import { LoadingList } from "@peated/web/components/feedback.stylex";
 import { redirect, usePathname, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 import { redirectToAuth } from "../lib/auth";

--- a/apps/web/src/hooks/useBottleRowActions.tsx
+++ b/apps/web/src/hooks/useBottleRowActions.tsx
@@ -4,8 +4,8 @@ import type { Outputs } from "@peated/server/orpc/router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 
-import type { RowMenuItem } from "@peated/web/components";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import type { RowMenuItem } from "@peated/web/components/rowMenu.stylex";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
 import { useORPC } from "@peated/web/lib/orpc/context";
 

--- a/apps/web/src/lib/bottleListItem.ts
+++ b/apps/web/src/lib/bottleListItem.ts
@@ -5,11 +5,9 @@ import {
 } from "@peated/server/lib/bottleDisplayName";
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
-import type {
-  BottleIdentityRowProps,
-  BottleListItem,
-  SearchPickerOption,
-} from "@peated/web/components";
+import type { BottleIdentityRowProps } from "@peated/web/components/bottleIdentityRow.stylex";
+import type { BottleListItem } from "@peated/web/components/bottleList.stylex";
+import type { SearchPickerOption } from "@peated/web/components/searchPicker.stylex";
 
 import { getReleaseFamilyHref } from "./releaseFamily";
 import { getBottleUrl, getEntityUrl } from "./urls";


### PR DESCRIPTION
Public pages now import UI components from their defining modules instead of the shared component barrel. This keeps unrelated client components out of common route chunks; in a production build, the entity overview route fell from 3.85 MB to 1.32 MB of raw JavaScript (about 66%) and no longer includes tasting-form code.

Google OAuth is also scoped to the Google login button instead of the root provider tree. Public routes no longer ship the Google OAuth client or load the GSI script, while the login route still includes both. The broad import-only diff is intentional; the main review points are the shared `PageFrame` import and the provider boundary around `GoogleLoginButton`.
