### PR TITLE
feat(web): explain the whisky catalog

### DIFF
--- a/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
@@ -17,6 +17,7 @@ const groups = [
   {
     label: "Reference",
     links: [
+      { href: "/about/catalog", label: "Catalog guide" },
       { href: "/about/categories", label: "Whisky categories" },
       { href: "/about/tasting-wheel", label: "Tasting wheel" },
       { href: "/about/ratings", label: "Rating guide" },

--- a/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
@@ -19,10 +19,11 @@ const STEPS_STACKED = "@media (max-width: 899px)";
 
 const aboutTabs = [
   { href: "/about", label: "About" },
-  { href: "/about/api", label: "API" },
+  { href: "/about/catalog", label: "Catalog" },
   { href: "/about/categories", label: "Whisky categories" },
   { href: "/about/tasting-wheel", label: "Tasting wheel" },
   { href: "/about/ratings", label: "Rating guide" },
+  { href: "/about/api", label: "API" },
   { href: "/updates", label: "Recent changes" },
 ] as const;
 

--- a/apps/web/src/app/(app)/about/catalog/catalogGuide.stylex.tsx
+++ b/apps/web/src/app/(app)/about/catalog/catalogGuide.stylex.tsx
@@ -1,0 +1,586 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { foundationStyles } from "../../../../styles/foundations.stylex";
+import {
+  colors,
+  controlMetrics,
+  space,
+} from "../../../../styles/tokens.stylex";
+
+const STACKED = "@media (max-width: 699px)";
+
+const recordParts = [
+  {
+    description: "The stable product name and the exact release people mean.",
+    fields: "Name · edition · Peated ID",
+    title: "Identity",
+  },
+  {
+    description:
+      "Links to the other catalog records that put the whisky in context.",
+    fields: "Brand · distillery · bottler · series",
+    title: "Connections",
+  },
+  {
+    description:
+      "Facts printed on the bottle or supported by another reliable source.",
+    fields: "Category · age · ABV · natural color · filtration",
+    title: "Label facts",
+  },
+  {
+    description:
+      "Separate dates keep the whisky's production and sale history clear.",
+    fields: "Distilled · bottled · released",
+    title: "Dates",
+  },
+  {
+    description:
+      "Details that distinguish a particular cask, batch, or limited release.",
+    fields: "Maturation · cask number · outturn",
+    title: "Release details",
+  },
+  {
+    description:
+      "The useful context added by sources and the people who drank it.",
+    fields: "Image · description · ratings · tastings",
+    title: "Public record",
+  },
+] as const;
+
+function MapNode({
+  body,
+  label,
+  placement,
+  title,
+}: {
+  body: string;
+  label: string;
+  placement: stylex.StyleXStyles;
+  title: string;
+}) {
+  return (
+    <div {...stylex.props(styles.mapNode, placement)}>
+      <div {...stylex.props(foundationStyles.metadata, styles.mapLabel)}>
+        {label}
+      </div>
+      <h3 {...stylex.props(foundationStyles.rowTitle, styles.mapNodeTitle)}>
+        {title}
+      </h3>
+      <p {...stylex.props(foundationStyles.metadata, styles.mapNodeBody)}>
+        {body}
+      </p>
+    </div>
+  );
+}
+
+/** Shows the catalog relationships that give one Bottle its public context. */
+export function CatalogRecordMap() {
+  return (
+    <figure {...stylex.props(styles.mapFigure)}>
+      <figcaption {...stylex.props(foundationStyles.prose, styles.mapCaption)}>
+        A bottle sits at the center. The records around it explain how it was
+        sold, who made it, and where it belongs.
+      </figcaption>
+      <div {...stylex.props(styles.map)}>
+        <svg
+          aria-hidden="true"
+          preserveAspectRatio="none"
+          viewBox="0 0 1000 500"
+          {...stylex.props(styles.mapLines)}
+        >
+          <path d="M245 95 L430 210" vectorEffect="non-scaling-stroke" />
+          <path d="M755 95 L570 210" vectorEffect="non-scaling-stroke" />
+          <path d="M245 405 L430 290" vectorEffect="non-scaling-stroke" />
+          <path d="M755 405 L570 290" vectorEffect="non-scaling-stroke" />
+        </svg>
+
+        <div {...stylex.props(styles.bottleNode)}>
+          <div
+            {...stylex.props(foundationStyles.metadata, styles.bottleNodeLabel)}
+          >
+            The catalog entry
+          </div>
+          <h3
+            {...stylex.props(
+              foundationStyles.sectionHeading,
+              styles.bottleNodeTitle,
+            )}
+          >
+            Bottle
+          </h3>
+          <p {...stylex.props(foundationStyles.body, styles.bottleNodeBody)}>
+            One marketed whisky release
+          </p>
+          <p
+            {...stylex.props(foundationStyles.metadata, styles.bottleNodeMeta)}
+          >
+            Ratings, tastings, library entries, and corrections belong here
+          </p>
+        </div>
+
+        <MapNode
+          body="The name the bottle is sold under."
+          label="Sold as"
+          placement={styles.brandNode}
+          title="Brand"
+        />
+        <MapNode
+          body="A named range, when the whisky belongs to one."
+          label="Part of"
+          placement={styles.seriesNode}
+          title="Series"
+        />
+        <MapNode
+          body="The producer or producers that made the whisky."
+          label="Made at"
+          placement={styles.distilleryNode}
+          title="Distillery"
+        />
+        <MapNode
+          body="The independent business that selected and released it, when there is one."
+          label="Released by"
+          placement={styles.bottlerNode}
+          title="Bottler"
+        />
+      </div>
+    </figure>
+  );
+}
+
+/** Groups Bottle facts by the question each group answers. */
+export function BottleRecordAnatomy() {
+  return (
+    <ul {...stylex.props(styles.recordList)}>
+      {recordParts.map((part) => (
+        <li key={part.title} {...stylex.props(styles.recordRow)}>
+          <h3 {...stylex.props(foundationStyles.compactRowTitle)}>
+            {part.title}
+          </h3>
+          <div
+            {...stylex.props(foundationStyles.metadata, styles.recordFields)}
+          >
+            {part.fields}
+          </div>
+          <p {...stylex.props(foundationStyles.body, styles.recordDescription)}>
+            {part.description}
+          </p>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function DecisionList({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <div {...stylex.props(styles.decisionColumn)}>
+      <h3 {...stylex.props(foundationStyles.rowTitle)}>{title}</h3>
+      <ul {...stylex.props(foundationStyles.body, styles.decisionList)}>
+        {children}
+      </ul>
+    </div>
+  );
+}
+
+/** Contrasts release changes that do and do not create a new Bottle record. */
+export function BottleIdentityDecision() {
+  return (
+    <div {...stylex.props(styles.decisionFrame)}>
+      <DecisionList title="A separate bottle record">
+        <li>A named edition or marketed batch</li>
+        <li>An annual or vintage release</li>
+        <li>A separately marketed single cask</li>
+      </DecisionList>
+      <DecisionList title="The same bottle record">
+        <li>Another bottle size</li>
+        <li>A gift box or export carton</li>
+        <li>Retailer wording or a newer photo</li>
+      </DecisionList>
+    </div>
+  );
+}
+
+function RelationshipExample({
+  bridge,
+  description,
+  left,
+  right,
+  title,
+}: {
+  bridge: string;
+  description: string;
+  left: string;
+  right: string;
+  title: string;
+}) {
+  return (
+    <article {...stylex.props(styles.relationshipExample)}>
+      <h3 {...stylex.props(foundationStyles.rowTitle)}>{title}</h3>
+      <div {...stylex.props(styles.relationshipFlow)}>
+        <div {...stylex.props(foundationStyles.fieldLabel, styles.flowNode)}>
+          {left}
+        </div>
+        <div {...stylex.props(foundationStyles.metadata, styles.flowBridge)}>
+          {bridge}
+        </div>
+        <div {...stylex.props(foundationStyles.fieldLabel, styles.flowNode)}>
+          {right}
+        </div>
+      </div>
+      <p {...stylex.props(foundationStyles.body, styles.relationshipBody)}>
+        {description}
+      </p>
+    </article>
+  );
+}
+
+/** Explains the difference between releases of one product and a wider Series. */
+export function BottleRelationships() {
+  return (
+    <div {...stylex.props(styles.relationshipGrid)}>
+      <RelationshipExample
+        bridge="same product"
+        description="Springbank 12 Cask Strength Batch 23 and Batch 24 are distinct releases of the same product. Shared facts can stay connected without treating the batches as one bottle."
+        left="Batch 23"
+        right="Batch 24"
+        title="Related releases"
+      />
+      <RelationshipExample
+        bridge="same series"
+        description="Octomore 13.1 and 13.3 are different products in one wider range. A series provides context; it does not make its bottles the same whisky."
+        left="Octomore 13.1"
+        right="Octomore 13.3"
+        title="One series"
+      />
+    </div>
+  );
+}
+
+const certaintyStates = [
+  {
+    body: "A reliable source states a 12-year age.",
+    label: "Known",
+    value: "12 years",
+  },
+  {
+    body: "The label was checked and has no age statement.",
+    label: "Confirmed",
+    value: "No age statement",
+  },
+  {
+    body: "Peated does not have reliable age evidence yet.",
+    label: "Unknown",
+    value: "Not recorded",
+  },
+] as const;
+
+/** Distinguishes a known value, a confirmed absence, and an unknown fact. */
+export function CatalogCertainty() {
+  return (
+    <ol {...stylex.props(styles.certaintyList)}>
+      {certaintyStates.map((state) => (
+        <li key={state.label} {...stylex.props(styles.certaintyItem)}>
+          <div
+            {...stylex.props(foundationStyles.metadata, styles.certaintyLabel)}
+          >
+            {state.label}
+          </div>
+          <div
+            {...stylex.props(foundationStyles.rowTitle, styles.certaintyValue)}
+          >
+            {state.value}
+          </div>
+          <p {...stylex.props(foundationStyles.body, styles.certaintyBody)}>
+            {state.body}
+          </p>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+const styles = stylex.create({
+  mapFigure: {
+    margin: 0,
+  },
+  mapCaption: {
+    maxWidth: "680px",
+    marginBottom: space.x4,
+    color: colors.inkMuted,
+  },
+  map: {
+    position: "relative",
+    display: "grid",
+    minHeight: "440px",
+    gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+    gridTemplateRows: "repeat(3, minmax(0, 1fr))",
+    gap: space.x4,
+    boxSizing: "border-box",
+    padding: space.x6,
+    overflow: "hidden",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: colors.sectionRule,
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.surface,
+    [STACKED]: {
+      display: "flex",
+      minHeight: 0,
+      flexDirection: "column",
+      gap: space.x2,
+      padding: space.x4,
+    },
+  },
+  mapLines: {
+    position: "absolute",
+    inset: 0,
+    width: "100%",
+    height: "100%",
+    color: colors.dataAccent,
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: "2px",
+    [STACKED]: {
+      display: "none",
+    },
+  },
+  mapNode: {
+    position: "relative",
+    zIndex: 1,
+    boxSizing: "border-box",
+    alignSelf: "center",
+    padding: space.x3,
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: colors.sectionRule,
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.ground,
+    [STACKED]: {
+      width: "100%",
+      alignSelf: "stretch",
+    },
+  },
+  mapLabel: {
+    color: colors.inkMuted,
+  },
+  mapNodeTitle: {
+    marginTop: space.x1,
+  },
+  mapNodeBody: {
+    margin: 0,
+    marginTop: space.x1,
+    color: colors.inkMuted,
+  },
+  brandNode: {
+    gridColumn: "1",
+    gridRow: "1",
+  },
+  seriesNode: {
+    gridColumn: "3",
+    gridRow: "1",
+  },
+  distilleryNode: {
+    gridColumn: "1",
+    gridRow: "3",
+  },
+  bottlerNode: {
+    gridColumn: "3",
+    gridRow: "3",
+  },
+  bottleNode: {
+    position: "relative",
+    zIndex: 2,
+    gridColumn: "2",
+    gridRow: "2",
+    alignSelf: "center",
+    boxSizing: "border-box",
+    padding: space.x4,
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: colors.accent,
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.accentTint,
+    textAlign: "center",
+    [STACKED]: {
+      order: -1,
+      width: "100%",
+      marginBottom: space.x2,
+    },
+  },
+  bottleNodeLabel: {
+    color: colors.accentDeep,
+  },
+  bottleNodeTitle: {
+    marginTop: space.x1,
+  },
+  bottleNodeBody: {
+    margin: 0,
+    marginTop: space.x1,
+    color: colors.ink,
+  },
+  bottleNodeMeta: {
+    margin: 0,
+    marginTop: space.x2,
+    color: colors.inkMuted,
+  },
+  recordList: {
+    margin: 0,
+    padding: 0,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.sectionRule,
+    listStyle: "none",
+  },
+  recordRow: {
+    display: "grid",
+    gridTemplateColumns: "140px minmax(220px, 0.8fr) minmax(0, 1fr)",
+    gap: space.x6,
+    alignItems: "baseline",
+    paddingTop: space.x4,
+    paddingBottom: space.x4,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.sectionRule,
+    [STACKED]: {
+      gridTemplateColumns: "minmax(0, 1fr)",
+      gap: space.x1,
+    },
+  },
+  recordFields: {
+    color: colors.accentDeep,
+  },
+  recordDescription: {
+    margin: 0,
+    color: colors.inkMuted,
+  },
+  decisionFrame: {
+    display: "grid",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    overflow: "hidden",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: colors.sectionRule,
+    borderRadius: controlMetrics.radius,
+    [STACKED]: {
+      gridTemplateColumns: "minmax(0, 1fr)",
+    },
+  },
+  decisionColumn: {
+    padding: space.x6,
+    backgroundColor: colors.surface,
+    ":first-child": {
+      borderRightWidth: "1px",
+      borderRightStyle: "solid",
+      borderRightColor: colors.sectionRule,
+    },
+    [STACKED]: {
+      padding: space.x4,
+      ":first-child": {
+        borderRightWidth: 0,
+        borderBottomWidth: "1px",
+        borderBottomStyle: "solid",
+        borderBottomColor: colors.sectionRule,
+      },
+    },
+  },
+  decisionList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space.x2,
+    margin: 0,
+    marginTop: space.x3,
+    paddingLeft: "20px",
+    color: colors.inkMuted,
+  },
+  relationshipGrid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    gap: space.x6,
+    [STACKED]: {
+      gridTemplateColumns: "minmax(0, 1fr)",
+    },
+  },
+  relationshipExample: {
+    paddingTop: space.x3,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.sectionRule,
+  },
+  relationshipFlow: {
+    display: "grid",
+    gridTemplateColumns: "minmax(0, 1fr) 72px minmax(0, 1fr)",
+    gap: space.x2,
+    alignItems: "center",
+    marginTop: space.x4,
+  },
+  flowNode: {
+    boxSizing: "border-box",
+    minWidth: 0,
+    padding: space.x3,
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: colors.sectionRule,
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.surface,
+    textAlign: "center",
+  },
+  flowBridge: {
+    color: colors.accentDeep,
+    textAlign: "center",
+  },
+  relationshipBody: {
+    margin: 0,
+    marginTop: space.x3,
+    color: colors.inkMuted,
+  },
+  certaintyList: {
+    display: "grid",
+    gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+    margin: 0,
+    padding: 0,
+    overflow: "hidden",
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: colors.sectionRule,
+    borderRadius: controlMetrics.radius,
+    listStyle: "none",
+    [STACKED]: {
+      gridTemplateColumns: "minmax(0, 1fr)",
+    },
+  },
+  certaintyItem: {
+    minWidth: 0,
+    padding: space.x4,
+    borderRightWidth: "1px",
+    borderRightStyle: "solid",
+    borderRightColor: colors.sectionRule,
+    ":last-child": {
+      borderRightWidth: 0,
+    },
+    [STACKED]: {
+      borderRightWidth: 0,
+      borderBottomWidth: "1px",
+      borderBottomStyle: "solid",
+      borderBottomColor: colors.sectionRule,
+      ":last-child": {
+        borderBottomWidth: 0,
+      },
+    },
+  },
+  certaintyLabel: {
+    color: colors.accentDeep,
+  },
+  certaintyValue: {
+    marginTop: space.x1,
+  },
+  certaintyBody: {
+    margin: 0,
+    marginTop: space.x2,
+    color: colors.inkMuted,
+  },
+});

--- a/apps/web/src/app/(app)/about/catalog/page.tsx
+++ b/apps/web/src/app/(app)/about/catalog/page.tsx
@@ -1,0 +1,130 @@
+import { RailList, RailListItem } from "@peated/web/components/lists.stylex";
+import {
+  PageSection,
+  RailSection,
+} from "@peated/web/components/pages/pageLayout.stylex";
+import type { Metadata } from "next";
+import {
+  AboutLink,
+  AboutPage,
+  AboutText,
+  AboutTextStack,
+} from "../aboutPage.stylex";
+import {
+  BottleIdentityDecision,
+  BottleRecordAnatomy,
+  BottleRelationships,
+  CatalogCertainty,
+  CatalogRecordMap,
+} from "./catalogGuide.stylex";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = {
+  title: "The Whisky Catalog",
+  description:
+    "How Peated records whisky releases, connects them to brands and producers, and handles uncertain facts.",
+};
+
+export default function CatalogGuidePage() {
+  return (
+    <AboutPage
+      currentHref="/about/catalog"
+      description="How Peated records each whisky release, connects it to the people and companies behind it, and keeps uncertain facts honest."
+      rail={
+        <>
+          <RailSection heading="Browse the catalog">
+            <RailList ariaLabel="Browse the Peated catalog">
+              <RailListItem href="/bottles" title="Bottles" />
+              <RailListItem href="/brands" title="Brands" />
+              <RailListItem href="/distillers" title="Distilleries" />
+              <RailListItem href="/bottlers" title="Bottlers" />
+            </RailList>
+          </RailSection>
+          <RailSection heading="Contribute">
+            <RailList ariaLabel="Contribute to the Peated catalog">
+              <RailListItem
+                href="/addBottle?intent=catalog"
+                metadata="Anything the catalog is missing"
+                title="Record a bottle"
+              />
+              <RailListItem
+                href="/bottles"
+                metadata="Open any bottle record"
+                title="Suggest a correction"
+              />
+            </RailList>
+          </RailSection>
+        </>
+      }
+      title="The whisky catalog"
+    >
+      <PageSection heading="A connected record">
+        <CatalogRecordMap />
+        <AboutText>
+          Brands, distilleries, bottlers, and companies each have their own
+          catalog record. One organization can fill more than one role; the
+          bottle's links explain the part it played.
+        </AboutText>
+      </PageSection>
+
+      <PageSection
+        heading="What a bottle record can tell you"
+        intro="Most bottles will not have every fact. Peated records what reliable evidence supports and leaves the rest open for a future correction."
+      >
+        <BottleRecordAnatomy />
+      </PageSection>
+
+      <PageSection heading="When is it a different bottle?">
+        <AboutTextStack>
+          <AboutText>
+            A new record represents a release the producer marketed separately.
+            A different package or shop listing does not create a new whisky by
+            itself.
+          </AboutText>
+          <BottleIdentityDecision />
+          <AboutText>
+            Peated only separates releases when a label or another reliable
+            source supports the difference.
+          </AboutText>
+        </AboutTextStack>
+      </PageSection>
+
+      <PageSection
+        heading="Two ways bottles relate"
+        intro="Related releases and a series answer different questions."
+      >
+        <BottleRelationships />
+      </PageSection>
+
+      <PageSection heading="A blank is not a no">
+        <AboutTextStack>
+          <AboutText>
+            Some facts have 3 honest states: known, confirmed absent, and not
+            yet known. Peated keeps those states separate instead of filling a
+            gap with a guess.
+          </AboutText>
+          <CatalogCertainty />
+        </AboutTextStack>
+      </PageSection>
+
+      <PageSection heading="Corrections keep the record intact">
+        <AboutTextStack>
+          <AboutText>
+            Every bottle and organization in the catalog, plus every series, has
+            a permanent Peated ID. When a record is corrected or a duplicate is
+            removed, Peated preserves its links, tastings, reviews, and history
+            rather than starting over.
+          </AboutText>
+          <AboutText>
+            Missing something?{" "}
+            <AboutLink href="/addBottle?intent=catalog">
+              Record a bottle
+            </AboutLink>
+            , or open an existing bottle and suggest a correction.
+          </AboutText>
+        </AboutTextStack>
+      </PageSection>
+    </AboutPage>
+  );
+}

--- a/apps/web/src/app/(app)/about/page.tsx
+++ b/apps/web/src/app/(app)/about/page.tsx
@@ -55,6 +55,10 @@ export default async function AboutRoute() {
           </RailSection>
           <RailSection heading="Reference">
             <RailList ariaLabel="Peated reference pages">
+              <RailListItem
+                href="/about/catalog"
+                title="How the catalog works"
+              />
               <RailListItem href="/updates" title="Recent changes" />
               <RailListItem href="/terms" title="Terms" />
             </RailList>

--- a/apps/web/src/app/sitemaps/static.xml/route.ts
+++ b/apps/web/src/app/sitemaps/static.xml/route.ts
@@ -14,6 +14,7 @@ export async function GET() {
     { url: "/bottlers" },
     { url: "/companies" },
     { url: "/about" },
+    { url: "/about/catalog" },
     { url: "/about/tasting-wheel" },
     { url: "/bot" },
     { url: "/bottlers/4263/codes" },

--- a/apps/web/src/components/siteFooter.stories.tsx
+++ b/apps/web/src/components/siteFooter.stories.tsx
@@ -15,6 +15,7 @@ const groups: SiteFooterProps["groups"] = [
   {
     label: "Reference",
     links: [
+      { href: "/about/catalog", label: "Catalog guide" },
       { href: "/about/categories", label: "Whisky categories" },
       { href: "/about/tasting-wheel", label: "Tasting wheel" },
       { href: "/about/ratings", label: "Rating guide" },


### PR DESCRIPTION
Adds a new `/about/catalog` guide that explains how Peated's public catalog fits together. It uses a connected-record diagram, a plain-language bottle anatomy, and concrete comparisons for separate releases, series membership, and unknown facts. The page also joins the About navigation, reference footer, About rail, and static sitemap.

The guide deliberately describes catalog concepts rather than API fields. Reviewers should focus on whether the brand, distillery, bottler, company, series, and related-release language matches how people understand the catalog while preserving Peated's identity rules.
