### PR TITLE
feat(admin): improve scraper index

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/health.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.test.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
 import {
+  catalogListings,
   externalReviews,
   externalSiteRuns,
   externalSiteScrapeTargets,
@@ -36,6 +37,12 @@ test("health list reports source inventory, runtime, and latest execution", asyn
     externalSiteId: site.id,
     bottleId: null,
     hidden: false,
+  });
+  await db.insert(catalogListings).values({
+    externalSiteId: site.id,
+    sourceFingerprint: "decadent-single-cask",
+    name: "Decadent Single Cask",
+    url: "https://decadent-drinks.com/products/single-cask",
   });
   await db.insert(scrapeTargets).values({
     key: "decadentdrinks",
@@ -89,6 +96,7 @@ test("health list reports source inventory, runtime, and latest execution", asyn
   expect(result.results).toHaveLength(1);
   expect(result.results[0]).toMatchObject({
     type: "decadentdrinks",
+    catalogListings: { total: 1 },
     externalReviews: { total: 0, matched: 0, unmatched: 0 },
     priceListings: { total: 2, matched: 1, unmatched: 1 },
     lastRunAt: null,

--- a/apps/server/src/orpc/routes/external-sites/health.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.ts
@@ -1,6 +1,7 @@
 import { isExternalReviewSiteKey } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import {
+  catalogListings,
   externalReviewArticles,
   externalReviewPublications,
   externalReviews,
@@ -39,6 +40,7 @@ async function getHealthForSites(
 
   const siteIds = sites.map((site) => site.id);
   const [
+    catalogCoverageRows,
     reviewCoverageRows,
     priceCoverageRows,
     latestRuns,
@@ -47,6 +49,14 @@ async function getHealthForSites(
     reviewPublications,
     configuredRows,
   ] = await Promise.all([
+    db
+      .select({
+        externalSiteId: catalogListings.externalSiteId,
+        total: sql<number>`count(*)::int`,
+      })
+      .from(catalogListings)
+      .where(inArray(catalogListings.externalSiteId, siteIds))
+      .groupBy(catalogListings.externalSiteId),
     db
       .select({
         externalSiteId: externalReviewArticles.externalSiteId,
@@ -163,6 +173,9 @@ async function getHealthForSites(
       .where(inArray(scrapeSources.externalSiteId, siteIds)),
   ]);
 
+  const catalogCoverageBySite = new Map(
+    catalogCoverageRows.map((row) => [row.externalSiteId, row]),
+  );
   const reviewCoverageBySite = new Map(
     reviewCoverageRows.map((row) => [row.externalSiteId, row]),
   );
@@ -231,6 +244,7 @@ async function getHealthForSites(
       isExternalReviewSiteKey(site.type) || configured?.kind === "review";
     const reviewCoverage = reviewCoverageBySite.get(site.id);
     const priceCoverage = priceCoverageBySite.get(site.id);
+    const catalogCoverage = catalogCoverageBySite.get(site.id);
     const latestRun = latestRunBySite.get(site.id);
     const lastSucceeded = lastSucceededBySite.get(site.id);
     const targets = targetsBySite.get(site.id);
@@ -238,6 +252,7 @@ async function getHealthForSites(
 
     return {
       ...serializeExternalSite(site),
+      catalogListings: catalogCoverage ?? { total: 0 },
       externalReviews: reviewCoverage ?? { total: 0, matched: 0, unmatched: 0 },
       priceListings: priceCoverage ?? { total: 0, matched: 0, unmatched: 0 },
       latestRun: latestRun ? serializeExternalSiteRun(latestRun) : null,
@@ -274,7 +289,7 @@ export const healthList = procedure
     path: "/admin/external-sites",
     summary: "List external site health",
     description:
-      "List import status, recent runs, and bottle matching counts for external sites. Includes reviews awaiting publication. Requires administrator privileges.",
+      "List import status, recent runs, catalog listing counts, and bottle matching counts for external sites. Includes reviews awaiting publication. Requires administrator privileges.",
     operationId: "listExternalSiteHealth",
   })
   .input(inputSchema)
@@ -312,7 +327,7 @@ export const healthDetails = procedure
     path: "/admin/external-sites/{site}/health",
     summary: "Get external site health",
     description:
-      "Get import status, recent runs, and bottle matching counts for one external site. Includes reviews awaiting publication. Requires administrator privileges.",
+      "Get import status, recent runs, catalog listing counts, and bottle matching counts for one external site. Includes reviews awaiting publication. Requires administrator privileges.",
     operationId: "retrieveExternalSiteHealth",
   })
   .input(z.object({ site: ExternalSiteKeySchema }))

--- a/apps/server/src/schemas/externalSites.ts
+++ b/apps/server/src/schemas/externalSites.ts
@@ -89,6 +89,9 @@ export const ExternalSiteScrapeTargetSchema = z.object({
 });
 
 export const ExternalSiteHealthSchema = ExternalSiteSchema.extend({
+  catalogListings: z.object({
+    total: z.number().int().min(0),
+  }),
   externalReviews: ExternalSiteItemCoverageSchema,
   priceListings: ExternalSiteItemCoverageSchema,
   latestRun: ExternalSiteRunSchema.nullable(),

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
@@ -8,6 +8,7 @@ import { AdminButton as Button } from "@peated/web/components/admin/adminButton.
 import {
   AdminActions,
   AdminBreadcrumbs,
+  AdminMetadataList,
   AdminPage,
   AdminPageHeader,
   AdminStat,
@@ -128,7 +129,16 @@ export default function Layout({
         <AdminStat
           label="Catalog products"
           value={catalogCoverage.total.toLocaleString("en-US")}
-          detail={`${catalogCoverage.withProductId.toLocaleString("en-US")} with product IDs · ${catalogCoverage.withImage.toLocaleString("en-US")} with images · ${catalogCoverage.withVolume.toLocaleString("en-US")} with volume · ${catalogCoverage.withBottleDetails.toLocaleString("en-US")} with bottle details`}
+          detail={
+            <AdminMetadataList
+              items={[
+                `${catalogCoverage.withProductId.toLocaleString("en-US")} with product IDs`,
+                `${catalogCoverage.withImage.toLocaleString("en-US")} with images`,
+                `${catalogCoverage.withVolume.toLocaleString("en-US")} with volume`,
+                `${catalogCoverage.withBottleDetails.toLocaleString("en-US")} with bottle details`,
+              ]}
+            />
+          }
         />
       </AdminStatGrid>
       <PageTabs

--- a/apps/web/src/app/(admin)/admin/(default)/sites/loading.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/loading.tsx
@@ -6,6 +6,7 @@ export default function Loading() {
       columns={4}
       label="Loading scrapers"
       title="Scrapers"
+      withSearch
     />
   );
 }

--- a/apps/web/src/app/(admin)/admin/(default)/sites/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/page.tsx
@@ -9,12 +9,17 @@ import {
 import { AdminTable as Table } from "@peated/web/components/admin/adminTable.stylex";
 import { AdminEmptyActivity as EmptyActivity } from "@peated/web/components/admin/adminUtility.stylex";
 import { ExternalSiteIdentity } from "@peated/web/components/admin/externalSiteIcon.stylex";
-import ExternalSiteRunStatus from "@peated/web/components/admin/externalSiteRunStatus";
 import ScraperCatalogCoverage from "@peated/web/components/admin/scraperCatalogCoverage";
-import TimeSince from "@peated/web/components/timeSince";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQueries } from "@tanstack/react-query";
+
+import { foundationStyles } from "../../../../../styles/foundations.stylex";
+import {
+  ScraperRecordCount,
+  ScraperRunSummary,
+} from "./scraperIndexCell.stylex";
 
 export default function Page() {
   const queryParams = useApiQueryParams({
@@ -38,6 +43,7 @@ export default function Page() {
     <AdminPage>
       <AdminPageHeader
         title="Scrapers"
+        description="Check what each source has saved and what needs attention."
         actions={
           <AdminActions>
             <Button href="/admin/sites/add" variant="accent">
@@ -57,6 +63,8 @@ export default function Page() {
           columns={[
             {
               name: "name",
+              fill: true,
+              showOnMobile: true,
               sort: "name",
               sortDefaultOrder: "asc",
               value: (site) => (
@@ -64,33 +72,55 @@ export default function Page() {
                   imageUrl={site.imageUrl}
                   name={site.name}
                   size="sm"
+                >
+                  <span {...stylex.props(foundationStyles.compactRowTitle)}>
+                    {site.name}
+                  </span>
+                </ExternalSiteIdentity>
+              ),
+            },
+            {
+              align: "left",
+              name: "catalogListings",
+              showOnMobile: true,
+              title: "Catalog",
+              value: (site) => (
+                <ScraperRecordCount total={site.catalogListings.total} />
+              ),
+            },
+            {
+              align: "left",
+              name: "externalReviews",
+              showOnMobile: true,
+              title: "Reviews",
+              value: (site) => (
+                <ScraperRecordCount
+                  total={site.externalReviews.total}
+                  unmatched={site.externalReviews.unmatched}
                 />
               ),
             },
             {
-              name: "inventory",
-              title: "Inventory",
-              value: (site) =>
-                `${site.externalReviews.matched.toLocaleString("en-US")} / ${site.externalReviews.total.toLocaleString("en-US")} reviews · ${site.priceListings.matched.toLocaleString("en-US")} / ${site.priceListings.total.toLocaleString("en-US")} prices`,
+              align: "left",
+              name: "priceListings",
+              showOnMobile: true,
+              title: "Prices",
+              value: (site) => (
+                <ScraperRecordCount
+                  total={site.priceListings.total}
+                  unmatched={site.priceListings.unmatched}
+                />
+              ),
             },
             {
-              name: "status",
-              title: "Status",
-              value: (site) => <ExternalSiteRunStatus site={site} />,
-            },
-            {
-              name: "nextRunAt",
-              title: "Next Run",
-              value: (site) =>
-                site.nextRunAt ? (
-                  <TimeSince date={site.nextRunAt} />
-                ) : site.runEvery === null ? (
-                  "Manual only"
-                ) : (
-                  "Due now"
-                ),
+              align: "left",
+              name: "run",
+              showOnMobile: true,
+              title: "Run",
+              value: (site) => <ScraperRunSummary site={site} />,
             },
           ]}
+          withSearch
         />
       ) : (
         <EmptyActivity>No scrapers are configured.</EmptyActivity>

--- a/apps/web/src/app/(admin)/admin/(default)/sites/scraperIndexCell.stylex.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/scraperIndexCell.stylex.tsx
@@ -1,0 +1,106 @@
+import type { Outputs } from "@peated/server/orpc/router";
+import ExternalSiteRunStatus from "@peated/web/components/admin/externalSiteRunStatus";
+import TimeSince from "@peated/web/components/timeSince";
+import * as stylex from "@stylexjs/stylex";
+
+import { foundationStyles } from "../../../../../styles/foundations.stylex";
+import { colors, space } from "../../../../../styles/tokens.stylex";
+
+type Site = Outputs["externalSites"]["healthList"]["results"][number];
+
+function formatCount(value: number) {
+  return value.toLocaleString("en-US");
+}
+
+/** Shows a saved record count and the matching work that remains. */
+export function ScraperRecordCount({
+  total,
+  unmatched,
+}: {
+  total: number;
+  unmatched?: number;
+}) {
+  const detail =
+    total === 0 || unmatched === undefined
+      ? null
+      : unmatched === 0
+        ? "All matched"
+        : `${formatCount(unmatched)} ${unmatched === 1 ? "needs" : "need"} matching`;
+
+  return (
+    <span {...stylex.props(styles.stack)}>
+      <strong
+        {...stylex.props(
+          foundationStyles.compactRowTitle,
+          styles.tabularNumber,
+        )}
+      >
+        {total === 0 ? (
+          <>
+            <span aria-hidden="true">—</span>
+            <span {...stylex.props(styles.visuallyHidden)}>None saved</span>
+          </>
+        ) : (
+          formatCount(total)
+        )}
+      </strong>
+      {detail ? (
+        <span
+          {...stylex.props(
+            foundationStyles.metadata,
+            styles.detail,
+            unmatched !== undefined && unmatched > 0 && styles.needsAttention,
+          )}
+        >
+          {detail}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/** Keeps the latest result and the next scheduled run together. */
+export function ScraperRunSummary({ site }: { site: Site }) {
+  return (
+    <span {...stylex.props(styles.stack, styles.run)}>
+      <ExternalSiteRunStatus site={site} />
+      <span {...stylex.props(foundationStyles.metadata, styles.detail)}>
+        {site.nextRunAt ? (
+          <>
+            Next <TimeSince date={site.nextRunAt} />
+          </>
+        ) : site.runEvery === null ? (
+          "Manual only"
+        ) : (
+          "Due now"
+        )}
+      </span>
+    </span>
+  );
+}
+
+const styles = stylex.create({
+  stack: {
+    display: "inline-flex",
+    minWidth: 0,
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: space.x1,
+    textAlign: "left",
+  },
+  run: { minWidth: "180px", whiteSpace: "nowrap" },
+  tabularNumber: { fontVariantNumeric: "tabular-nums" },
+  detail: { color: colors.inkMuted, whiteSpace: "nowrap" },
+  needsAttention: { color: colors.accentDeep, fontWeight: 600 },
+  visuallyHidden: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    margin: "-1px",
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+  },
+});

--- a/apps/web/src/app/(admin)/admin/(default)/sites/scraperIndexCell.test.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/scraperIndexCell.test.tsx
@@ -1,0 +1,30 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ScraperRecordCount } from "./scraperIndexCell.stylex";
+
+describe("ScraperRecordCount", () => {
+  it("keeps an empty record count quiet and accessible", () => {
+    const html = renderToStaticMarkup(<ScraperRecordCount total={0} />);
+
+    expect(html).toContain('aria-hidden="true">—');
+    expect(html).toContain("None saved");
+  });
+
+  it("shows outstanding matching work", () => {
+    const html = renderToStaticMarkup(
+      <ScraperRecordCount total={526} unmatched={199} />,
+    );
+
+    expect(html).toContain("526");
+    expect(html).toContain("199 need matching");
+  });
+
+  it("confirms when every saved record is matched", () => {
+    const html = renderToStaticMarkup(
+      <ScraperRecordCount total={10} unmatched={0} />,
+    );
+
+    expect(html).toContain("All matched");
+  });
+});

--- a/apps/web/src/components/admin/adminContent.stylex.tsx
+++ b/apps/web/src/components/admin/adminContent.stylex.tsx
@@ -329,16 +329,40 @@ export function AdminStat({
   );
 }
 
+/** Shows short metadata values with consistently spaced separators. */
+export function AdminMetadataList({ items }: { items: readonly ReactNode[] }) {
+  return (
+    <span {...stylex.props(foundationStyles.metadata, styles.metadataList)}>
+      {items.map((item, index) => (
+        <span key={index} {...stylex.props(styles.metadataListItem)}>
+          {index > 0 ? (
+            <span
+              aria-hidden="true"
+              {...stylex.props(styles.metadataSeparator)}
+            >
+              ·
+            </span>
+          ) : null}
+          {item}
+        </span>
+      ))}
+    </span>
+  );
+}
+
 /** Shows a compact status whose text carries the meaning and tone adds emphasis. */
 export function AdminStatus({
   children,
+  title,
   tone = "neutral",
 }: {
   children: ReactNode;
+  title?: string;
   tone?: "accent" | "danger" | "neutral" | "success" | "warning";
 }) {
   return (
     <span
+      title={title}
       {...stylex.props(
         foundationStyles.metadata,
         styles.status,
@@ -569,6 +593,13 @@ const styles = stylex.create({
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
+  },
+  metadataList: { display: "inline" },
+  metadataListItem: { display: "inline-block", whiteSpace: "nowrap" },
+  metadataSeparator: {
+    display: "inline-block",
+    marginRight: space.x2,
+    marginLeft: space.x2,
   },
   status: {
     display: "inline-flex",

--- a/apps/web/src/components/admin/adminMetadataList.stories.tsx
+++ b/apps/web/src/components/admin/adminMetadataList.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { StoryCanvas } from "../storyFixtures.stylex";
+import { AdminMetadataList } from "./adminContent.stylex";
+
+const meta = {
+  title: "Admin/Metadata List",
+  component: AdminMetadataList,
+  args: {
+    items: ["78% described", "48% pictured", "26% with reviews"],
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas>
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta<typeof AdminMetadataList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {};

--- a/apps/web/src/components/admin/adminStatus.stories.tsx
+++ b/apps/web/src/components/admin/adminStatus.stories.tsx
@@ -26,7 +26,12 @@ export const Overview: Story = {
       <AdminStatus tone="accent">In progress</AdminStatus>
       <AdminStatus tone="success">Active</AdminStatus>
       <AdminStatus tone="warning">Needs review</AdminStatus>
-      <AdminStatus tone="danger">Failed</AdminStatus>
+      <AdminStatus
+        title="Failed Sep 9, 2026, 1:14 PM PDT. Last succeeded Sep 8, 2026, 11:03 PM PDT."
+        tone="danger"
+      >
+        Failed
+      </AdminStatus>
     </StoryRow>
   ),
 };

--- a/apps/web/src/components/admin/externalSiteRunStatus.tsx
+++ b/apps/web/src/components/admin/externalSiteRunStatus.tsx
@@ -1,18 +1,18 @@
+"use client";
+
 import { type ExternalSiteHealthSchema } from "@peated/server/schemas";
-import TimeSince from "@peated/web/components/timeSince";
+import {
+  formatTimestamp,
+  useViewerTimeZone,
+} from "@peated/web/components/timestamp";
 import { type z } from "zod";
 
 import { AdminStatus } from "./adminContent.stylex";
 
 type SiteHealth = z.infer<typeof ExternalSiteHealthSchema>;
 
-export default function ExternalSiteRunStatus({
-  site,
-  compact = false,
-}: {
-  site: SiteHealth;
-  compact?: boolean;
-}) {
+export default function ExternalSiteRunStatus({ site }: { site: SiteHealth }) {
+  const timeZone = useViewerTimeZone();
   const run = site.latestRun;
   const status = run?.status ?? "never";
   const labels = {
@@ -35,22 +35,24 @@ export default function ExternalSiteRunStatus({
       : run?.status === "running"
         ? run.startedAt
         : run?.completedAt;
+  const timingLabel = {
+    never: "No runs have been recorded.",
+    queued: "Queued",
+    running: "Started",
+    succeeded: "Succeeded",
+    failed: "Failed",
+  } as const;
+  const title = timestamp
+    ? `${timingLabel[status]} ${formatTimestamp(timestamp, "dateTime", timeZone)}.${
+        status === "failed" && site.lastSucceededAt
+          ? ` Last succeeded ${formatTimestamp(site.lastSucceededAt, "dateTime", timeZone)}.`
+          : ""
+      }`
+    : timingLabel[status];
 
   return (
-    <AdminStatus tone={tones[status]}>
+    <AdminStatus title={title} tone={tones[status]}>
       {labels[status]}
-      {timestamp ? (
-        <>
-          {" "}
-          · <TimeSince date={timestamp} />
-        </>
-      ) : null}
-      {!compact && status === "failed" && site.lastSucceededAt ? (
-        <>
-          {" "}
-          · last succeeded <TimeSince date={site.lastSucceededAt} />
-        </>
-      ) : null}
     </AdminStatus>
   );
 }

--- a/apps/web/src/components/admin/scraperCatalogCoverage.tsx
+++ b/apps/web/src/components/admin/scraperCatalogCoverage.tsx
@@ -1,6 +1,11 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
-import { AdminSection, AdminStat, AdminStatGrid } from "./adminContent.stylex";
+import {
+  AdminMetadataList,
+  AdminSection,
+  AdminStat,
+  AdminStatGrid,
+} from "./adminContent.stylex";
 
 type Coverage = Outputs["admin"]["catalogCoverage"];
 
@@ -19,17 +24,40 @@ export default function ScraperCatalogCoverage({
         <AdminStat
           label="Active bottles"
           value={coverage.bottles.total.toLocaleString("en-US")}
-          detail={`${percentage(coverage.bottles.withDescription, coverage.bottles.total)} described · ${percentage(coverage.bottles.withImage, coverage.bottles.total)} pictured · ${percentage(coverage.bottles.withReviews, coverage.bottles.total)} with reviews · ${percentage(coverage.bottles.withPriceListings, coverage.bottles.total)} with prices`}
+          detail={
+            <AdminMetadataList
+              items={[
+                `${percentage(coverage.bottles.withDescription, coverage.bottles.total)} described`,
+                `${percentage(coverage.bottles.withImage, coverage.bottles.total)} pictured`,
+                `${percentage(coverage.bottles.withReviews, coverage.bottles.total)} with reviews`,
+                `${percentage(coverage.bottles.withPriceListings, coverage.bottles.total)} with prices`,
+              ]}
+            />
+          }
         />
         <AdminStat
           label="Visible reviews"
           value={coverage.externalReviews.total.toLocaleString("en-US")}
-          detail={`${coverage.externalReviews.matched.toLocaleString("en-US")} matched · ${coverage.externalReviews.unmatched.toLocaleString("en-US")} unmatched`}
+          detail={
+            <AdminMetadataList
+              items={[
+                `${coverage.externalReviews.matched.toLocaleString("en-US")} matched`,
+                `${coverage.externalReviews.unmatched.toLocaleString("en-US")} unmatched`,
+              ]}
+            />
+          }
         />
         <AdminStat
           label="Visible prices"
           value={coverage.priceListings.total.toLocaleString("en-US")}
-          detail={`${coverage.priceListings.matched.toLocaleString("en-US")} matched · ${coverage.priceListings.unmatched.toLocaleString("en-US")} unmatched`}
+          detail={
+            <AdminMetadataList
+              items={[
+                `${coverage.priceListings.matched.toLocaleString("en-US")} matched`,
+                `${coverage.priceListings.unmatched.toLocaleString("en-US")} unmatched`,
+              ]}
+            />
+          }
         />
       </AdminStatGrid>
     </AdminSection>

--- a/apps/web/src/components/admin/scraperObservability.test.tsx
+++ b/apps/web/src/components/admin/scraperObservability.test.tsx
@@ -25,6 +25,7 @@ const site = {
   lastRunAt: null,
   nextRunAt: null,
   runEvery: 1_440,
+  catalogListings: { total: 0 },
   externalReviews: { total: 12, matched: 10, unmatched: 2 },
   priceListings: { total: 0, matched: 0, unmatched: 0 },
   latestRun: null,
@@ -114,7 +115,29 @@ describe("scraper observability", () => {
       <ExternalSiteRunStatus site={manualOnlySite} />,
     );
     expect(html).toContain("Never recorded");
+    expect(html).toContain('title="No runs have been recorded."');
     expect(html).not.toContain("Disabled");
+  });
+
+  it("keeps run timing in a tooltip", () => {
+    const html = renderToStaticMarkup(
+      <ExternalSiteRunStatus
+        site={{
+          ...site,
+          latestRun: {
+            ...run,
+            status: "failed",
+            completedAt: timestamp,
+          },
+          lastSucceededAt: "2026-08-17T12:00:00.000Z",
+        }}
+      />,
+    );
+
+    expect(html).toContain(">Failed</span>");
+    expect(html).toContain('title="Failed Aug 18, 2026');
+    expect(html).toContain("Last succeeded Aug 17, 2026");
+    expect(html).not.toContain("<time");
   });
 
   it("shows review publishing with matched coverage", () => {
@@ -189,6 +212,7 @@ describe("scraper observability", () => {
     );
 
     expect(html).toContain("50% described");
+    expect(html).toContain('aria-hidden="true"');
     expect(html).toContain("30 matched");
     expect(html).toContain("180 matched");
   });


### PR DESCRIPTION
The scraper index now separates catalog, review, and price inventory so operators can see what each source has saved and what still needs matching. Empty counts stay quiet, matching work is called out beneath nonzero totals, search is available on the table, and the run column keeps its schedule while reducing the badge to a simple status with exact timing in a tooltip.

External-site health responses now include catalog listing totals, with schema and route coverage. A shared metadata-list treatment also gives middle-dot separators equal spacing in the catalog coverage widgets and source details.
