### PR TITLE
perf(moderation): query paginated history in postgres

### DIFF
--- a/apps/server/src/lib/moderationHistory.ts
+++ b/apps/server/src/lib/moderationHistory.ts
@@ -7,125 +7,129 @@ import {
   users,
 } from "@peated/server/db/schema";
 import type { ModerationHistorySummary } from "@peated/server/orpc/routes/admin/moderation/schemas";
-import { desc, eq, isNotNull } from "drizzle-orm";
+import { and, isNotNull, sql, type SQL } from "drizzle-orm";
 
-const MAX_PROJECTED_HISTORY_ROWS = 10_000;
+type ModerationHistoryInput = {
+  query?: string;
+  category?: "listing" | "catalog";
+  outcome?: string;
+  actor?: string;
+  offset: number;
+  limit: number;
+};
 
-function operationTitle(
-  proposal: (typeof bottleOperations.$inferSelect)["proposal"],
-): string {
-  switch (proposal.type) {
-    case "update_bottle":
-      return `Update bottle #${proposal.input.bottleId}`;
-    case "merge_bottles":
-      return `Merge bottle #${proposal.input.sourceBottleId} into #${proposal.input.destinationBottleId}`;
-    case "update_entity":
-      return `Update brand or producer #${proposal.input.entityId}`;
-    case "merge_entities":
-      return `Merge brand or producer #${proposal.input.sourceEntityId} into #${proposal.input.destinationEntityId}`;
+type ModerationHistoryRow = Omit<ModerationHistorySummary, "occurredAt"> & {
+  occurredAt: Date | string;
+};
+
+export async function queryModerationHistory(
+  input: ModerationHistoryInput,
+): Promise<ModerationHistorySummary[]> {
+  const conditions: SQL<unknown>[] = [];
+  if (input.category) {
+    conditions.push(sql`history.category = ${input.category}`);
   }
-}
+  if (input.outcome) {
+    conditions.push(
+      sql`STRPOS(LOWER(history.outcome), LOWER(${input.outcome})) > 0`,
+    );
+  }
+  if (input.actor) {
+    conditions.push(
+      sql`STRPOS(LOWER(history.actor), LOWER(${input.actor})) > 0`,
+    );
+  }
+  if (input.query) {
+    conditions.push(sql`
+      STRPOS(
+        LOWER(CONCAT_WS(' ', history.title, history.outcome, history.actor, history.key)),
+        LOWER(${input.query})
+      ) > 0
+    `);
+  }
+  const where = and(...conditions) ?? sql`TRUE`;
 
-export async function projectModerationHistory(): Promise<
-  ModerationHistorySummary[]
-> {
-  const [incoming, operations, closures] = await Promise.all([
-    db
-      .select({ log: incomingBottleDecisionLogs, actor: actors.displayName })
-      .from(incomingBottleDecisionLogs)
-      .innerJoin(actors, eq(actors.id, incomingBottleDecisionLogs.actorId))
-      .orderBy(
-        desc(incomingBottleDecisionLogs.createdAt),
-        desc(incomingBottleDecisionLogs.id),
-      )
-      .limit(MAX_PROJECTED_HISTORY_ROWS),
-    db
-      .select({ operation: bottleOperations, actor: users.username })
-      .from(bottleOperations)
-      .leftJoin(users, eq(users.id, bottleOperations.reviewedById))
-      .where(isNotNull(bottleOperations.reviewedAt))
-      .orderBy(desc(bottleOperations.reviewedAt), desc(bottleOperations.id))
-      .limit(MAX_PROJECTED_HISTORY_ROWS),
-    db
-      .select({ check: bottleChecks, actor: users.username })
-      .from(bottleChecks)
-      .leftJoin(users, eq(users.id, bottleChecks.closedById))
-      .where(isNotNull(bottleChecks.closedAt))
-      .orderBy(desc(bottleChecks.closedAt), desc(bottleChecks.id))
-      .limit(MAX_PROJECTED_HISTORY_ROWS),
-  ]);
+  const result = await db.execute<ModerationHistoryRow>(sql`
+    SELECT *
+    FROM (
+      SELECT
+        'incoming:' || ${incomingBottleDecisionLogs.id} AS key,
+        'incoming_decision'::text AS kind,
+        'listing'::text AS category,
+        ${incomingBottleDecisionLogs.name} AS title,
+        REPLACE(${incomingBottleDecisionLogs.decision}::text, '_', ' ') AS outcome,
+        ${actors.displayName} AS actor,
+        ${incomingBottleDecisionLogs.createdAt} AS "occurredAt"
+      FROM ${incomingBottleDecisionLogs}
+      INNER JOIN ${actors}
+        ON ${actors.id} = ${incomingBottleDecisionLogs.actorId}
 
-  return [
-    ...incoming.map(
-      ({ log, actor }): ModerationHistorySummary => ({
-        key: `incoming:${log.id}`,
-        kind: "incoming_decision",
-        category: "listing",
-        title: log.name,
-        outcome: log.decision.replaceAll("_", " "),
-        actor,
-        occurredAt: log.createdAt.toISOString(),
-      }),
-    ),
-    ...operations.map(
-      ({ operation, actor }): ModerationHistorySummary => ({
-        key: `operation:${operation.id}`,
-        kind: "operation",
-        category: "catalog",
-        title: operationTitle(operation.proposal),
-        outcome: operation.status.replaceAll("_", " "),
-        actor,
-        occurredAt: operation.reviewedAt!.toISOString(),
-      }),
-    ),
-    ...closures.map(
-      ({ check, actor }): ModerationHistorySummary => ({
-        key: `closure:${check.id}`,
-        kind: "audit_closure",
-        category: "catalog",
-        title: check.bottleId
-          ? `Bottle #${check.bottleId}`
-          : `Check #${check.id}`,
-        outcome: check.closeReason?.replaceAll("_", " ") ?? "closed",
-        actor,
-        occurredAt: check.closedAt!.toISOString(),
-      }),
-    ),
-  ].sort(
-    (left, right) =>
-      right.occurredAt.localeCompare(left.occurredAt) ||
-      left.key.localeCompare(right.key),
-  );
-}
+      UNION ALL
 
-export function filterModerationHistory(
-  events: ModerationHistorySummary[],
-  input: {
-    query?: string;
-    category?: "listing" | "catalog";
-    outcome?: string;
-    actor?: string;
-  },
-): ModerationHistorySummary[] {
-  const query = input.query?.toLocaleLowerCase();
-  const outcome = input.outcome?.toLocaleLowerCase();
-  const actor = input.actor?.toLocaleLowerCase();
-  return events.filter((event) => {
-    if (input.category && event.category !== input.category) return false;
-    if (outcome && !event.outcome.toLocaleLowerCase().includes(outcome)) {
-      return false;
-    }
-    if (actor && !event.actor?.toLocaleLowerCase().includes(actor))
-      return false;
-    if (
-      query &&
-      ![event.title, event.outcome, event.actor, event.key]
-        .join(" ")
-        .toLocaleLowerCase()
-        .includes(query)
-    ) {
-      return false;
-    }
-    return true;
-  });
+      SELECT
+        'operation:' || ${bottleOperations.id} AS key,
+        'operation'::text AS kind,
+        'catalog'::text AS category,
+        CASE ${bottleOperations.proposal}->>'type'
+          WHEN 'update_bottle' THEN
+            CONCAT(
+              'Update bottle #',
+              ${bottleOperations.proposal}#>>'{input,bottleId}'
+            )
+          WHEN 'merge_bottles' THEN
+            CONCAT(
+              'Merge bottle #',
+              ${bottleOperations.proposal}#>>'{input,sourceBottleId}',
+              ' into #',
+              ${bottleOperations.proposal}#>>'{input,destinationBottleId}'
+            )
+          WHEN 'update_entity' THEN
+            CONCAT(
+              'Update brand or producer #',
+              ${bottleOperations.proposal}#>>'{input,entityId}'
+            )
+          WHEN 'merge_entities' THEN
+            CONCAT(
+              'Merge brand or producer #',
+              ${bottleOperations.proposal}#>>'{input,sourceEntityId}',
+              ' into #',
+              ${bottleOperations.proposal}#>>'{input,destinationEntityId}'
+            )
+          ELSE 'Operation #' || ${bottleOperations.id}
+        END AS title,
+        REPLACE(${bottleOperations.status}::text, '_', ' ') AS outcome,
+        ${users.username} AS actor,
+        ${bottleOperations.reviewedAt} AS "occurredAt"
+      FROM ${bottleOperations}
+      LEFT JOIN ${users} ON ${users.id} = ${bottleOperations.reviewedById}
+      WHERE ${isNotNull(bottleOperations.reviewedAt)}
+
+      UNION ALL
+
+      SELECT
+        'closure:' || ${bottleChecks.id} AS key,
+        'audit_closure'::text AS kind,
+        'catalog'::text AS category,
+        CASE
+          WHEN ${bottleChecks.bottleId} IS NOT NULL
+            THEN 'Bottle #' || ${bottleChecks.bottleId}
+          ELSE 'Check #' || ${bottleChecks.id}
+        END AS title,
+        COALESCE(REPLACE(${bottleChecks.closeReason}::text, '_', ' '), 'closed') AS outcome,
+        ${users.username} AS actor,
+        ${bottleChecks.closedAt} AS "occurredAt"
+      FROM ${bottleChecks}
+      LEFT JOIN ${users} ON ${users.id} = ${bottleChecks.closedById}
+      WHERE ${isNotNull(bottleChecks.closedAt)}
+    ) AS history
+    WHERE ${where}
+    ORDER BY history."occurredAt" DESC, history.key ASC
+    OFFSET ${input.offset}
+    LIMIT ${input.limit}
+  `);
+
+  return result.rows.map((row) => ({
+    ...row,
+    occurredAt: new Date(row.occurredAt).toISOString(),
+  }));
 }

--- a/apps/server/src/orpc/routes/admin/moderation/history.test.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/history.test.ts
@@ -96,6 +96,39 @@ describe("admin moderation history", () => {
       `closure:${check!.id}`,
     ]);
 
+    const firstPage = await routerClient.admin.moderation.listHistory(
+      { limit: 2 },
+      { context: { user: admin } },
+    );
+    expect(firstPage.results.map(({ key }) => key)).toEqual([
+      `operation:${operation!.id}`,
+      `incoming:${incoming!.id}`,
+    ]);
+    expect(firstPage.rel).toEqual({ nextCursor: 2, prevCursor: null });
+    const secondPage = await routerClient.admin.moderation.listHistory(
+      { cursor: 2, limit: 2 },
+      { context: { user: admin } },
+    );
+    expect(secondPage.results.map(({ key }) => key)).toEqual([
+      `closure:${check!.id}`,
+    ]);
+    expect(secondPage.rel).toEqual({ nextCursor: null, prevCursor: 1 });
+
+    const listingHistory = await routerClient.admin.moderation.listHistory(
+      { category: "listing", query: "history listing" },
+      { context: { user: admin } },
+    );
+    expect(listingHistory.results.map(({ key }) => key)).toEqual([
+      `incoming:${incoming!.id}`,
+    ]);
+    const rejectedHistory = await routerClient.admin.moderation.listHistory(
+      { outcome: "reject", actor: "history-reviewer" },
+      { context: { user: admin } },
+    );
+    expect(rejectedHistory.results.map(({ key }) => key)).toEqual([
+      `operation:${operation!.id}`,
+    ]);
+
     const incomingDetails = await routerClient.admin.moderation.historyDetails(
       { key: `incoming:${incoming!.id}` },
       { context: { user: admin } },

--- a/apps/server/src/orpc/routes/admin/moderation/list-history.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/list-history.ts
@@ -1,7 +1,4 @@
-import {
-  filterModerationHistory,
-  projectModerationHistory,
-} from "@peated/server/lib/moderationHistory";
+import { queryModerationHistory } from "@peated/server/lib/moderationHistory";
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import {
@@ -22,16 +19,16 @@ export default procedure
   .input(ModerationHistoryListInputSchema)
   .output(ModerationHistoryListResponseSchema)
   .handler(async ({ input }) => {
-    const events = filterModerationHistory(
-      await projectModerationHistory(),
-      input,
-    );
     const offset = (input.cursor - 1) * input.limit;
+    const events = await queryModerationHistory({
+      ...input,
+      offset,
+      limit: input.limit + 1,
+    });
     return {
-      results: events.slice(offset, offset + input.limit),
+      results: events.slice(0, input.limit),
       rel: {
-        nextCursor:
-          offset + input.limit < events.length ? input.cursor + 1 : null,
+        nextCursor: events.length > input.limit ? input.cursor + 1 : null,
         prevCursor: input.cursor > 1 ? input.cursor - 1 : null,
       },
     };


### PR DESCRIPTION
Moves moderation-history projection, filtering, ordering, and pagination into PostgreSQL. The route now fetches only one narrow page plus a lookahead row instead of loading up to 10,000 full rows from each of three JSON-heavy tables and processing them in Node.

The production plan returns the first 51 unified events in 10.5 ms with 677 buffer accesses. The previous hottest source query alone ran at roughly 0.75–1.7 seconds and returned 5,508 full records per request.

Adds integration coverage for stable page navigation and category, text, outcome, and actor filters. Verified with the moderation-history integration suite, server typecheck, oxlint, Prettier, and `git diff --check`.
