### PR TITLE
perf(database): use indexed bottle relationship scopes

### DIFF
--- a/apps/server/src/lib/distilleryBottleView.ts
+++ b/apps/server/src/lib/distilleryBottleView.ts
@@ -3,45 +3,63 @@ import {
   bottlesToDistillers,
   entities,
 } from "@peated/server/db/schema";
-import type { SQL } from "drizzle-orm";
-import { and, eq, isNull, not, or, sql } from "drizzle-orm";
+import { sql, type SQL } from "drizzle-orm";
 
 /**
  * A distillery release uses the distillery or one of its directly owned
  * labels as the brand, with no outside bottler. Other bottlings use an
  * outside brand or bottler.
  */
-export function bottlesForDistilleryView(
+export function bottleIdsForDistilleryView(
   distilleryId: number,
   view: "releases" | "other",
 ): SQL<unknown> {
-  const ownBrand = or(
-    eq(bottles.brandId, distilleryId),
-    sql`EXISTS(
-      SELECT FROM ${entities}
-      WHERE ${entities.id} = ${bottles.brandId}
-        AND ${entities.ownerId} = ${distilleryId}
+  const scope = sql`
+    WITH owned_entities AS MATERIALIZED (
+      SELECT ${distilleryId}::bigint AS entity_id
+
+      UNION
+
+      SELECT ${entities.id} AS entity_id
+      FROM ${entities}
+      WHERE ${entities.ownerId} = ${distilleryId}
         AND ${entities.kind} IN ('brand', 'bottler')
-    )`,
-  )!;
-  const ownBottler = or(
-    isNull(bottles.bottlerId),
-    eq(bottles.bottlerId, distilleryId),
-    sql`EXISTS(
-      SELECT FROM ${entities}
-      WHERE ${entities.id} = ${bottles.bottlerId}
-        AND ${entities.ownerId} = ${distilleryId}
-        AND ${entities.kind} IN ('brand', 'bottler')
-    )`,
-  )!;
-  const madeByDistillery = sql`EXISTS(
-    SELECT FROM ${bottlesToDistillers}
-    WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
-      AND ${bottlesToDistillers.distillerId} = ${distilleryId}
-  )`;
-  const ownRelease = and(ownBrand, ownBottler)!;
+    ),
+    official_releases AS MATERIALIZED (
+      SELECT ${bottles.id} AS bottle_id
+      FROM ${bottles}
+      INNER JOIN owned_entities AS brands
+        ON brands.entity_id = ${bottles.brandId}
+      WHERE ${bottles.bottlerId} IS NULL
+        OR ${bottles.bottlerId} IN (
+          SELECT entity_id FROM owned_entities
+        )
+    )
+  `;
 
   return view === "releases"
-    ? ownRelease
-    : and(or(ownBrand, madeByDistillery), not(ownRelease))!;
+    ? sql`
+        ${scope}
+        SELECT bottle_id FROM official_releases
+      `
+    : sql`
+        ${scope},
+        candidate_bottles AS MATERIALIZED (
+          SELECT ${bottles.id} AS bottle_id
+          FROM ${bottles}
+          INNER JOIN owned_entities AS brands
+            ON brands.entity_id = ${bottles.brandId}
+
+          UNION
+
+          SELECT ${bottlesToDistillers.bottleId} AS bottle_id
+          FROM ${bottlesToDistillers}
+          WHERE ${bottlesToDistillers.distillerId} = ${distilleryId}
+        )
+        SELECT candidate_bottles.bottle_id
+        FROM candidate_bottles
+        LEFT JOIN official_releases
+          ON official_releases.bottle_id = candidate_bottles.bottle_id
+        WHERE official_releases.bottle_id IS NULL
+      `;
 }

--- a/apps/server/src/lib/entityBottleIds.ts
+++ b/apps/server/src/lib/entityBottleIds.ts
@@ -1,22 +1,33 @@
-import { db } from "@peated/server/db";
 import { bottles, bottlesToDistillers } from "@peated/server/db/schema";
-import { eq } from "drizzle-orm";
-import { union } from "drizzle-orm/pg-core";
+import { sql, type SQL } from "drizzle-orm";
 
 /** Uses each Bottle relationship index independently and removes role overlaps. */
-export function bottleIdsForEntity(entityId: number) {
-  return union(
-    db
-      .select({ id: bottles.id })
-      .from(bottles)
-      .where(eq(bottles.brandId, entityId)),
-    db
-      .select({ id: bottles.id })
-      .from(bottles)
-      .where(eq(bottles.bottlerId, entityId)),
-    db
-      .select({ id: bottlesToDistillers.bottleId })
-      .from(bottlesToDistillers)
-      .where(eq(bottlesToDistillers.distillerId, entityId)),
-  );
+export function bottleIdsForEntities(entityIds: SQL<unknown>): SQL<unknown> {
+  return sql`
+    WITH target_entities AS MATERIALIZED (
+      ${entityIds}
+    )
+    SELECT ${bottles.id}
+    FROM ${bottles}
+    INNER JOIN target_entities
+      ON target_entities.entity_id = ${bottles.brandId}
+
+    UNION
+
+    SELECT ${bottles.id}
+    FROM ${bottles}
+    INNER JOIN target_entities
+      ON target_entities.entity_id = ${bottles.bottlerId}
+
+    UNION
+
+    SELECT ${bottlesToDistillers.bottleId}
+    FROM ${bottlesToDistillers}
+    INNER JOIN target_entities
+      ON target_entities.entity_id = ${bottlesToDistillers.distillerId}
+  `;
+}
+
+export function bottleIdsForEntity(entityId: number): SQL<unknown> {
+  return bottleIdsForEntities(sql`SELECT ${entityId}::bigint AS entity_id`);
 }

--- a/apps/server/src/orpc/routes/activity/reviews-and-tastings.ts
+++ b/apps/server/src/orpc/routes/activity/reviews-and-tastings.ts
@@ -6,7 +6,6 @@ import type {
 } from "@peated/server/db/schema";
 import {
   bottles,
-  bottlesToDistillers,
   bottleTombstones,
   entities,
   externalReviewArticles,
@@ -18,6 +17,7 @@ import {
 } from "@peated/server/db/schema";
 import { visibleExternalReviewWhere } from "@peated/server/externalReviews/visibility";
 import { viewerVisibleUserCondition } from "@peated/server/lib/activityVisibility";
+import { bottleIdsForEntity } from "@peated/server/lib/entityBottleIds";
 import {
   ActiveBottleSelectionError,
   resolveActiveBottleIds,
@@ -99,27 +99,24 @@ export default implement(contract).handler(
       ? new Date(parsedCursor.snapshotAt)
       : new Date();
     const userCondition = viewerVisibleUserCondition(context.user?.id);
+    const scopeCte = input.entity
+      ? sql`
+          WITH scoped_bottles AS MATERIALIZED (
+            SELECT ${bottles.id} AS bottle_id
+            FROM ${bottles}
+            WHERE ${bottles.id} IN (${bottleIdsForEntity(input.entity)})
+              AND ${bottles.groupId} IS NOT NULL
+              AND NOT EXISTS (
+                SELECT FROM ${bottleTombstones}
+                WHERE ${bottleTombstones.bottleId} = ${bottles.id}
+              )
+          )
+        `
+      : sql``;
     const scope = (bottleId: SQL<unknown>) =>
       input.bottle
         ? sql`${bottleId} = ${input.bottle}`
-        : sql`${bottleId} IN (
-          SELECT ${bottles.id}
-          FROM ${bottles}
-          WHERE ${bottles.groupId} IS NOT NULL
-            AND NOT EXISTS (
-              SELECT FROM ${bottleTombstones}
-              WHERE ${bottleTombstones.bottleId} = ${bottles.id}
-            )
-            AND (
-              ${bottles.brandId} = ${input.entity}
-              OR ${bottles.bottlerId} = ${input.entity}
-              OR EXISTS (
-                SELECT FROM ${bottlesToDistillers}
-                WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
-                  AND ${bottlesToDistillers.distillerId} = ${input.entity}
-              )
-            )
-        )`;
+        : sql`${bottleId} IN (SELECT bottle_id FROM scoped_bottles)`;
     const after = parsedCursor
       ? sql`AND (
         activity.occurred_at < ${new Date(parsedCursor.occurredAt)}
@@ -136,6 +133,7 @@ export default implement(contract).handler(
       : sql``;
 
     const result = await db.execute<Row>(sql`
+    ${scopeCte}
     SELECT activity.type, activity.kind_rank AS "kindRank", activity.id,
       activity.bottle_id AS "bottleId",
       activity.occurred_at AS "occurredAt"

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -17,8 +17,11 @@ import {
 import { bottleProducedIn } from "@peated/server/lib/bottleProductionLocation";
 import { companyBottleEntityIds } from "@peated/server/lib/companyPortfolio";
 import { getReservedCollection } from "@peated/server/lib/db";
-import { bottlesForDistilleryView } from "@peated/server/lib/distilleryBottleView";
-import { bottleIdsForEntity } from "@peated/server/lib/entityBottleIds";
+import { bottleIdsForDistilleryView } from "@peated/server/lib/distilleryBottleView";
+import {
+  bottleIdsForEntities,
+  bottleIdsForEntity,
+} from "@peated/server/lib/entityBottleIds";
 import {
   plainTextSearchQuery,
   prefixTextSearchQuery,
@@ -253,15 +256,7 @@ export default implement(bottleListContract).handler(async function ({
 
     const companyEntityIds = companyBottleEntityIds(rest.company);
     where.push(
-      or(
-        sql`${bottles.brandId} IN (${companyEntityIds})`,
-        sql`${bottles.bottlerId} IN (${companyEntityIds})`,
-        sql`EXISTS(
-          SELECT FROM ${bottlesToDistillers}
-          WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
-            AND ${bottlesToDistillers.distillerId} IN (${companyEntityIds})
-        )`,
-      ),
+      sql`${bottles.id} IN (${bottleIdsForEntities(companyEntityIds)})`,
     );
   }
   if (rest.distilleryView) {
@@ -279,9 +274,11 @@ export default implement(bottleListContract).handler(async function ({
         message: "Choose a distillery for this view.",
       });
     }
-    where.push(bottlesForDistilleryView(rest.entity, rest.distilleryView));
+    where.push(
+      sql`${bottles.id} IN (${bottleIdsForDistilleryView(rest.entity, rest.distilleryView)})`,
+    );
   } else if (rest.entity) {
-    where.push(inArray(bottles.id, bottleIdsForEntity(rest.entity)));
+    where.push(sql`${bottles.id} IN (${bottleIdsForEntity(rest.entity)})`);
   }
   if (rest.series) {
     where.push(eq(bottles.seriesId, rest.series));

--- a/apps/server/src/orpc/routes/entities/catalog.ts
+++ b/apps/server/src/orpc/routes/entities/catalog.ts
@@ -8,13 +8,13 @@ import {
 import { bottleIdsForEntity } from "@peated/server/lib/entityBottleIds";
 import { implement } from "@peated/server/orpc";
 import entityCatalogContract from "@peated/server/orpc/contracts/entities/catalog";
-import { and, asc, desc, eq, inArray, isNotNull, ne, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNotNull, ne, sql } from "drizzle-orm";
 
 const activeBottleWhere = (entityId: number) => {
   return and(
     isNotNull(bottles.groupId),
     sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
-    inArray(bottles.id, bottleIdsForEntity(entityId)),
+    sql`${bottles.id} IN (${bottleIdsForEntity(entityId)})`,
   );
 };
 


### PR DESCRIPTION
Replaces the correlated Bottle relationship filters behind Entity, Company, and Distillery views with deduplicated ID sets that can use the existing brand, bottler, and distiller indexes. The reviews-and-tastings feed now materializes that scope once for all three activity sources.

Production `EXPLAIN ANALYZE` on Karuizawa showed:

- Distillery release count: 81.6 ms → 4.4 ms; 20,048 → 2,759 buffer hits.
- Three-source activity feed: 155 ms → 7.2 ms; 41,618 → 7,707 buffer hits.

Verified with the 62 Bottle list, 4 reviews-and-tastings, and 4 Entity catalog integration tests, plus server typecheck, oxlint, Prettier, and `git diff --check`.
