### PR TITLE
docs(catalog): record Karuizawa production audit

### DIFF
--- a/docs/operations/catalog-research.md
+++ b/docs/operations/catalog-research.md
@@ -15,6 +15,14 @@ results from individual tasks live under `docs/research/catalog/`.
 5. Record what was searched, what years and markets were covered, and what is
    still unknown.
 
+For a large, cask-heavy catalog, keep two independent inventories: the expected
+release inventory from outside sources and the complete Peated scope fetched by
+every relevant relationship. Partition the release inventory by vintage or
+distillation year and by marketed range. Reconcile both directions after every
+batch of changes. Names alone are not stable enough for this comparison; use
+the exact combination of producer, age or NAS, vintage, bottling year, ABV,
+edition, cask number, and Series when those facts are known.
+
 ## Best Places To Search
 
 | Place                              | Good for                                   | Watch for                                                 |
@@ -76,9 +84,18 @@ producer, auction, or retailer evidence.
 
 - A current range is not the full catalog.
 - One country site is not the worldwide catalog.
+- A distillery name is not the only way its historical releases were branded.
+  Check former owner and house brands, domestic blends, and local-language
+  labels, then require evidence that the distillery made the whisky in scope.
 - One auction or shop row is not always a separate release.
 - Gift boxes, bottle sizes, wax colors, and label changes often use the same
   whisky.
+- A person's, hotel, bar, retailer, importer, or private-cask customer's name
+  on a label does not establish a Bottler. Look for evidence that a business
+  independently selected and released the whisky.
+- Shared artwork or packaging does not establish a BottleSeries. Confirm a
+  named range, its Brand, and each member; split similarly named ranges when the
+  Brand changes.
 - Labels can be more accurate than page text.
 - Auction, shop, image, approval, distillation, and bottling dates are not
   release dates.
@@ -95,7 +112,9 @@ producer, auction, or retailer evidence.
   the exact label against an independent auction, producer, or retailer source
   before creating a Bottle; a plausible old date and name are not evidence.
 - An exact image may still lack permission for Peated to store it.
-- A direct image URL does not record its source or license.
+- A direct image URL does not record its source page or license. Count image
+  identity, source-page provenance, and reuse status separately in the final
+  audit.
 
 ## Preserve Durable Research
 

--- a/docs/research/catalog/2026-09-07-karuizawa-source-starting-points.md
+++ b/docs/research/catalog/2026-09-07-karuizawa-source-starting-points.md
@@ -3,6 +3,9 @@
 These links were identified during a September 7 review of prior catalog tasks.
 Recheck each site before use.
 
+The completed production review is recorded in
+[Karuizawa — September 8, 2026](2026-09-08-karuizawa.md).
+
 | Sources that worked                                                                                                                                                                                     | Useful note                              |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
 | [Wealth Solutions](https://en.wealth.pl/our-projects/karuizawa-gardens/), [Japanese collector pages](https://yabejojo.jimdoweb.com/karuizawa/karuizawa-vintage-1981/), exact auction labels, Whiskybase | Labels overruled errors on project pages |

--- a/docs/research/catalog/2026-09-08-karuizawa.md
+++ b/docs/research/catalog/2026-09-08-karuizawa.md
@@ -1,0 +1,150 @@
+# Karuizawa — September 8, 2026
+
+This production review covered every Bottle where Karuizawa (`E1098`) was the
+Brand or an evidenced distillery. It included Karuizawa-branded single malts,
+post-closure independent releases, cask samples, art and collector ranges, and
+historical Ocean Whisky Co. and Mercian products supported by product evidence.
+The point-in-time verification snapshot was fetched at 8:00 p.m. PDT on
+September 8, 2026. Re-fetch records before using these IDs or counts later.
+
+## Method
+
+The work used separate outside-source and Peated inventories.
+
+1. The Peated inventory was the union of every paginated Bottle returned for
+   Brand `E1098` and distillery `E1098`. Each Bottle, its Series, image fields,
+   aliases, and assigned references was fetched by stable ID.
+2. The outside inventory was divided by distillation year from 1960 through
+   2000, then by historical producer family and marketed collection. This kept
+   repeated names such as `Vintage`, `Single Cask`, and `Cask Sample` from
+   hiding distinct casks or bottlings.
+3. Broad collector and catalog indexes supplied leads. Exact producer pages,
+   contemporary announcements, readable front and back labels, auction lots,
+   and auction catalog PDFs supplied Bottle facts. When page prose conflicted
+   with a readable label, the label controlled the printed fact.
+4. Every proposed identity was compared on Brand, distillery, age or NAS, ABV,
+   vintage, bottling year, edition, cask number, and Series. Package size,
+   ceramic or glass presentation, carton art, and label art alone were not used
+   to create another Bottle.
+5. Writes used explicit production IDs and the authenticated API. Each changed
+   Bottle and uploaded image was read back. The final aggregate audit checked
+   identity duplicates, Karuizawa relationships, age/NAS contradictions,
+   barcode collisions, Series descriptions and membership counts, unsupported
+   tasting data, and image source fields.
+
+Temporary work included rendered PDF pages, downloaded source images, API
+responses, request bodies, and comparison scripts. Those files are deliberately
+not part of this archive. The reusable method belongs in
+[Catalog Research](../../operations/catalog-research.md) and
+[Catalog Maintenance](../../operations/catalog-maintenance.md).
+
+## Source Coverage
+
+No single source proved the complete Karuizawa catalog. The inventory was built
+by overlapping sources:
+
+- The Japanese collector [Karuizawa index](https://yabejojo.jimdoweb.com/karuizawa/)
+  supplied year-by-year release and cask leads, including Japanese-market
+  labels and cask samples. These pages were treated as collector evidence, not
+  as a producer-complete catalog.
+- The surviving [Karuizawa Whisky archive](https://karuizawa-whisky.com/en_us/)
+  supplied official post-closure product pages, collection membership, and
+  images.
+- Whisky Auctioneer's [Karuizawa distillery index](https://whiskyauctioneer.com/learn/explore-whisky/distilleries/karuizawa),
+  [36 Views of Mount Fuji](https://whiskyauctioneer.com/learn/explore-whisky/series/karuizawa-36-views-mount-fuji),
+  [Geishas](https://whiskyauctioneer.com/learn/explore-whisky/series/karuizawa-geishas),
+  and [Last Masterpieces](https://whiskyauctioneer.com/learn/explore-whisky/series/karuizawa-last-masterpieces)
+  pages supplied historical leads, exact lots, readable labels, and range
+  boundaries.
+- Wealth Solutions' [Karuizawa Gardens](https://en.wealth.pl/our-projects/karuizawa-gardens/)
+  and other project pages supplied collection membership and presentation
+  evidence. Exact labels overruled project-page errors.
+- Sotheby's [Scenes of Japan](https://www.sothebys.com/en/buy/auction/2023/scenes-of-japan-the-ultimate-karuizawa-collection),
+  Bonhams and Spink catalog PDFs, Christie's, Whisky.Auction, The Whisky
+  Exchange, Master of Malt, Distilia, dekanta, and other exact retailer or
+  auction pages filled label, cask, strength, outturn, and historical Ocean or
+  Mercian gaps.
+- [Whiskybase's Karuizawa index](https://www.whiskybase.com/whiskies/distillery/173/whiskies)
+  and Spirit Radar were used as manually reviewed lead indexes. They were not
+  copied as authority. Both can mix duplicate catalog records, package
+  variants, samples, and bottles whose Karuizawa association is wrong.
+
+The check covered the known 1960–2000 distillation years, the older domestic
+Ocean and Mercian families found in Japanese and auction sources, and the
+post-closure collections visible in producer, bottler, retailer, collector, and
+auction archives through September 8, 2026. It does not claim that every
+private cask or unreleased sample has surviving public evidence.
+
+## Production Result
+
+The final production scope contained 818 Bottles: 755 single malts, 55 blends,
+and 8 blended malts. Karuizawa was the Brand on 748; 70 used another evidenced
+Brand. Every Bottle retained Karuizawa as a distillery.
+
+- All 818 Bottles had descriptions. ABV was present on 817, vintage year on
+  600, bottling year on 631, maturation on 487, cask number on 593, and outturn
+  on 386. Unknown values remained `null`.
+- The scope used 107 BottleSeries. Evidence supported Series membership for
+  707 Bottles; 111 were intentionally unassigned. Every Series had a
+  description, included Karuizawa as a distillery, and had a Karuizawa member
+  count matching the scoped Bottle inventory.
+- Bottler was assigned to 397 Bottles. The other 421 were official releases or
+  lacked evidence of an independent selector and releaser. Owners, importers,
+  distributors, physical packers, retailers, bars, and private-barrel customers
+  were not treated as Bottlers merely because they appeared on a label.
+- Fifty-seven Bottles held 60 barcodes. No barcode was assigned to more than
+  one Bottle.
+- The final identity audit found no duplicate Peated IDs, exact structured
+  identity duplicates, missing Karuizawa distillery relationships, age/NAS
+  contradictions, or unsupported flavor-profile or tasting-note data.
+
+The audit also corrected high-risk edge cases rather than filling them by
+analogy. `B53193` is the 61.4% Karuizawa Five Decades release, with its
+no-age-statement status, 2015 release year, 200-bottle outturn, Series `S0578`,
+and exact image. Ocean Whisky Co. Ship Bottle `B56079`, Victory `B56083`, Ocean
+Whisky `B56119`, and Hiroshima Toyo Carp `B56120` were kept as their own
+marketed identities. The lighthouse-shaped container on `B56119` is packaging,
+not a separate edition.
+
+## Images And Provenance
+
+There were 763 exact stored Bottle images and 55 Bottles without an exact
+image. Every stored image had a source value, but the quality of the provenance
+metadata is not uniform: 63 source values are direct image assets rather than a
+canonical source page, and none of the 763 stored images had an explicit image
+license value. These are provenance gaps, not evidence that the images depict
+the wrong Bottle.
+
+The 55 exact-image gaps were 36 Cask Sample releases, 14 Vintage Single Cask
+Malt Whisky releases, 3 Bottles with no Series, 1 Number One Single Cask, and 1
+Rouge Cask Series release. A similar bottle, another bottling from the same
+cask, or a small crop without enough label identity was not used as a
+substitute.
+
+## Unresolved And Rejected Leads
+
+- `B53616`, Karuizawa Vintage Single Cask Malt Whisky — Private Barrel of
+  Hideki Kurosaki, remains without an ABV. Its label supports 25 years and cask
+  6359 but does not print a strength. Hideki Kurosaki is an edition descriptor,
+  not a Bottler; no evidence shows an independent whisky release business.
+- Four unassigned production references matched the exact query `Karuizawa` at
+  final follow-up: reference `12893` (`Karuizawa 1981`), reference `14631`
+  (`Karuizawa 1981 Vintage - Single Cask Malt Whisky`), reference `14037`
+  (`Karuizawa 1984 Vintage - Single Cask Malt Whisky`), and reference `12901`
+  (`Karuizawa Spirit of Asama`). Each can identify more than one structured
+  Bottle and therefore remains unassigned.
+- A `Karuizawa 100% Grain` lead was rejected because the exact bottle is
+  Kawasaki grain whisky; its Karuizawa association in a broad catalog was
+  wrong.
+- An Imperial Hotel lead remained unsupported by an exact label or independent
+  corroboration. A single catalog row did not establish a marketed release.
+- Lucky Ocean leads had contradictory identities and were not proven to use
+  Karuizawa whisky. They were not added merely because Ocean later owned
+  Karuizawa.
+- A private experimental WWCP item was not proven to be a marketed Bottle.
+- A 35% Ocean Carp lead lacked an exact label or facts that distinguished it
+  from the supported Carp release, so it was not created.
+
+The final state is a point-in-time, evidence-bounded catalog. Later discoveries
+should add or correct records only after the exact Bottle and every changed
+fact are re-verified.

--- a/skills/peated-catalog/SKILL.md
+++ b/skills/peated-catalog/SKILL.md
@@ -26,7 +26,9 @@ user gives.
    from sources outside Peated. Fetch every page of Peated results and compare
    the lists. The producer's current range does not define the catalog. Search
    every period and product family, including discontinued, one-off, and
-   country-specific releases.
+   country-specific releases. For a distillery scope, also search historical
+   owner and house brands; domestic blends and older releases may not use the
+   distillery as their Brand.
 3. Use specialist catalogs, collector lists, old sites, and auction archives to
    find past releases. Verify each release and fact with producer pages,
    announcements from the time, readable labels, or exact auction records. If a
@@ -71,11 +73,19 @@ the scoped research artifact.
   facts, and outturn in their fields.
 - Use `null` for unknown or disputed facts. Keep an existing value unless a
   stronger source for the same Bottle proves it wrong.
-- Use a Series only for a named product range. Add an alias only for a proven
-  public name. Assign an import reference only when the full text identifies one
-  Bottle.
-- Use only an image of the exact Bottle. Save the page where it appears and its
-  reuse terms, then inspect the stored image.
+- A Bottler independently selects and releases whisky made by another producer.
+  A name on the label does not prove that role: do not infer it from an owner,
+  importer, distributor, physical packer, customer, retailer, bar, or private
+  barrel holder. Do not clear an existing Bottler only because a source omits
+  it; require stronger evidence that the assignment is wrong.
+- Use a Series only for an evidenced, named product range owned by one Brand.
+  Shared artwork, a client, a release year, or similar packaging does not prove
+  Series membership. Add an alias only for a proven public name. Assign an
+  import reference only when the full text identifies one Bottle.
+- Use only an image of the exact Bottle. Save the canonical page where it
+  appears and its reuse terms, then inspect the stored image. A populated image
+  URL, a direct asset URL, or a missing license does not by itself complete the
+  provenance check.
 - Merge only proven copies of the same marketed release.
 
 Completing one family or the current range does not complete the catalog.


### PR DESCRIPTION
Records the completed Karuizawa production catalog audit, including its scope, research method, source coverage, final 818-Bottle and 107-Series reconciliation, known image-provenance and reference gaps, and rejected misleading leads.

The catalog workflow now also requires relationship-based inventory for distillery scopes, evidence that an Entity truly acted as an independent Bottler, Brand-owned Series membership rather than shared-artwork inference, and separate checks for exact image identity, canonical source provenance, and reuse status. The 742 MB temporary evidence workspace remains local and is not part of the PR.
