### PR TITLE
fix(scraper): block stale worker writes

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/activate.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/activate.test.ts
@@ -1,6 +1,8 @@
+import { db } from "@peated/server/db";
+import { scrapeSourceRevisions } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
-import { recordScrapeSourcePreview } from "@peated/server/scraper/configured/service";
+import { eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 import { createTestRevision, createTestSource } from "./testUtils";
 
@@ -48,11 +50,14 @@ describe("POST /admin/scrape-sources/:id/revisions/:revisionId/activate", () => 
     const admin = await fixtures.User({ admin: true });
     const { source } = await createTestSource(admin.id);
     const revision = await createTestRevision(source.id, admin.id);
-    await recordScrapeSourcePreview({
-      revisionId: revision.id,
-      status: "passed",
-      result: { issues: [], pages: [] },
-    });
+    await db
+      .update(scrapeSourceRevisions)
+      .set({
+        previewStatus: "passed",
+        previewResult: { issues: [], pages: [] },
+        previewedAt: new Date(),
+      })
+      .where(eq(scrapeSourceRevisions.id, revision.id));
 
     await expect(
       routerClient.externalSites.scrapeSources.activate(

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/pause.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/pause.test.ts
@@ -1,11 +1,14 @@
 import { db } from "@peated/server/db";
-import { externalSiteRuns, externalSites } from "@peated/server/db/schema";
+import {
+  externalSiteRuns,
+  externalSites,
+  scrapeSourceRevisions,
+} from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { createPinnedScrapeSourceRun } from "@peated/server/scraper/configured/runs";
 import {
   activateScrapeSourceRevision,
-  recordScrapeSourcePreview,
   SCRAPE_SOURCE_PAUSED_ERROR,
 } from "@peated/server/scraper/configured/service";
 import { eq } from "drizzle-orm";
@@ -54,11 +57,14 @@ describe("POST /admin/scrape-sources/:id/pause", () => {
     const admin = await fixtures.User({ admin: true });
     const { site, source } = await createTestSource(admin.id);
     const revision = await createTestRevision(source.id, admin.id);
-    await recordScrapeSourcePreview({
-      revisionId: revision.id,
-      status: "passed",
-      result: { issues: [], pages: [] },
-    });
+    await db
+      .update(scrapeSourceRevisions)
+      .set({
+        previewStatus: "passed",
+        previewResult: { issues: [], pages: [] },
+        previewedAt: new Date(),
+      })
+      .where(eq(scrapeSourceRevisions.id, revision.id));
     await activateScrapeSourceRevision({
       scrapeSourceId: source.id,
       revisionId: revision.id,

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -7,6 +7,7 @@ import {
   externalSiteRuns,
   externalSites,
   externalSiteScrapeTargets,
+  scrapeSourceRevisions,
   scrapeSourceRuns,
   scrapeSources,
   scrapeTargets,
@@ -23,7 +24,6 @@ import {
   activateScrapeSourceRevision,
   createScrapeSourceRevision,
   pauseScrapeSource,
-  recordScrapeSourcePreview,
   ScrapeSourceValidationError,
 } from "@peated/server/scraper/configured/service";
 import {
@@ -2831,6 +2831,7 @@ describe("POST /admin/scrape-sources/prepare", () => {
     const suggestionRegistry = await resolveScrapeSourceRunRegistry(
       suggestion.id,
       registry,
+      "suggestion-owner",
     );
     expect(
       [...suggestionRegistry.sources.values()].map((value) => value.key),
@@ -2878,6 +2879,7 @@ describe("POST /admin/scrape-sources/prepare", () => {
     const previewRegistry = await resolveScrapeSourceRunRegistry(
       preview.id,
       registry,
+      "preview-owner",
     );
     expect(
       [...previewRegistry.sources.values()].map((value) => value.key),
@@ -2887,11 +2889,14 @@ describe("POST /admin/scrape-sources/prepare", () => {
       .update(externalSiteRuns)
       .set({ status: "succeeded", completedAt: new Date() })
       .where(eq(externalSiteRuns.id, preview.id));
-    await recordScrapeSourcePreview({
-      revisionId: revision.id,
-      status: "passed",
-      result: { pages: [], issues: [] },
-    });
+    await db
+      .update(scrapeSourceRevisions)
+      .set({
+        previewStatus: "passed",
+        previewResult: { pages: [], issues: [] },
+        previewedAt: new Date(),
+      })
+      .where(eq(scrapeSourceRevisions.id, revision.id));
     await activateScrapeSourceRevision({
       scrapeSourceId: source.id,
       revisionId: revision.id,

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -17,6 +17,9 @@ directly. The files are split by responsibility:
 - `runs.ts`, `session.ts`, `http.ts`, `networkPolicy.ts`, `robots.ts`, and
   `coordinator.ts` own core execution without importing production registry or
   worker infrastructure;
+- `runTimeout.ts` keeps the database and queue timeouts together. It also says
+  how often a worker extends the database timeout during slow work such as AI
+  setup;
 - `registry.ts` lists the built-in sources and request settings;
 - `adapters/legacy/` contains migrated source implementations that still use
   the old helpers in `legacy/`;
@@ -81,6 +84,10 @@ version that passes its preview can be used. An admin can return to any older
 version that passed. Pausing a source fails queued collection runs and stops
 active work at the next request, save, or checkpoint. Saved versions and run
 history stay. Preview and AI setup still work.
+
+Before saving a preview or AI version, code checks that the worker still owns
+the run. The check and save happen together. If another worker has taken over,
+the old worker cannot overwrite the preview or add another version.
 
 Older rule versions remain supported so saved sources keep working. New
 sources use version 11. Most rule fields are CSS selectors. `list.links` finds article

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -33,7 +33,6 @@ import {
   createScrapeSourceRevision,
   createSiteWithScrapeSource,
   pauseScrapeSource,
-  recordScrapeSourcePreview,
   SCRAPE_SOURCE_PAUSED_ERROR,
 } from "./service";
 
@@ -51,6 +50,17 @@ function fixedClock(): TestClock {
       now = value;
     },
   };
+}
+
+async function markPreviewPassed(revisionId: number) {
+  await db
+    .update(scrapeSourceRevisions)
+    .set({
+      previewStatus: "passed",
+      previewResult: { issues: [], pages: [] },
+      previewedAt: new Date(),
+    })
+    .where(eq(scrapeSourceRevisions.id, revisionId));
 }
 
 async function runToCompletion({
@@ -166,11 +176,7 @@ async function setupCatalogSource(
 
 async function setupCatalogCollection() {
   const created = await setupCatalogSource();
-  await recordScrapeSourcePreview({
-    revisionId: created.revision.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(created.revision.id);
   await activateScrapeSourceRevision({
     scrapeSourceId: created.source.id,
     revisionId: created.revision.id,
@@ -537,11 +543,7 @@ test("stops an active collection before saving later observations", async () => 
 
 test("collects and updates only catalog listings", async () => {
   const { revision, site, source, user } = await setupCatalogSource();
-  await recordScrapeSourcePreview({
-    revisionId: revision.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(revision.id);
   await activateScrapeSourceRevision({
     scrapeSourceId: source.id,
     revisionId: revision.id,
@@ -589,11 +591,7 @@ test("collects and updates only catalog listings", async () => {
 
 test("keeps a catalog product that is absent from a later run", async () => {
   const { revision, site, source, user } = await setupCatalogSource();
-  await recordScrapeSourcePreview({
-    revisionId: revision.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(revision.id);
   await activateScrapeSourceRevision({
     scrapeSourceId: source.id,
     revisionId: revision.id,
@@ -722,11 +720,7 @@ test("stores safe validation issues when a selector stops matching", async () =>
 
 test("a collection failure does not change the preview result", async () => {
   const { revision, site, source, user } = await setupSource("h3.missing");
-  await recordScrapeSourcePreview({
-    revisionId: revision.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(revision.id);
   await activateScrapeSourceRevision({
     scrapeSourceId: source.id,
     revisionId: revision.id,

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -357,6 +357,8 @@ export function createLocalScrapeSourcePreview(input: {
 
 function createScrapeSourceDefinition(input: {
   siteKey: string;
+  runId: number;
+  executionToken: string;
   scrapeSourceId: number;
   revisionId: number;
   targetKey: string;
@@ -413,6 +415,8 @@ function createScrapeSourceDefinition(input: {
           purpose: "preview",
           recordPreview: async ({ status, result }) => {
             await recordScrapeSourcePreview({
+              runId: input.runId,
+              executionToken: input.executionToken,
               revisionId: input.revisionId,
               status,
               result,
@@ -443,6 +447,7 @@ function createScrapeSourceDefinition(input: {
 export async function resolveScrapeSourceRunRegistry(
   runId: number,
   baseRegistry: ScraperRegistry,
+  executionToken: string,
 ): Promise<ScraperRegistry> {
   const [suggestion] = await db
     .select({
@@ -618,9 +623,10 @@ export async function resolveScrapeSourceRunRegistry(
                 throw error;
               }
             }
-            const revision = await suggestScrapeSourceRevision({
+            await suggestScrapeSourceRevision({
               scrapeSourceId: suggestion.source.id,
               externalSiteRunId: runId,
+              executionToken,
               createdById: requestedById,
               listPages,
               detailPages,
@@ -636,10 +642,6 @@ export async function resolveScrapeSourceRunRegistry(
                 };
               },
             });
-            await db
-              .update(scrapeSourceRuns)
-              .set({ revisionId: revision.id })
-              .where(eq(scrapeSourceRuns.externalSiteRunId, runId));
           };
     const source: ScraperSourceDefinition<null, unknown> = {
       key: `source-${suggestion.source.id}`,
@@ -702,6 +704,8 @@ export async function resolveScrapeSourceRunRegistry(
   const target = await loadScrapeSourceTarget(row.target);
   const source = createScrapeSourceDefinition({
     siteKey: row.siteKey,
+    runId,
+    executionToken,
     scrapeSourceId: row.source.id,
     revisionId: row.revision.id,
     targetKey: target.key,

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -14,9 +14,13 @@ import {
   users,
 } from "@peated/server/db/schema";
 import { eq } from "drizzle-orm";
+import { ScraperRunTakenOverError } from "../session";
 import { reviewSourceKey } from "./reviewSourceKey";
 import type { ScrapeRules } from "./rules";
-import { createPinnedScrapeSourceRun } from "./runs";
+import {
+  createPinnedScrapeSourceRun,
+  createScrapeSourceSuggestionRun,
+} from "./runs";
 import {
   activateScrapeSourceRevision,
   createScrapeSourceRevision,
@@ -24,6 +28,7 @@ import {
   createSiteWithScrapeSource,
   listScrapeSourceRevisions,
   recordScrapeSourcePreview,
+  saveScrapeSourceSuggestion,
   ScrapeSourceConflictError,
   ScrapeSourceValidationError,
 } from "./service";
@@ -57,6 +62,17 @@ async function createUser() {
     .returning();
   if (!user) throw new Error("Failed to create test user.");
   return user;
+}
+
+async function markPreviewPassed(revisionId: number) {
+  await db
+    .update(scrapeSourceRevisions)
+    .set({
+      previewStatus: "passed",
+      previewResult: { issues: [], pages: [] },
+      previewedAt: new Date(),
+    })
+    .where(eq(scrapeSourceRevisions.id, revisionId));
 }
 
 test("creates a site and its admin-owned request rows", async () => {
@@ -127,11 +143,7 @@ test("keeps immutable revisions and only activates a passing revision", async ()
     }),
   ).rejects.toBeInstanceOf(ScrapeSourceValidationError);
 
-  await recordScrapeSourcePreview({
-    revisionId: first.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(first.id);
   const activated = await activateScrapeSourceRevision({
     scrapeSourceId: source.id,
     revisionId: first.id,
@@ -181,16 +193,118 @@ test("keeps immutable revisions and only activates a passing revision", async ()
     .set({ status: "succeeded", completedAt: new Date() })
     .where(eq(externalSiteRuns.id, pinned.run.id));
 
-  await recordScrapeSourcePreview({
-    revisionId: second.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(second.id);
   const updated = await activateScrapeSourceRevision({
     scrapeSourceId: source.id,
     revisionId: second.id,
   });
   expect(updated.source.listUrl).toBe("https://versioned.example/new-archive");
+});
+
+test("an old worker cannot overwrite a preview after another worker takes over", async () => {
+  const user = await createUser();
+  const { site, source } = await createSiteWithScrapeSource({
+    name: "Owned Preview",
+    kind: "review",
+    websiteUrl: "https://owned-preview.example/",
+    createdById: user.id,
+  });
+  const revision = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules,
+    author: "person",
+    createdById: user.id,
+  });
+  const pinned = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    requestedById: user.id,
+    trigger: "manual",
+    purpose: "preview",
+    revisionId: revision.id,
+  });
+  await db
+    .update(externalSiteRuns)
+    .set({
+      status: "running",
+      executionToken: "new-worker",
+      executionExpiresAt: new Date("2026-09-08T13:00:00Z"),
+    })
+    .where(eq(externalSiteRuns.id, pinned.run.id));
+
+  await expect(
+    recordScrapeSourcePreview({
+      runId: pinned.run.id,
+      executionToken: "old-worker",
+      revisionId: revision.id,
+      status: "passed",
+      result: { issues: [], pages: [] },
+    }),
+  ).rejects.toBeInstanceOf(ScraperRunTakenOverError);
+  const [stored] = await db
+    .select()
+    .from(scrapeSourceRevisions)
+    .where(eq(scrapeSourceRevisions.id, revision.id));
+  expect(stored).toMatchObject({
+    previewStatus: "pending",
+    previewedAt: null,
+  });
+});
+
+test("an old worker cannot add an AI version after another worker takes over", async () => {
+  const user = await createUser();
+  const { source } = await createSiteWithScrapeSource({
+    name: "Owned Suggestion",
+    kind: "review",
+    websiteUrl: "https://owned-suggestion.example/",
+    createdById: user.id,
+  });
+  const run = await createScrapeSourceSuggestionRun({
+    scrapeSourceId: source.id,
+    requestedById: user.id,
+  });
+  await db
+    .update(externalSiteRuns)
+    .set({
+      status: "running",
+      executionToken: "new-worker",
+      executionExpiresAt: new Date("2026-09-08T13:00:00Z"),
+    })
+    .where(eq(externalSiteRuns.id, run.id));
+  const input = {
+    scrapeSourceId: source.id,
+    externalSiteRunId: run.id,
+    rules,
+    author: "ai" as const,
+    createdById: user.id,
+    aiModel: "test-model",
+    aiInstructionsVersion: "test-instructions",
+  };
+
+  await expect(
+    saveScrapeSourceSuggestion({
+      ...input,
+      executionToken: "old-worker",
+    }),
+  ).rejects.toBeInstanceOf(ScraperRunTakenOverError);
+  expect(await db.select().from(scrapeSourceRevisions)).toEqual([]);
+
+  const revision = await saveScrapeSourceSuggestion({
+    ...input,
+    executionToken: "new-worker",
+  });
+  await expect(
+    saveScrapeSourceSuggestion({
+      ...input,
+      executionToken: "new-worker",
+    }),
+  ).resolves.toMatchObject({ id: revision.id });
+  expect(await db.select().from(scrapeSourceRevisions)).toHaveLength(1);
+  expect(await db.select().from(scrapeSourceRuns)).toEqual([
+    expect.objectContaining({
+      externalSiteRunId: run.id,
+      revisionId: revision.id,
+    }),
+  ]);
 });
 
 test("keeps the original review and the newer scraped data", async ({
@@ -260,11 +374,7 @@ test("keeps the original review and the newer scraped data", async ({
     author: "person",
     createdById: user.id,
   });
-  await recordScrapeSourcePreview({
-    revisionId: revision.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(revision.id);
   await activateScrapeSourceRevision({
     scrapeSourceId: source.id,
     revisionId: revision.id,
@@ -337,11 +447,7 @@ test("refuses conflicting Bottle matches for the same review", async ({
     author: "person",
     createdById: user.id,
   });
-  await recordScrapeSourcePreview({
-    revisionId: revision.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(revision.id);
 
   await expect(
     activateScrapeSourceRevision({
@@ -389,11 +495,7 @@ test("refuses review identities that depend on page position", async () => {
     author: "person",
     createdById: user.id,
   });
-  await recordScrapeSourcePreview({
-    revisionId: revision.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(revision.id);
 
   await expect(
     activateScrapeSourceRevision({
@@ -423,11 +525,7 @@ test("does not activate a revision while a run is active", async () => {
     author: "person",
     createdById: user.id,
   });
-  await recordScrapeSourcePreview({
-    revisionId: revision.id,
-    status: "passed",
-    result: { issues: [], pages: [] },
-  });
+  await markPreviewPassed(revision.id);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "queued",

--- a/apps/server/src/scraper/configured/service.ts
+++ b/apps/server/src/scraper/configured/service.ts
@@ -1,4 +1,4 @@
-import { type AnyDatabase, db } from "@peated/server/db";
+import { type AnyDatabase, type AnyTransaction, db } from "@peated/server/db";
 import {
   externalReviewArticles,
   externalReviewBodies,
@@ -20,12 +20,13 @@ import {
 } from "@peated/server/schemas";
 import { ExternalSiteKeySchema } from "@peated/server/schemas/externalSites";
 import slugify from "@sindresorhus/slugify";
-import { and, asc, desc, eq, inArray, max } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, max } from "drizzle-orm";
 import { z } from "zod";
 import {
   DEFAULT_SCRAPER_SETTINGS,
   getHourlyRequestSettings,
 } from "../definitions";
+import { ScraperRunTakenOverError } from "../session";
 import type { ScrapeSourcePreviewResult } from "./preview";
 import { reviewSourceKey } from "./reviewSourceKey";
 import {
@@ -330,49 +331,108 @@ export async function createScrapeSourceRevision(
   input: CreateScrapeSourceRevisionInput,
 ) {
   const rules = ScrapeRulesSchema.parse(input.rules);
-  return await db.transaction(async (tx) => {
-    const [source] = await tx
-      .select()
-      .from(scrapeSources)
-      .where(eq(scrapeSources.id, input.scrapeSourceId))
-      .for("update");
-    if (!source) throw new ScrapeSourceNotFoundError();
-    const listUrl = ScrapeSourceUrlSchema.parse(
-      input.listUrl ?? source.listUrl,
+  return await db.transaction(async (tx) =>
+    insertScrapeSourceRevision(tx, input, rules),
+  );
+}
+
+async function insertScrapeSourceRevision(
+  tx: AnyTransaction,
+  input: CreateScrapeSourceRevisionInput,
+  rules: ScrapeRules,
+) {
+  const [source] = await tx
+    .select()
+    .from(scrapeSources)
+    .where(eq(scrapeSources.id, input.scrapeSourceId))
+    .for("update");
+  if (!source) throw new ScrapeSourceNotFoundError();
+  const listUrl = ScrapeSourceUrlSchema.parse(input.listUrl ?? source.listUrl);
+  if (exactOrigin(new URL(listUrl)) !== exactOrigin(new URL(source.listUrl))) {
+    throw new ScrapeSourceValidationError(
+      "The list page must stay on the source website.",
     );
+  }
+  if (source.kind !== rules.kind) {
+    throw new ScrapeSourceValidationError(
+      "The rules collect the wrong content.",
+    );
+  }
+  const [latest] = await tx
+    .select({ revision: max(scrapeSourceRevisions.revision) })
+    .from(scrapeSourceRevisions)
+    .where(eq(scrapeSourceRevisions.scrapeSourceId, source.id));
+  const [revision] = await tx
+    .insert(scrapeSourceRevisions)
+    .values({
+      scrapeSourceId: source.id,
+      revision: (latest?.revision ?? 0) + 1,
+      rulesVersion: SCRAPE_RULES_VERSION,
+      listUrl: new URL(listUrl).toString(),
+      rules,
+      author: input.author,
+      aiModel: input.author === "ai" ? input.aiModel : null,
+      aiInstructionsVersion:
+        input.author === "ai" ? input.aiInstructionsVersion : null,
+      previewResult: { issues: [], pages: [] },
+      createdById: input.createdById,
+    })
+    .returning();
+  if (!revision) throw new Error("Failed to save the new rule version.");
+  return revision;
+}
+
+export async function saveScrapeSourceSuggestion(
+  input: CreateScrapeSourceRevisionInput & {
+    externalSiteRunId: number;
+    executionToken: string;
+  },
+) {
+  const rules = ScrapeRulesSchema.parse(input.rules);
+  return await db.transaction(async (tx) => {
+    const [runState] = await tx
+      .select({ run: externalSiteRuns, sourceRun: scrapeSourceRuns })
+      .from(scrapeSourceRuns)
+      .innerJoin(
+        externalSiteRuns,
+        eq(externalSiteRuns.id, scrapeSourceRuns.externalSiteRunId),
+      )
+      .where(
+        and(
+          eq(scrapeSourceRuns.externalSiteRunId, input.externalSiteRunId),
+          eq(scrapeSourceRuns.scrapeSourceId, input.scrapeSourceId),
+          eq(scrapeSourceRuns.purpose, "suggest"),
+        ),
+      )
+      .for("update");
+    if (!runState) throw new ScrapeSourceNotFoundError();
     if (
-      exactOrigin(new URL(listUrl)) !== exactOrigin(new URL(source.listUrl))
+      runState.run.status !== "running" ||
+      runState.run.executionToken !== input.executionToken
     ) {
-      throw new ScrapeSourceValidationError(
-        "The list page must stay on the source website.",
-      );
+      throw new ScraperRunTakenOverError();
     }
-    if (source.kind !== rules.kind) {
-      throw new ScrapeSourceValidationError(
-        "The rules collect the wrong content.",
-      );
+    if (runState.sourceRun.revisionId !== null) {
+      const [revision] = await tx
+        .select()
+        .from(scrapeSourceRevisions)
+        .where(eq(scrapeSourceRevisions.id, runState.sourceRun.revisionId));
+      if (!revision) throw new ScrapeSourceNotFoundError();
+      return revision;
     }
-    const [latest] = await tx
-      .select({ revision: max(scrapeSourceRevisions.revision) })
-      .from(scrapeSourceRevisions)
-      .where(eq(scrapeSourceRevisions.scrapeSourceId, source.id));
-    const [revision] = await tx
-      .insert(scrapeSourceRevisions)
-      .values({
-        scrapeSourceId: source.id,
-        revision: (latest?.revision ?? 0) + 1,
-        rulesVersion: SCRAPE_RULES_VERSION,
-        listUrl: new URL(listUrl).toString(),
-        rules,
-        author: input.author,
-        aiModel: input.author === "ai" ? input.aiModel : null,
-        aiInstructionsVersion:
-          input.author === "ai" ? input.aiInstructionsVersion : null,
-        previewResult: { issues: [], pages: [] },
-        createdById: input.createdById,
-      })
-      .returning();
-    if (!revision) throw new Error("Failed to save the new rule version.");
+
+    const revision = await insertScrapeSourceRevision(tx, input, rules);
+    const [linked] = await tx
+      .update(scrapeSourceRuns)
+      .set({ revisionId: revision.id })
+      .where(
+        and(
+          eq(scrapeSourceRuns.externalSiteRunId, input.externalSiteRunId),
+          isNull(scrapeSourceRuns.revisionId),
+        ),
+      )
+      .returning({ externalSiteRunId: scrapeSourceRuns.externalSiteRunId });
+    if (!linked) throw new ScraperRunTakenOverError();
     return revision;
   });
 }
@@ -418,21 +478,47 @@ export async function getLatestScrapeSourceSetup(scrapeSourceId: number) {
 }
 
 export async function recordScrapeSourcePreview(input: {
+  runId: number;
+  executionToken: string;
   revisionId: number;
   status: "passed" | "failed";
   result: ScrapeSourcePreviewResult;
 }) {
-  const [revision] = await db
-    .update(scrapeSourceRevisions)
-    .set({
-      previewStatus: input.status,
-      previewResult: input.result,
-      previewedAt: new Date(),
-    })
-    .where(eq(scrapeSourceRevisions.id, input.revisionId))
-    .returning();
-  if (!revision) throw new ScrapeSourceNotFoundError();
-  return revision;
+  return await db.transaction(async (tx) => {
+    const [runState] = await tx
+      .select({ run: externalSiteRuns })
+      .from(scrapeSourceRuns)
+      .innerJoin(
+        externalSiteRuns,
+        eq(externalSiteRuns.id, scrapeSourceRuns.externalSiteRunId),
+      )
+      .where(
+        and(
+          eq(scrapeSourceRuns.externalSiteRunId, input.runId),
+          eq(scrapeSourceRuns.revisionId, input.revisionId),
+          eq(scrapeSourceRuns.purpose, "preview"),
+        ),
+      )
+      .for("update");
+    if (!runState) throw new ScrapeSourceNotFoundError();
+    if (
+      runState.run.status !== "running" ||
+      runState.run.executionToken !== input.executionToken
+    ) {
+      throw new ScraperRunTakenOverError();
+    }
+    const [revision] = await tx
+      .update(scrapeSourceRevisions)
+      .set({
+        previewStatus: input.status,
+        previewResult: input.result,
+        previewedAt: new Date(),
+      })
+      .where(eq(scrapeSourceRevisions.id, input.revisionId))
+      .returning();
+    if (!revision) throw new ScrapeSourceNotFoundError();
+    return revision;
+  });
 }
 
 export async function activateScrapeSourceRevision(input: {

--- a/apps/server/src/scraper/configured/suggestion.ts
+++ b/apps/server/src/scraper/configured/suggestion.ts
@@ -12,7 +12,7 @@ import type {
 } from "openai/resources/responses/responses";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
 import type { ScrapeRules } from "./rules";
-import { createScrapeSourceRevision } from "./service";
+import { saveScrapeSourceSuggestion } from "./service";
 import {
   AI_INSTRUCTIONS_VERSION,
   MAX_PAGES_TO_CHECK,
@@ -302,6 +302,7 @@ async function requestAi(input: {
 export async function suggestScrapeSourceRevision(input: {
   scrapeSourceId: number;
   externalSiteRunId: number;
+  executionToken: string;
   createdById: number;
   listPages: WebsitePage[];
   detailPages: WebsitePage[];
@@ -375,8 +376,10 @@ export async function suggestScrapeSourceRevision(input: {
   });
   const suggestedRules = setup.rules;
   const listPage = setup.checked.listPage;
-  return await createScrapeSourceRevision({
+  return await saveScrapeSourceSuggestion({
     scrapeSourceId: input.scrapeSourceId,
+    externalSiteRunId: input.externalSiteRunId,
+    executionToken: input.executionToken,
     listUrl: listPage.url,
     rules: suggestedRules,
     author: "ai",

--- a/apps/server/src/scraper/runTimeout.ts
+++ b/apps/server/src/scraper/runTimeout.ts
@@ -1,0 +1,5 @@
+// A worker extends its run timeout every 15 minutes. Both the database timeout
+// and the queue job lock last one hour.
+export const SCRAPER_RUN_TIMEOUT_MS = 60 * 60_000;
+export const SCRAPER_RUN_REFRESH_MS = 15 * 60_000;
+export const SCRAPER_JOB_LOCK_MS = 60 * 60_000;

--- a/apps/server/src/scraper/runs.test.ts
+++ b/apps/server/src/scraper/runs.test.ts
@@ -19,8 +19,8 @@ import {
 } from "./definitions";
 import type { ScraperHttpClock } from "./http";
 import { ScraperRequestWaitError } from "./http";
-import { executeScraperRun } from "./runs";
-import { ScraperRunOwnershipError } from "./session";
+import { executeScraperRun, extendRunTimeout } from "./runs";
+import { ScraperRunTakenOverError } from "./session";
 import { syncScraperDefinitions } from "./syncDefinitions";
 import type { ScraperAdapter, ScraperSink } from "./types";
 
@@ -368,7 +368,30 @@ test("duplicate delivery cannot advance an actively owned run", async () => {
   await expect(first).resolves.toEqual({ status: "completed" });
 });
 
-test("a reclaimed execution cannot emit through the prior owner's sink", async () => {
+test("gives a worker more time to finish its run", async () => {
+  const { run } = await setupRun();
+  await db
+    .update(externalSiteRuns)
+    .set({
+      status: "running",
+      executionToken: "slow-worker",
+      executionExpiresAt: new Date("2026-08-18T13:00:00Z"),
+    })
+    .where(eq(externalSiteRuns.id, run.id));
+
+  await extendRunTimeout({
+    runId: run.id,
+    executionToken: "slow-worker",
+    now: new Date("2026-08-18T12:30:00Z"),
+  });
+  const [stored] = await db
+    .select({ executionExpiresAt: externalSiteRuns.executionExpiresAt })
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, run.id));
+  expect(stored?.executionExpiresAt).toEqual(new Date("2026-08-18T13:30:00Z"));
+});
+
+test("an old worker cannot save after another worker takes over", async () => {
   let entered: (() => void) | undefined;
   let resume: (() => void) | undefined;
   const ready = new Promise<void>((resolve) => {
@@ -391,19 +414,19 @@ test("a reclaimed execution cannot emit through the prior owner's sink", async (
   const { registry, run } = await setupRun({ adapter, sink });
   const execution = executeScraperRun(
     { runId: run.id },
-    { registry, clock: fixedClock(), executionToken: "prior-owner" },
+    { registry, clock: fixedClock(), executionToken: "old-worker" },
   );
   await ready;
   await db
     .update(externalSiteRuns)
     .set({
-      executionToken: "successor-owner",
+      executionToken: "new-worker",
       executionExpiresAt: new Date("2026-08-18T13:00:00Z"),
     })
     .where(eq(externalSiteRuns.id, run.id));
   resume?.();
 
-  await expect(execution).rejects.toBeInstanceOf(ScraperRunOwnershipError);
+  await expect(execution).rejects.toBeInstanceOf(ScraperRunTakenOverError);
   expect(sink).not.toHaveBeenCalled();
 });
 

--- a/apps/server/src/scraper/runs.ts
+++ b/apps/server/src/scraper/runs.ts
@@ -26,14 +26,14 @@ import {
   type ScraperHttpClock,
 } from "./http";
 import { ScraperRobotsDeniedError } from "./robots";
-import { createScraperSession, ScraperRunOwnershipError } from "./session";
+import { SCRAPER_RUN_REFRESH_MS, SCRAPER_RUN_TIMEOUT_MS } from "./runTimeout";
+import { createScraperSession, ScraperRunTakenOverError } from "./session";
 import type {
   ScraperRegistry,
   ScraperRunPayload,
   ScraperSourceDefinition,
 } from "./types";
 
-const RUN_EXECUTION_LEASE_MS = 60 * 60_000;
 const MAX_RUN_EXECUTION_ATTEMPTS = 10;
 const MAX_RUN_AGE_MS = 3 * 24 * 60 * 60_000;
 const DEFAULT_WAIT_MS = 15 * 60_000;
@@ -173,7 +173,7 @@ async function claimScraperRun({
             : candidate.run.sliceRequestCount,
         nextAttemptAt: null,
         executionToken,
-        executionExpiresAt: new Date(now.getTime() + RUN_EXECUTION_LEASE_MS),
+        executionExpiresAt: new Date(now.getTime() + SCRAPER_RUN_TIMEOUT_MS),
       })
       .where(eq(externalSiteRuns.id, runId))
       .returning();
@@ -218,7 +218,7 @@ async function completeRun(claim: ClaimedRun, completedAt: Date) {
         id: externalSiteRuns.id,
         externalSiteId: externalSiteRuns.externalSiteId,
       });
-    if (!completed) throw new ScraperRunOwnershipError();
+    if (!completed) throw new ScraperRunTakenOverError();
     await tx
       .update(externalSites)
       .set({ lastRunAt: completedAt, lastRunId: completed.id })
@@ -311,7 +311,11 @@ export async function executeScraperRun(
   },
 ): Promise<ScraperRunExecutionResult> {
   const { runId } = ScraperRunJobInputSchema.parse(input);
-  const runRegistry = await resolveScrapeSourceRunRegistry(runId, registry);
+  const runRegistry = await resolveScrapeSourceRunRegistry(
+    runId,
+    registry,
+    executionToken,
+  );
   const claimed = await claimScraperRun({
     runId,
     registry: runRegistry,
@@ -319,6 +323,12 @@ export async function executeScraperRun(
     executionToken,
   });
   if (!("run" in claimed)) return claimed;
+
+  const stopExtendingRun = startExtendingRunTimeout({
+    runId: claimed.run.id,
+    executionToken: claimed.executionToken,
+    clock,
+  });
 
   Sentry.getIsolationScope().setContext("externalSiteRun", {
     id: claimed.run.id,
@@ -340,6 +350,7 @@ export async function executeScraperRun(
       clock,
     });
     await claimed.source.adapter({ cursor, session });
+    await stopExtendingRun();
 
     const [latest] = await db
       .select({ emittedItemCount: externalSiteRuns.emittedItemCount })
@@ -349,8 +360,9 @@ export async function executeScraperRun(
     await completeRun(claimed, clock.now());
     return { status: "completed" };
   } catch (error) {
+    await stopExtendingRun().catch(() => {});
     if (
-      (error instanceof ScraperRunOwnershipError ||
+      (error instanceof ScraperRunTakenOverError ||
         (error instanceof ScraperRequestError &&
           error.category === "invalid_request")) &&
       (await isScraperRunPaused(claimed.run.id))
@@ -375,4 +387,67 @@ export async function executeScraperRun(
     );
     throw error;
   }
+}
+
+function startExtendingRunTimeout({
+  runId,
+  executionToken,
+  clock,
+}: {
+  runId: number;
+  executionToken: string;
+  clock: ScraperHttpClock;
+}) {
+  let stopped = false;
+  let refreshError: unknown;
+  let refresh = Promise.resolve();
+  const timer = setInterval(() => {
+    refresh = refresh
+      .then(async () => {
+        await extendRunTimeout({
+          runId,
+          executionToken,
+          now: clock.now(),
+        });
+      })
+      .catch((error) => {
+        refreshError = error;
+        clearInterval(timer);
+      });
+  }, SCRAPER_RUN_REFRESH_MS);
+  timer.unref();
+
+  return async () => {
+    if (!stopped) {
+      stopped = true;
+      clearInterval(timer);
+      await refresh;
+    }
+    if (refreshError) throw refreshError;
+  };
+}
+
+export async function extendRunTimeout({
+  runId,
+  executionToken,
+  now,
+}: {
+  runId: number;
+  executionToken: string;
+  now: Date;
+}) {
+  const [updated] = await db
+    .update(externalSiteRuns)
+    .set({
+      executionExpiresAt: new Date(now.getTime() + SCRAPER_RUN_TIMEOUT_MS),
+    })
+    .where(
+      and(
+        eq(externalSiteRuns.id, runId),
+        eq(externalSiteRuns.status, "running"),
+        eq(externalSiteRuns.executionToken, executionToken),
+      ),
+    )
+    .returning({ id: externalSiteRuns.id });
+  if (!updated) throw new ScraperRunTakenOverError();
 }

--- a/apps/server/src/scraper/session.ts
+++ b/apps/server/src/scraper/session.ts
@@ -8,6 +8,7 @@ import {
   scraperSystemClock,
 } from "./http";
 import { ensureRobotsAllowed } from "./robots";
+import { SCRAPER_RUN_TIMEOUT_MS } from "./runTimeout";
 import type {
   ScraperObservation,
   ScraperRegistry,
@@ -24,13 +25,12 @@ const ScraperSinkResultSchema = z
     existingItemCount: z.number().int().nonnegative(),
   })
   .strict();
-const RUN_EXECUTION_LEASE_MS = 60 * 60_000;
 
-export class ScraperRunOwnershipError extends Error {
-  override name = "ScraperRunOwnershipError";
+export class ScraperRunTakenOverError extends Error {
+  override name = "ScraperRunTakenOverError";
 
   constructor() {
-    super("Scraper run is no longer owned by this execution.");
+    super("Another worker has taken over this scraper run.");
   }
 }
 
@@ -62,7 +62,7 @@ export function createScraperSession<TCursor, TObservation>({
       .update(externalSiteRuns)
       .set({
         ...values,
-        executionExpiresAt: new Date(now.getTime() + RUN_EXECUTION_LEASE_MS),
+        executionExpiresAt: new Date(now.getTime() + SCRAPER_RUN_TIMEOUT_MS),
       })
       .where(
         and(
@@ -75,7 +75,7 @@ export function createScraperSession<TCursor, TObservation>({
         requestLimit: externalSiteRuns.requestLimit,
         sliceRequestCount: externalSiteRuns.sliceRequestCount,
       });
-    if (!updated) throw new ScraperRunOwnershipError();
+    if (!updated) throw new ScraperRunTakenOverError();
     remaining = Math.max(0, updated.requestLimit - updated.sliceRequestCount);
   }
 
@@ -138,7 +138,7 @@ export function createScraperSession<TCursor, TObservation>({
           emittedItemCount: sql`${externalSiteRuns.emittedItemCount} + ${validated.itemCount}`,
           newItemCount: sql`${externalSiteRuns.newItemCount} + ${counts.newItemCount}`,
           existingItemCount: sql`${externalSiteRuns.existingItemCount} + ${counts.existingItemCount}`,
-          executionExpiresAt: new Date(now.getTime() + RUN_EXECUTION_LEASE_MS),
+          executionExpiresAt: new Date(now.getTime() + SCRAPER_RUN_TIMEOUT_MS),
         })
         .where(
           and(
@@ -151,7 +151,7 @@ export function createScraperSession<TCursor, TObservation>({
           requestLimit: externalSiteRuns.requestLimit,
           sliceRequestCount: externalSiteRuns.sliceRequestCount,
         });
-      if (!updated) throw new ScraperRunOwnershipError();
+      if (!updated) throw new ScraperRunTakenOverError();
       remaining = Math.max(0, updated.requestLimit - updated.sliceRequestCount);
     },
 

--- a/apps/server/src/worker/client.ts
+++ b/apps/server/src/worker/client.ts
@@ -7,6 +7,7 @@ import config from "../config";
 import { syncExternalSites } from "../lib/externalSites";
 import { logError, logInfo, logTelemetryError } from "../lib/log";
 import { initializeScraperRuntime } from "../scraper";
+import { SCRAPER_JOB_LOCK_MS } from "../scraper/runTimeout";
 import { pushUniqueJob, runJob, type WorkerDispatch } from "./dispatch";
 import "./jobs";
 import createNextRepeatingEvents from "./jobs/createNextRepeatingEvents";
@@ -122,8 +123,6 @@ export const queueWorkerDispatch: WorkerDispatch = {
   pushUniqueJob: pushUniqueJobToQueue,
   runJob: runRegisteredJob,
 };
-const SCRAPER_JOB_LOCK_DURATION_MS = 60 * 60_000;
-
 export async function gracefulShutdown(signal?: string, worker?: Worker) {
   scheduler.stop();
   disconnectConnection();
@@ -165,8 +164,7 @@ export async function startWorkerRuntime(): Promise<WorkerRuntime> {
     connection,
     autorun: false,
     concurrency: 4,
-    // Scraper runs own a one-hour database lease and can wait on model or site requests.
-    lockDuration: SCRAPER_JOB_LOCK_DURATION_MS,
+    lockDuration: SCRAPER_JOB_LOCK_MS,
   });
 
   for (const worker of [defaultWorker, scraperWorker]) {


### PR DESCRIPTION
Configured scraper runs now extend their database timeout while slow work is in progress and use the same one-hour timeout as the queue worker. Preview results and AI-generated rule versions are saved only by the current worker, so a worker that has been replaced cannot overwrite newer preview state or create duplicate versions.

The worker check and each write happen in the same database transaction. Database-backed tests cover takeover during preview and AI suggestion work.

Fixes #1196
Refs #1210
