### PR TITLE
fix(web): open member tastings from header

### DIFF
--- a/apps/web/src/app/(app)/tastings/page.tsx
+++ b/apps/web/src/app/(app)/tastings/page.tsx
@@ -5,5 +5,5 @@ import { redirect } from "next/navigation";
 export default async function TastingsPage() {
   const user = await getCurrentUser();
   if (!user) return redirectToAuth({ pathname: "/tastings" });
-  redirect(`/users/${user.username}`);
+  redirect(`/users/${user.username}/tastings`);
 }


### PR DESCRIPTION
The signed-in header’s Tastings link now opens the member’s Tastings tab instead of their profile overview. The existing `/tastings` authentication shortcut remains unchanged for signed-out visitors.
