### PR TITLE
ref(scraper): isolate saved rule compatibility

### DIFF
--- a/apps/cli/src/commands/scrapers.test.ts
+++ b/apps/cli/src/commands/scrapers.test.ts
@@ -43,10 +43,10 @@ describe("parsePreviewInput", () => {
   test("accepts an explicit rules version for the runtime parser", () => {
     expect(
       parsePreviewInput({
-        rulesVersion: 2,
+        rulesVersion: 3,
         listUrl: "https://example.test/products",
         rules,
       }),
-    ).toMatchObject({ rulesVersion: 2, rules });
+    ).toMatchObject({ rulesVersion: 3, rules });
   });
 });

--- a/apps/server/src/schemas/scrapeSources.ts
+++ b/apps/server/src/schemas/scrapeSources.ts
@@ -7,7 +7,10 @@ import {
 } from "../scraper/configured/rules";
 import { ExternalSiteSchema } from "./externalSites";
 
-export { ScrapeRulesSchema } from "../scraper/configured/rules";
+export {
+  SCRAPE_RULES_VERSION,
+  ScrapeRulesSchema,
+} from "../scraper/configured/rules";
 
 export const ScrapeSourceUrlSchema = z
   .url()

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -95,6 +95,19 @@ or product links. `list.nextPage` can find the next page of links. Links must
 stay on the source website. Code reads at most five list pages and stops at
 `list.limit`. It reads `href` from HTML links and text from XML links.
 
+Each stored rule version has a decoder in `configured/compatibility/`. The
+decoder validates the saved JSON and returns the executable contract used by
+the runtime. Historical meaning, including review source keys, belongs to that
+version's decoder instead of being inferred from the JSON shape. Current rule
+generation uses the current schema directly. Source-specific URL behavior is
+registered in `configured/sourceCompatibility.ts`; generic parsing must not
+identify a source by name or host.
+
+Move a source to the current rule format by creating a new revision, previewing
+it, and activating it. Never change a saved revision's version or rules in
+place: completed runs keep their revision ID. Remove a compatibility decoder
+only after production has no active or runnable revisions that use it.
+
 Fields on an article or product page are CSS selectors too. Code reads text by
 default. It reads `href` from links, `src` from images, `datetime` from dates,
 `content` from meta tags, and `value` from form fields. It also trims spaces,
@@ -184,13 +197,13 @@ pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 
 ```
 
 The input has the same `listUrl` and `rules` fields accepted by the API. Set
-`rulesVersion` to `10` for new rules. An omitted version means version 1 so
+`rulesVersion` to `11` for new rules. An omitted version means version 1 so
 existing preview files keep their original behavior. If the site exists only
 in production, the command creates the local records needed for the preview:
 
 ```json
 {
-  "rulesVersion": 10,
+  "rulesVersion": 11,
   "listUrl": "https://example.com/reviews",
   "rules": {
     "kind": "review",

--- a/apps/server/src/scraper/configured/compatibility/contract.ts
+++ b/apps/server/src/scraper/configured/compatibility/contract.ts
@@ -1,0 +1,20 @@
+import type { JsonValue } from "@peated/server/scraper/types";
+import type { ScrapeDetailResult, ScrapeListResult } from "../parser";
+import type { ScrapeSourceKind, StoredScrapeRules } from "../rules";
+
+export type ExecutableScrapeRules = {
+  kind: ScrapeSourceKind;
+  storedRules: StoredScrapeRules;
+  limit: number;
+  listLinkField: string;
+  nextPageField: string;
+  parseList(html: string, pageUrl: URL): ScrapeListResult;
+  parseDetail(html: string, pageUrl: URL): ScrapeDetailResult;
+  withLimit(limit: number): ExecutableScrapeRules;
+};
+
+export type StoredScrapeRulesInput = StoredScrapeRules | JsonValue;
+
+export type ScrapeRulesDecoder = (
+  storedJson: StoredScrapeRulesInput,
+) => ExecutableScrapeRules;

--- a/apps/server/src/scraper/configured/compatibility/index.test.ts
+++ b/apps/server/src/scraper/configured/compatibility/index.test.ts
@@ -1,0 +1,273 @@
+import type { JsonValue } from "@peated/server/scraper/types";
+import { describe, expect, it } from "vitest";
+import { loadExecutableScrapeRules } from ".";
+
+const listHtml = '<a class="item" href="/detail">Detail</a>';
+const detailHtml = `
+  <h1>Example Whisky</h1>
+  <time datetime="2026-09-08"></time>
+  <article class="review"><h2>Example Whisky</h2><p>Smoke.</p></article>
+  <span class="price">£42.50</span>
+`;
+
+function earlyReviewRules(): JsonValue {
+  return {
+    kind: "review",
+    list: {
+      detailLink: { selector: "a.item", attribute: "href" },
+      maxItems: 20,
+    },
+    detail: {
+      title: { selector: "h1" },
+      publishedAt: { selector: "time", attribute: "datetime" },
+      reviewItem: "article.review",
+      name: { selector: "h2" },
+    },
+  };
+}
+
+function savedPriceRules(version: 6 | 7 | 8 | 9): JsonValue {
+  const read = (selector: string): JsonValue =>
+    version < 8
+      ? {
+          get: "text",
+          selector,
+          take: "first",
+          startsWith: null,
+          clean: null,
+        }
+      : {
+          get: "text",
+          selector,
+          take: "first",
+          match: null,
+          addStart: null,
+          addEnd: null,
+        };
+  const fixed: JsonValue =
+    version < 8
+      ? { get: "fixed", value: "700 ml", clean: null }
+      : { get: "fixed", value: "700 ml", addStart: null, addEnd: null };
+  return {
+    kind: "price",
+    products: {
+      oneProductPer: "body",
+      link: "a.item",
+      skipWhen: null,
+      nextPage: null,
+      limit: 20,
+    },
+    product: {
+      name: { try: [read("h1")] },
+      price: { try: [read(".price")] },
+      currency: "gbp",
+      volume: { try: [fixed] },
+      url: null,
+      externalProductId: null,
+      imageUrl: null,
+      barcode: null,
+    },
+  };
+}
+
+function directPriceRules(): JsonValue {
+  return {
+    kind: "price",
+    list: { links: "a.item", nextPage: null, limit: 20 },
+    detail: {
+      name: "h1",
+      price: ".price",
+      currency: "gbp",
+      volume: 700,
+      url: null,
+      id: null,
+      image: null,
+      barcode: null,
+    },
+  };
+}
+
+const fixtures: Array<[number, () => JsonValue]> = [
+  [1, earlyReviewRules],
+  [3, earlyReviewRules],
+  [6, () => savedPriceRules(6)],
+  [7, () => savedPriceRules(7)],
+  [8, () => savedPriceRules(8)],
+  [9, () => savedPriceRules(9)],
+  [10, directPriceRules],
+  [11, directPriceRules],
+];
+
+describe.each(fixtures)("saved rules version %i", (version, fixture) => {
+  it("decodes and executes its stored fixture", () => {
+    const rules = loadExecutableScrapeRules(version, fixture());
+
+    expect(rules.limit).toBe(20);
+    expect(
+      rules.parseList(listHtml, new URL("https://example.test/list")),
+    ).toMatchObject({
+      links: ["https://example.test/detail"],
+      issues: [],
+    });
+
+    const detail = rules.parseDetail(
+      detailHtml,
+      new URL("https://example.test/detail"),
+    );
+    expect(detail.issues).toEqual([]);
+    expect(detail.value).toBeTruthy();
+  });
+
+  it("owns its list limit", () => {
+    const rules = loadExecutableScrapeRules(version, fixture()).withLimit(3);
+
+    expect(rules.limit).toBe(3);
+    expect(loadExecutableScrapeRules(version, rules.storedRules).limit).toBe(3);
+  });
+});
+
+it("keeps positional review keys in version 6", () => {
+  const result = loadExecutableScrapeRules(6, {
+    kind: "review",
+    articles: {
+      oneArticlePer: "body",
+      link: "a.item",
+      skipWhen: null,
+      nextPage: null,
+      limit: 20,
+    },
+    article: {
+      canonicalUrl: null,
+      title: {
+        try: [
+          {
+            get: "text",
+            selector: "h1",
+            take: "first",
+            startsWith: null,
+            clean: null,
+          },
+        ],
+      },
+      publishedDate: {
+        try: [
+          {
+            get: "attribute",
+            selector: "time",
+            attribute: "datetime",
+            clean: null,
+          },
+        ],
+      },
+      reviews: {
+        inside: "body",
+        oneReviewPer: "element",
+        selector: "article.review",
+        name: {
+          try: [
+            {
+              get: "text",
+              from: "review",
+              selector: "h2",
+              take: "first",
+              startsWith: null,
+              clean: null,
+            },
+          ],
+        },
+        reviewer: null,
+        tastingNotes: null,
+        score: null,
+      },
+    },
+  }).parseDetail(detailHtml, new URL("https://example.test/detail"));
+  if (result.kind !== "review" || !result.value) {
+    throw new Error("Expected a parsed review.");
+  }
+
+  expect(result.value.article.externalReviews[0]?.sourceKey).toBe(
+    "https://example.test/detail#review-1",
+  );
+});
+
+it("uses name-and-writer review keys in version 9", () => {
+  const savedReviewRules = {
+    kind: "review",
+    articles: {
+      document: "html",
+      oneArticlePer: "body",
+      link: "a.item",
+      skipWhen: null,
+      nextPage: null,
+      limit: 20,
+    },
+    article: {
+      canonicalUrl: null,
+      title: {
+        try: [
+          {
+            get: "text",
+            selector: "h1",
+            take: "first",
+            match: null,
+            addStart: null,
+            addEnd: null,
+          },
+        ],
+      },
+      publishedDate: {
+        try: [
+          {
+            get: "attribute",
+            selector: "time",
+            attribute: "datetime",
+            match: null,
+            addStart: null,
+            addEnd: null,
+          },
+        ],
+      },
+      reviews: {
+        inside: "body",
+        oneReviewPer: "element",
+        selector: "article.review",
+        contains: null,
+        name: {
+          try: [
+            {
+              get: "text",
+              from: "review",
+              selector: "h2",
+              take: "first",
+              match: null,
+              addStart: null,
+              addEnd: null,
+            },
+          ],
+        },
+        reviewer: null,
+        tastingNotes: null,
+        score: null,
+      },
+    },
+  } satisfies JsonValue;
+  const result = loadExecutableScrapeRules(9, savedReviewRules).parseDetail(
+    detailHtml,
+    new URL("https://example.test/detail"),
+  );
+  if (result.kind !== "review" || !result.value) {
+    throw new Error("Expected a parsed review.");
+  }
+
+  expect(result.value.article.externalReviews[0]?.sourceKey).toMatch(
+    /^review:[a-f0-9]{64}$/u,
+  );
+});
+
+it("rejects versions without a registered compatibility module", () => {
+  for (const version of [2, 4, 5, 12]) {
+    expect(() =>
+      loadExecutableScrapeRules(version, directPriceRules()),
+    ).toThrow(`Unsupported scrape rules version: ${version}.`);
+  }
+});

--- a/apps/server/src/scraper/configured/compatibility/index.ts
+++ b/apps/server/src/scraper/configured/compatibility/index.ts
@@ -1,0 +1,35 @@
+import type { JsonValue } from "@peated/server/scraper/types";
+import type { ScrapeRulesDecoder } from "./contract";
+import { decodeRulesVersion1 } from "./version1";
+import { decodeRulesVersion10 } from "./version10";
+import { decodeRulesVersion11 } from "./version11";
+import { decodeRulesVersion3 } from "./version3";
+import { decodeRulesVersion6 } from "./version6";
+import { decodeRulesVersion7 } from "./version7";
+import { decodeRulesVersion8 } from "./version8";
+import { decodeRulesVersion9 } from "./version9";
+
+const DECODERS = new Map<number, ScrapeRulesDecoder>([
+  [1, decodeRulesVersion1],
+  [3, decodeRulesVersion3],
+  [6, decodeRulesVersion6],
+  [7, decodeRulesVersion7],
+  [8, decodeRulesVersion8],
+  [9, decodeRulesVersion9],
+  [10, decodeRulesVersion10],
+  [11, decodeRulesVersion11],
+]);
+
+/** Decodes saved JSON and binds it to the parsing behavior for that version. */
+export function loadExecutableScrapeRules(
+  rulesVersion: number,
+  storedJson: JsonValue,
+) {
+  const decode = DECODERS.get(rulesVersion);
+  if (!decode) {
+    throw new Error(`Unsupported scrape rules version: ${rulesVersion}.`);
+  }
+  return decode(storedJson);
+}
+
+export type { ExecutableScrapeRules } from "./contract";

--- a/apps/server/src/scraper/configured/compatibility/interpreters.ts
+++ b/apps/server/src/scraper/configured/compatibility/interpreters.ts
@@ -1,0 +1,115 @@
+import {
+  parseDirectScrapeDetail,
+  parseDirectScrapeList,
+  parseEarlyScrapeDetail,
+  parseEarlyScrapeList,
+  parseSavedScrapeDetail,
+  parseSavedScrapeList,
+  type ScrapeDetailResult,
+  type ScrapeListResult,
+} from "../parser";
+import type { ScrapeRules, StoredScrapeRules } from "../rules";
+import type { ExecutableScrapeRules, ScrapeRulesDecoder } from "./contract";
+
+type EarlyRules = Extract<StoredScrapeRules, { list: { detailLink: unknown } }>;
+type SavedRules = Extract<
+  StoredScrapeRules,
+  { articles: unknown } | { products: unknown }
+>;
+
+function contract<T extends StoredScrapeRules>(input: {
+  rules: T;
+  limit: number;
+  listLinkField: string;
+  nextPageField: string;
+  parseList(html: string, pageUrl: URL): ScrapeListResult;
+  parseDetail(html: string, pageUrl: URL): ScrapeDetailResult;
+  withLimit(limit: number): ExecutableScrapeRules;
+}): ExecutableScrapeRules {
+  return {
+    kind: input.rules.kind,
+    storedRules: input.rules,
+    limit: input.limit,
+    listLinkField: input.listLinkField,
+    nextPageField: input.nextPageField,
+    parseList: (html, pageUrl) => input.parseList(html, pageUrl),
+    parseDetail: (html, pageUrl) => input.parseDetail(html, pageUrl),
+    withLimit: (limit) => input.withLimit(limit),
+  };
+}
+
+export function interpretEarlyRules(
+  rules: EarlyRules,
+  decode: ScrapeRulesDecoder,
+) {
+  return contract({
+    rules,
+    limit: rules.list.maxItems,
+    listLinkField: "list.detailLink",
+    nextPageField: "list.nextPage",
+    parseList: (html, pageUrl) => parseEarlyScrapeList(rules, html, pageUrl),
+    parseDetail: (html, pageUrl) =>
+      parseEarlyScrapeDetail(rules, html, pageUrl),
+    withLimit: (requestedLimit) =>
+      decode({
+        ...rules,
+        list: {
+          ...rules.list,
+          maxItems: Math.min(rules.list.maxItems, requestedLimit),
+        },
+      }),
+  });
+}
+
+export function interpretSavedRules(
+  rules: SavedRules,
+  reviewKeys: "position" | "name-and-writer",
+  decode: ScrapeRulesDecoder,
+) {
+  const list = rules.kind === "review" ? rules.articles : rules.products;
+  const fieldRoot = rules.kind === "review" ? "articles" : "products";
+  return contract({
+    rules,
+    limit: list.limit,
+    listLinkField: `${fieldRoot}.link`,
+    nextPageField: `${fieldRoot}.nextPage`,
+    parseList: (html, pageUrl) => parseSavedScrapeList(rules, html, pageUrl),
+    parseDetail: (html, pageUrl) =>
+      parseSavedScrapeDetail(rules, html, pageUrl, reviewKeys),
+    withLimit: (requestedLimit) => {
+      const limit = Math.min(list.limit, requestedLimit);
+      return rules.kind === "review"
+        ? decode({
+            ...rules,
+            articles: { ...rules.articles, limit },
+          })
+        : decode({
+            ...rules,
+            products: { ...rules.products, limit },
+          });
+    },
+  });
+}
+
+export function interpretDirectRules(
+  rules: ScrapeRules,
+  decode: ScrapeRulesDecoder,
+) {
+  return contract({
+    rules,
+    limit: rules.list.limit,
+    listLinkField: "list.links",
+    nextPageField: "list.nextPage",
+    parseList: (html, pageUrl) => parseDirectScrapeList(rules, html, pageUrl),
+    parseDetail: (html, pageUrl) =>
+      parseDirectScrapeDetail(rules, html, pageUrl),
+    withLimit: (requestedLimit) =>
+      decode({
+        ...rules,
+        list: {
+          ...rules.list,
+          limit: Math.min(rules.list.limit, requestedLimit),
+        },
+      }),
+  });
+}

--- a/apps/server/src/scraper/configured/compatibility/version1.ts
+++ b/apps/server/src/scraper/configured/compatibility/version1.ts
@@ -1,0 +1,8 @@
+import { ScrapeRulesV1Schema } from "../rules";
+import type { StoredScrapeRulesInput } from "./contract";
+import { interpretEarlyRules } from "./interpreters";
+
+export function decodeRulesVersion1(storedJson: StoredScrapeRulesInput) {
+  const rules = ScrapeRulesV1Schema.parse(storedJson);
+  return interpretEarlyRules(rules, decodeRulesVersion1);
+}

--- a/apps/server/src/scraper/configured/compatibility/version10.ts
+++ b/apps/server/src/scraper/configured/compatibility/version10.ts
@@ -1,0 +1,8 @@
+import { ScrapeRulesV10Schema } from "../rules";
+import type { StoredScrapeRulesInput } from "./contract";
+import { interpretDirectRules } from "./interpreters";
+
+export function decodeRulesVersion10(storedJson: StoredScrapeRulesInput) {
+  const rules = ScrapeRulesV10Schema.parse(storedJson);
+  return interpretDirectRules(rules, decodeRulesVersion10);
+}

--- a/apps/server/src/scraper/configured/compatibility/version11.ts
+++ b/apps/server/src/scraper/configured/compatibility/version11.ts
@@ -1,0 +1,8 @@
+import { ScrapeRulesV11Schema } from "../rules";
+import type { StoredScrapeRulesInput } from "./contract";
+import { interpretDirectRules } from "./interpreters";
+
+export function decodeRulesVersion11(storedJson: StoredScrapeRulesInput) {
+  const rules = ScrapeRulesV11Schema.parse(storedJson);
+  return interpretDirectRules(rules, decodeRulesVersion11);
+}

--- a/apps/server/src/scraper/configured/compatibility/version3.ts
+++ b/apps/server/src/scraper/configured/compatibility/version3.ts
@@ -1,0 +1,8 @@
+import { ScrapeRulesV3Schema } from "../rules";
+import type { StoredScrapeRulesInput } from "./contract";
+import { interpretEarlyRules } from "./interpreters";
+
+export function decodeRulesVersion3(storedJson: StoredScrapeRulesInput) {
+  const rules = ScrapeRulesV3Schema.parse(storedJson);
+  return interpretEarlyRules(rules, decodeRulesVersion3);
+}

--- a/apps/server/src/scraper/configured/compatibility/version6.ts
+++ b/apps/server/src/scraper/configured/compatibility/version6.ts
@@ -1,0 +1,8 @@
+import { ScrapeRulesV6Schema } from "../rules";
+import type { StoredScrapeRulesInput } from "./contract";
+import { interpretSavedRules } from "./interpreters";
+
+export function decodeRulesVersion6(storedJson: StoredScrapeRulesInput) {
+  const rules = ScrapeRulesV6Schema.parse(storedJson);
+  return interpretSavedRules(rules, "position", decodeRulesVersion6);
+}

--- a/apps/server/src/scraper/configured/compatibility/version7.ts
+++ b/apps/server/src/scraper/configured/compatibility/version7.ts
@@ -1,0 +1,8 @@
+import { ScrapeRulesV7Schema } from "../rules";
+import type { StoredScrapeRulesInput } from "./contract";
+import { interpretSavedRules } from "./interpreters";
+
+export function decodeRulesVersion7(storedJson: StoredScrapeRulesInput) {
+  const rules = ScrapeRulesV7Schema.parse(storedJson);
+  return interpretSavedRules(rules, "position", decodeRulesVersion7);
+}

--- a/apps/server/src/scraper/configured/compatibility/version8.ts
+++ b/apps/server/src/scraper/configured/compatibility/version8.ts
@@ -1,0 +1,8 @@
+import { ScrapeRulesV8Schema } from "../rules";
+import type { StoredScrapeRulesInput } from "./contract";
+import { interpretSavedRules } from "./interpreters";
+
+export function decodeRulesVersion8(storedJson: StoredScrapeRulesInput) {
+  const rules = ScrapeRulesV8Schema.parse(storedJson);
+  return interpretSavedRules(rules, "name-and-writer", decodeRulesVersion8);
+}

--- a/apps/server/src/scraper/configured/compatibility/version9.ts
+++ b/apps/server/src/scraper/configured/compatibility/version9.ts
@@ -1,0 +1,8 @@
+import { ScrapeRulesV9Schema } from "../rules";
+import type { StoredScrapeRulesInput } from "./contract";
+import { interpretSavedRules } from "./interpreters";
+
+export function decodeRulesVersion9(storedJson: StoredScrapeRulesInput) {
+  const rules = ScrapeRulesV9Schema.parse(storedJson);
+  return interpretSavedRules(rules, "name-and-writer", decodeRulesVersion9);
+}

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -11,23 +11,63 @@ import {
   discoverWhiskeyReviewerArticles,
   parseWhiskeyReviewerArticle,
 } from "../adapters/whiskeyReviewer";
-import {
-  discoverWhiskyNotesArticles,
-  parseWhiskyNotesArticle,
-} from "../adapters/whiskyNotes";
 import { parseWhiskySagaArticle } from "../adapters/whiskySaga";
 import { parseWhiskyStudyArticle } from "../adapters/whiskyStudy";
+import { loadExecutableScrapeRules } from "./compatibility";
 import {
-  discoverWordsOfWhiskyArticles,
-  parseWordsOfWhiskyArticle,
-} from "../adapters/wordsOfWhisky";
-import { parseScrapeDetail, parseScrapeList } from "./parser";
+  parseEarlyScrapeDetail,
+  parseEarlyScrapeList,
+  parseSavedScrapeDetail,
+  parseSavedScrapeList,
+  parseScrapeDetail,
+  parseScrapeList,
+} from "./parser";
 import {
-  parseScrapeRules,
   type ScrapeRules,
-  type ScrapeRulesV5,
+  type ScrapeRulesV3,
   type StoredScrapeRules,
 } from "./rules";
+
+type SavedFixtureRules = Extract<
+  StoredScrapeRules,
+  { articles: unknown } | { products: unknown }
+>;
+
+function isDirectFixtureRules(rules: StoredScrapeRules): rules is ScrapeRules {
+  return "list" in rules && "links" in rules.list;
+}
+
+function isSavedFixtureRules(
+  rules: StoredScrapeRules,
+): rules is SavedFixtureRules {
+  return "articles" in rules || "products" in rules;
+}
+
+function parseFixtureList(
+  rules: StoredScrapeRules,
+  html: string,
+  pageUrl: URL,
+) {
+  if (isDirectFixtureRules(rules)) {
+    return parseScrapeList(rules, html, pageUrl);
+  }
+  return isSavedFixtureRules(rules)
+    ? parseSavedScrapeList(rules, html, pageUrl)
+    : parseEarlyScrapeList(rules, html, pageUrl);
+}
+
+function parseFixtureDetail(
+  rules: StoredScrapeRules,
+  html: string,
+  pageUrl: URL,
+) {
+  if (isDirectFixtureRules(rules)) {
+    return parseScrapeDetail(rules, html, pageUrl);
+  }
+  return isSavedFixtureRules(rules)
+    ? parseSavedScrapeDetail(rules, html, pageUrl, "name-and-writer")
+    : parseEarlyScrapeDetail(rules, html, pageUrl);
+}
 
 it("reads price fields from text and their usual HTML attributes", () => {
   const rules = {
@@ -650,7 +690,7 @@ const whiskyStudyRules = {
       scale: 100,
     },
   },
-} satisfies ScrapeRulesV5;
+} satisfies ScrapeRulesV3;
 
 const whiskySagaRules = {
   kind: "review",
@@ -687,7 +727,7 @@ const whiskySagaRules = {
       scale: 100,
     },
   },
-} satisfies ScrapeRulesV5;
+} satisfies ScrapeRulesV3;
 
 const bourbonCultureRules = {
   kind: "review",
@@ -729,7 +769,7 @@ const bourbonCultureRules = {
       scale: 10,
     },
   },
-} satisfies ScrapeRulesV5;
+} satisfies ScrapeRulesV3;
 
 const compassBoxRules = {
   kind: "price",
@@ -745,7 +785,7 @@ const compassBoxRules = {
     currency: "gbp",
     volume: { value: "700 ml" },
   },
-} satisfies ScrapeRulesV5;
+} satisfies ScrapeRulesV3;
 
 const kilchomanRules = {
   kind: "price",
@@ -767,7 +807,7 @@ const kilchomanRules = {
       attribute: "content",
     },
   },
-} satisfies ScrapeRulesV5;
+} satisfies ScrapeRulesV3;
 
 const whiskeyReviewerRules = {
   kind: "review",
@@ -826,87 +866,7 @@ const whiskeyReviewerRules = {
       ],
     },
   },
-} satisfies ScrapeRulesV5;
-
-const wordsOfWhiskyRules = {
-  kind: "review",
-  list: {
-    item: "article.category-tastingnotes",
-    detailLink: { selector: "a[href]", attribute: "href" },
-    maxItems: 20,
-  },
-  detail: {
-    canonicalUrl: {
-      selector: 'link[rel="canonical"]',
-      attribute: "href",
-      removeSuffixes: ["/"],
-    },
-    title: { selector: ".post-wrap .entry-title" },
-    publishedAt: {
-      selector: ".post-wrap time.entry-date",
-      attribute: "datetime",
-    },
-    reviewItem: { start: ".entry-content > h2" },
-    name: { selector: "h2" },
-    reviewerName: {
-      selector: ".side-author__wrap .side-meta .title",
-    },
-    reviewText: {
-      selector: "p",
-      startsWith: ["Nose:", "Palate:", "Taste:", "Finish:"],
-      all: true,
-    },
-    score: {
-      value: {
-        selector: ".lets-review-block__final-score",
-        suffix: "/10",
-      },
-      scale: 10,
-    },
-  },
-} satisfies ScrapeRulesV5;
-
-const whiskyNotesRules = {
-  kind: "review",
-  list: {
-    item: "#featured article, #posts article",
-    detailLink: { selector: "a.entry-permalink", attribute: "href" },
-    excludeWhen: {
-      selector:
-        ".category-armagnac, .category-bars, .category-cognac, .category-distillery-visits, .category-other-spirits, .category-rum, .category-whisky-news",
-    },
-    nextPage: { selector: 'link[rel="next"]', attribute: "href" },
-    maxItems: 20,
-  },
-  detail: {
-    title: { selector: "#main article.post .entry-title" },
-    publishedAt: {
-      selector: "#main article.post time.entry-date.published",
-      attribute: "datetime",
-    },
-    reviewItem: {
-      start:
-        '.entry-content > h2:contains("%"), .entry-content > h2:contains("Proof"), .entry-content > h2:contains("proof")',
-      endBefore: ".entry-content > .yarpp",
-    },
-    name: { selector: "h2" },
-    reviewerName: { selector: ".author.vcard" },
-    reviewText: { selector: "h2, h2 ~ p", all: true },
-    score: {
-      value: {
-        selector:
-          'p:contains("Score:") > span:last-child strong, p:contains("Score:") > strong:last-child',
-        removeSuffixes: ["/100"],
-        suffix: "/100",
-      },
-      firstReviewFallback: {
-        selector: ".entry-score",
-        suffix: "/100",
-      },
-      scale: 100,
-    },
-  },
-} satisfies ScrapeRulesV5;
+} satisfies ScrapeRulesV3;
 
 function pageText(selector: string) {
   return {
@@ -1206,7 +1166,7 @@ test("reads text links from an XML review index", () => {
   } as const satisfies StoredScrapeRules;
 
   expect(
-    parseScrapeList(
+    parseFixtureList(
       rules,
       `
         <rss><channel>
@@ -1252,7 +1212,7 @@ test("reads formatted dates from attributes and filters review elements", () => 
     },
   } as const satisfies StoredScrapeRules;
 
-  const result = parseScrapeDetail(
+  const result = parseFixtureDetail(
     rules,
     `
       <a name="070926"></a><h1>September seven</h1>
@@ -1275,7 +1235,7 @@ test("reads formatted dates from attributes and filters review elements", () => 
 });
 
 function expectReviewFactsAndEvidenceToMatch(
-  configured: ReturnType<typeof parseScrapeDetail>,
+  configured: ReturnType<typeof parseFixtureDetail>,
   legacy: NonNullable<ReturnType<typeof parseWhiskyStudyArticle>>,
 ) {
   expect(configured.kind).toBe("review");
@@ -1305,7 +1265,7 @@ function expectReviewFactsAndEvidenceToMatch(
 
 describe("scrape source parser", () => {
   it("limits detail links to the same website", () => {
-    const result = parseScrapeList(
+    const result = parseFixtureList(
       reviewConfig,
       '<a class="review" href="/one">One</a><a class="review" href="https://reviews.test/two#top">Two</a><a class="review" href="/three">Three</a>',
       new URL("https://reviews.test/archive"),
@@ -1318,7 +1278,7 @@ describe("scrape source parser", () => {
   });
 
   it("extracts a same-website next page", () => {
-    const result = parseScrapeList(
+    const result = parseFixtureList(
       {
         ...reviewConfig,
         list: {
@@ -1359,7 +1319,7 @@ describe("scrape source parser", () => {
     } as const satisfies StoredScrapeRules;
 
     expect(
-      parseScrapeList(
+      parseFixtureList(
         rules,
         '<article class="product"><a href="/products/glenallachie-12">Bottle</a></article>',
         new URL("https://shop.theglenallachie.com/collections/all-products"),
@@ -1374,7 +1334,7 @@ describe("scrape source parser", () => {
   });
 
   it("excludes unavailable list cards with bounded text matching", () => {
-    const result = parseScrapeList(
+    const result = parseFixtureList(
       {
         ...reviewConfig,
         list: {
@@ -1401,7 +1361,7 @@ describe("scrape source parser", () => {
       ({ url }) => url,
     );
 
-    expect(parseScrapeList(compassBoxRules, html, pageUrl)).toEqual({
+    expect(parseFixtureList(compassBoxRules, html, pageUrl)).toEqual({
       links: legacyLinks,
       nextPageUrl: null,
       issues: [],
@@ -1415,7 +1375,7 @@ describe("scrape source parser", () => {
       ({ url }) => url,
     );
 
-    expect(parseScrapeList(kilchomanRules, html, pageUrl)).toEqual({
+    expect(parseFixtureList(kilchomanRules, html, pageUrl)).toEqual({
       links: legacyLinks,
       nextPageUrl: null,
       issues: [],
@@ -1429,7 +1389,7 @@ describe("scrape source parser", () => {
       (url) => url.href,
     );
 
-    expect(parseScrapeList(bourbonCultureRules, html, pageUrl)).toEqual({
+    expect(parseFixtureList(bourbonCultureRules, html, pageUrl)).toEqual({
       links: legacyLinks,
       nextPageUrl: null,
       issues: [],
@@ -1443,7 +1403,7 @@ describe("scrape source parser", () => {
       (url) => url.href,
     );
 
-    expect(parseScrapeList(whiskeyReviewerRules, html, pageUrl)).toEqual({
+    expect(parseFixtureList(whiskeyReviewerRules, html, pageUrl)).toEqual({
       links: [
         "https://whiskeyreviewer.com/2026/08/example-bourbon-review-081026/",
         "https://whiskeyreviewer.com/2026/08/example-scotch-review-080626/",
@@ -1452,38 +1412,10 @@ describe("scrape source parser", () => {
       issues: [],
     });
     expect(
-      parseScrapeList(whiskeyReviewerRules, html, pageUrl).links.map((url) =>
+      parseFixtureList(whiskeyReviewerRules, html, pageUrl).links.map((url) =>
         url.replace(/\/$/u, ""),
       ),
     ).toEqual(legacyLinks);
-  });
-
-  it("matches the current Words of Whisky article links", async () => {
-    const pageUrl = new URL("https://wordsofwhisky.com/");
-    const html = await loadFixture("wordsofwhisky", "index.html");
-    const legacyLinks = discoverWordsOfWhiskyArticles(html).map(
-      (url) => url.href,
-    );
-
-    expect(
-      parseScrapeList(wordsOfWhiskyRules, html, pageUrl).links.map((url) =>
-        url.replace(/\/$/u, ""),
-      ),
-    ).toEqual(legacyLinks);
-  });
-
-  it("matches the current WhiskyNotes article links", async () => {
-    const pageUrl = new URL("https://www.whiskynotes.be/");
-    const html = await loadFixture("whiskynotes", "archive.html");
-    const legacyLinks = discoverWhiskyNotesArticles(html).map(
-      (url) => url.href,
-    );
-
-    expect(parseScrapeList(whiskyNotesRules, html, pageUrl)).toEqual({
-      links: legacyLinks,
-      nextPageUrl: "https://www.whiskynotes.be/page/2/",
-      issues: [],
-    });
   });
 
   it.each([
@@ -1503,7 +1435,7 @@ describe("scrape source parser", () => {
     const html = await loadFixture("dramface", fixture);
     const pageUrl = new URL(url);
     const legacy = parseDramfaceArticle(html, pageUrl);
-    const configured = parseScrapeDetail(dramfaceSavedRules, html, pageUrl);
+    const configured = parseFixtureDetail(dramfaceSavedRules, html, pageUrl);
 
     expect(configured.kind).toBe("review");
     expect(configured.issues).toEqual([]);
@@ -1527,7 +1459,7 @@ describe("scrape source parser", () => {
   });
 
   it("rejects a next page on another website", () => {
-    const result = parseScrapeList(
+    const result = parseFixtureList(
       {
         ...reviewConfig,
         list: {
@@ -1546,7 +1478,7 @@ describe("scrape source parser", () => {
   });
 
   it("rejects links on another origin", () => {
-    const result = parseScrapeList(
+    const result = parseFixtureList(
       reviewConfig,
       '<a class="review" href="https://other.test/one">One</a>',
       new URL("https://reviews.test/archive"),
@@ -1558,7 +1490,7 @@ describe("scrape source parser", () => {
   });
 
   it("extracts and validates review records", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       reviewConfig,
       '<h1>Spring reviews</h1><time datetime="2026-04-02"></time><article class="review"><h2>Example 12 Year</h2><span class="author">Ada</span><span class="score">91 / 100</span><div class="body">Rich and balanced.</div></article>',
       new URL("https://reviews.test/spring"),
@@ -1574,7 +1506,7 @@ describe("scrape source parser", () => {
   });
 
   it("parses an ordinal published date", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         ...currentReviewRules,
         article: {
@@ -1605,7 +1537,7 @@ describe("scrape source parser", () => {
   ])(
     "reports one canonical URL issue when the configured value %s",
     (_, canonicalMarkup, message) => {
-      const result = parseScrapeDetail(
+      const result = parseFixtureDetail(
         {
           ...reviewConfig,
           detail: {
@@ -1634,7 +1566,7 @@ describe("scrape source parser", () => {
     );
     const html = await loadFixture("whiskeyreviewer", "review.html");
     const legacy = parseWhiskeyReviewerArticle(html, pageUrl);
-    const configured = parseScrapeDetail(whiskeyReviewerRules, html, pageUrl);
+    const configured = parseFixtureDetail(whiskeyReviewerRules, html, pageUrl);
 
     expect(configured.kind).toBe("review");
     expect(configured.issues).toEqual([]);
@@ -1659,89 +1591,11 @@ describe("scrape source parser", () => {
     );
   });
 
-  it.each(["single-review.html", "multi-review.html"])(
-    "matches the current Words of Whisky parser for %s",
-    async (fixture) => {
-      const url = new URL(
-        fixture === "single-review.html"
-          ? "https://wordsofwhisky.com/bruichladdich-greener-still-review"
-          : "https://wordsofwhisky.com/kanosuke-dingle-meikle-toir-the-whisky-exchange",
-      );
-      const html = await loadFixture("wordsofwhisky", fixture);
-      const legacy = parseWordsOfWhiskyArticle(html, url);
-      const configured = parseScrapeDetail(wordsOfWhiskyRules, html, url);
-
-      expect(configured.kind).toBe("review");
-      expect(configured.issues).toEqual([]);
-      if (configured.kind !== "review" || !configured.value) {
-        throw new Error("Expected configured review output.");
-      }
-      expect(configured.value.article).toMatchObject({
-        canonicalUrl: legacy.article.canonicalUrl,
-        title: legacy.article.title,
-        publishedAt: legacy.article.publishedAt,
-      });
-      expect(configured.value.article.externalReviews).toMatchObject(
-        legacy.article.externalReviews.map((review) => ({
-          name: review.name,
-          reviewerName: review.reviewerName,
-          nativeScore: review.nativeScore,
-        })),
-      );
-      expect(Object.values(configured.value.externalReviewTexts)).toEqual(
-        Object.values(legacy.externalReviewTexts),
-      );
-      expect(Object.values(configured.value.externalReviewBodies)).toEqual(
-        Object.values(legacy.externalReviewBodies),
-      );
-    },
-  );
-
-  it.each([
-    [
-      "single-review.html",
-      "https://www.whiskynotes.be/2026/world/kanekou-okinawa-whisky/",
-    ],
-    [
-      "multi-review.html",
-      "https://www.whiskynotes.be/2026/bowmore/bowmore-2005-ben-nevis-1996-whisky-agency/",
-    ],
-  ])("matches the current WhiskyNotes parser for %s", async (fixture, url) => {
-    const html = await loadFixture("whiskynotes", fixture);
-    const pageUrl = new URL(url);
-    const legacy = parseWhiskyNotesArticle(html, pageUrl);
-    const configured = parseScrapeDetail(whiskyNotesRules, html, pageUrl);
-
-    expect(configured.kind).toBe("review");
-    expect(configured.issues).toEqual([]);
-    if (configured.kind !== "review" || !configured.value) {
-      throw new Error("Expected configured review output.");
-    }
-    expect(configured.value.article).toMatchObject({
-      canonicalUrl: legacy.article.canonicalUrl,
-      title: legacy.article.title,
-      publishedAt: legacy.article.publishedAt,
-    });
-    expect(configured.value.article.externalReviews).toMatchObject(
-      legacy.article.externalReviews.map((review) => ({
-        name: review.name,
-        reviewerName: review.reviewerName,
-        nativeScore: review.nativeScore,
-      })),
-    );
-    expect(Object.values(configured.value.externalReviewTexts)).toEqual(
-      Object.values(legacy.externalReviewTexts),
-    );
-    expect(Object.values(configured.value.externalReviewBodies)).toEqual(
-      Object.values(legacy.externalReviewBodies),
-    );
-  });
-
   it("rejects conflicting URL dates and unmapped scores", async () => {
     const html = (await loadFixture("whiskeyreviewer", "review.html"))
       .replace("/2026/08/example-bourbon", "/2025/08/example-bourbon")
       .replace("Rating: B+", "Rating: E");
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       whiskeyReviewerRules,
       html,
       new URL(
@@ -1760,7 +1614,7 @@ describe("scrape source parser", () => {
   });
 
   it("removes Whisky Study title suffixes and finds a labeled score", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         ...reviewConfig,
         detail: {
@@ -1801,7 +1655,7 @@ describe("scrape source parser", () => {
   });
 
   it("joins only Whisky Saga tasting sections in document order", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         ...reviewConfig,
         detail: {
@@ -1848,7 +1702,7 @@ describe("scrape source parser", () => {
     if (!legacy) throw new Error("Expected legacy review output.");
 
     expectReviewFactsAndEvidenceToMatch(
-      parseScrapeDetail(whiskyStudyRules, html, url),
+      parseFixtureDetail(whiskyStudyRules, html, url),
       legacy,
     );
   });
@@ -1864,7 +1718,7 @@ describe("scrape source parser", () => {
     if (!legacy) throw new Error("Expected legacy review output.");
 
     expectReviewFactsAndEvidenceToMatch(
-      parseScrapeDetail(whiskySagaRules, html, url),
+      parseFixtureDetail(whiskySagaRules, html, url),
       legacy,
     );
   });
@@ -1878,13 +1732,13 @@ describe("scrape source parser", () => {
     expect(legacy.article.externalReviews).toHaveLength(1);
 
     expectReviewFactsAndEvidenceToMatch(
-      parseScrapeDetail(bourbonCultureRules, html, url),
+      parseFixtureDetail(bourbonCultureRules, html, url),
       legacy,
     );
   });
 
   it("uses fixed values and literal prefixes before price validation", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         kind: "price",
         list: {
@@ -1909,7 +1763,7 @@ describe("scrape source parser", () => {
   });
 
   it("reports joined values over the element bound", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         ...reviewConfig,
         detail: {
@@ -1932,7 +1786,7 @@ describe("scrape source parser", () => {
   });
 
   it("treats values emptied by literal cleanup as missing", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         ...reviewConfig,
         detail: {
@@ -1950,9 +1804,8 @@ describe("scrape source parser", () => {
   });
 
   it("keeps version 1 parsing output unchanged", () => {
-    const rules = parseScrapeRules(1, reviewConfig);
-    const result = parseScrapeDetail(
-      rules,
+    const rules = loadExecutableScrapeRules(1, reviewConfig);
+    const result = rules.parseDetail(
       '<h1>Spring reviews</h1><time datetime="2026-04-02"></time><article class="review"><h2>Example 12 Year</h2><span class="score">91 / 100</span><div class="body">Rich and balanced.</div></article>',
       new URL("https://reviews.test/spring"),
     );
@@ -1970,7 +1823,7 @@ describe("scrape source parser", () => {
   });
 
   it("reads page fields for a single review", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       reviewConfig,
       '<h1>Spring reviews</h1><time datetime="2026-04-02"></time><h2>Example 12 Year</h2><article class="review"><span class="author">Ada</span><div class="body">Rich and balanced.</div></article>',
       new URL("https://reviews.test/spring"),
@@ -1989,7 +1842,7 @@ describe("scrape source parser", () => {
 
   it("keeps complete plain-text bodies per review while selecting narrower tasting text", () => {
     const longParagraph = "Body prose. ".repeat(5000).trim();
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       reviewConfig,
       `
       <nav>Page navigation</nav><h1>Two reviews</h1><time datetime="2026-09-01"></time>
@@ -2018,43 +1871,8 @@ describe("scrape source parser", () => {
     });
   });
 
-  it("stops review sections at the next heading or end selector", () => {
-    const result = parseScrapeDetail(
-      {
-        ...reviewConfig,
-        detail: {
-          ...reviewConfig.detail,
-          reviewItem: {
-            start: ".reviews > h2.review",
-            endBefore: ".reviews > .related",
-          },
-          name: { selector: "h2.review" },
-          reviewText: { selector: "p.notes" },
-          score: undefined,
-        },
-      },
-      `<h1>Two reviews</h1><time datetime="2026-09-01"></time>
-      <div class="reviews">
-        <h2 class="review">First Bottle</h2><p class="notes">Nose: fruit.</p>
-        <h2 class="review">Second Bottle</h2><p class="notes">Palate: smoke.</p>
-        <div class="related">Related reviews</div>
-      </div>`,
-      new URL("https://reviews.test/sections"),
-    );
-
-    expect(result.issues).toEqual([]);
-    if (result.kind !== "review" || !result.value) {
-      throw new Error("Expected reviews");
-    }
-    const [first, second] = result.value.article.externalReviews;
-    expect(result.value.externalReviewBodies).toEqual({
-      [first.sourceKey]: "First Bottle\n\nNose: fruit.",
-      [second.sourceKey]: "Second Bottle\n\nPalate: smoke.",
-    });
-  });
-
   it("does not reuse a page field for repeated reviews", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       reviewConfig,
       '<h1>Spring reviews</h1><h2>Shared bottle</h2><article class="review"></article><article class="review"></article>',
       new URL("https://reviews.test/spring"),
@@ -2089,7 +1907,7 @@ describe("scrape source parser", () => {
   ])(
     "keeps review fields separate with %s",
     (_, pageBylines, firstByline, reviewers) => {
-      const result = parseScrapeDetail(
+      const result = parseFixtureDetail(
         reviewConfig,
         `<h1>Two reviews</h1><time datetime="2026-08-22"></time>${pageBylines}
       <span class="score">99</span>
@@ -2121,7 +1939,7 @@ describe("scrape source parser", () => {
   );
 
   it("extracts repeated reviews and reports invalid dates and scores", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       reviewConfig,
       '<h1>Spring reviews</h1><time datetime="not-a-date"></time><article class="review"><h2>First Bottle</h2><span class="score">none</span></article><article class="review"><h2>Second Bottle</h2><span class="score">88</span></article>',
       new URL("https://reviews.test/spring"),
@@ -2139,7 +1957,7 @@ describe("scrape source parser", () => {
   });
 
   it("reports required review fields when unrelated markup is selected", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       reviewConfig,
       "<main><p>Nothing to parse</p></main>",
       new URL("https://reviews.test/unrelated"),
@@ -2155,7 +1973,7 @@ describe("scrape source parser", () => {
   });
 
   it("normalizes a store price and volume", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         kind: "price",
         list: {
@@ -2210,7 +2028,7 @@ describe("scrape source parser", () => {
             },
       ],
     });
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         kind: "catalog",
         products: {
@@ -2269,7 +2087,7 @@ describe("scrape source parser", () => {
   });
 
   it("reports a missing catalog product name", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         kind: "catalog",
         products: {
@@ -2311,7 +2129,7 @@ describe("scrape source parser", () => {
   });
 
   it("converts liters to milliliters", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         kind: "price",
         list: {
@@ -2336,7 +2154,7 @@ describe("scrape source parser", () => {
   });
 
   it("reports invalid store fields", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       {
         kind: "price",
         list: {
@@ -2365,7 +2183,7 @@ describe("scrape source parser", () => {
   });
 
   it("reports a selector that no longer finds detail links", () => {
-    const result = parseScrapeList(
+    const result = parseFixtureList(
       reviewConfig,
       '<a class="new-review-link" href="/one">One</a>',
       new URL("https://reviews.test/archive"),
@@ -2383,7 +2201,7 @@ describe("scrape source parser", () => {
   });
 
   it("reads version 8 article links inside each result", () => {
-    const result = parseScrapeList(
+    const result = parseFixtureList(
       currentReviewRules,
       `<main>
         <article class="card"><a href="/one">One</a></article>
@@ -2402,7 +2220,7 @@ describe("scrape source parser", () => {
   });
 
   it("accepts a list page where every result is explicitly skipped", () => {
-    const result = parseScrapeList(
+    const result = parseFixtureList(
       currentReviewRules,
       `<main>
         <article class="card"><span class="skip">News</span><a href="/news">News</a></article>
@@ -2420,7 +2238,7 @@ describe("scrape source parser", () => {
 
   it("still reports when a saved result selector finds nothing", () => {
     expect(
-      parseScrapeList(
+      parseFixtureList(
         currentReviewRules,
         "<main></main>",
         new URL("https://reviews.test/"),
@@ -2438,7 +2256,7 @@ describe("scrape source parser", () => {
   });
 
   it("reads version 8 review sections and explicit article values", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       currentReviewRules,
       `<article>
         <h1 class="title">Two autumn reviews</h1>
@@ -2486,8 +2304,8 @@ describe("scrape source parser", () => {
 
   it("keeps reviews matched when they move", () => {
     const parseKeys = (reviews: string) => {
-      const result = parseScrapeDetail(
-        currentReviewRules,
+      const rules = loadExecutableScrapeRules(9, currentReviewRules);
+      const result = rules.parseDetail(
         `<article>
           <h1 class="title">Reviews</h1>
           <time datetime="2026-09-01"></time>
@@ -2517,8 +2335,8 @@ describe("scrape source parser", () => {
   });
 
   it("rejects reviews without a stable identity", () => {
-    const result = parseScrapeDetail(
-      currentReviewRules,
+    const rules = loadExecutableScrapeRules(9, currentReviewRules);
+    const result = rules.parseDetail(
       `<article>
         <h1 class="title">Reviews</h1>
         <time datetime="2026-09-01"></time>
@@ -2539,7 +2357,7 @@ describe("scrape source parser", () => {
   });
 
   it("can keep the full article area for one version 8 review", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       currentReviewRules,
       `<article>
         <h1 class="title">One autumn review</h1>
@@ -2568,7 +2386,7 @@ describe("scrape source parser", () => {
   });
 
   it("reports a version 8 review area that is not unique", () => {
-    const result = parseScrapeDetail(
+    const result = parseFixtureDetail(
       currentReviewRules,
       `<h1 class="title">Reviews</h1>
        <time datetime="2026-09-01"></time>
@@ -2631,7 +2449,7 @@ describe("scrape source parser", () => {
     } as const satisfies StoredScrapeRules;
 
     expect(
-      parseScrapeDetail(
+      parseFixtureDetail(
         rules,
         `<h1>Coastal Malt</h1>
          <span class="price">$84.99</span>

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -20,11 +20,11 @@ import type {
   StoredScrapeReviewField,
   StoredScrapeRules,
 } from "./rules";
+import { normalizeScrapeReviewNameRule } from "./rules";
 import {
-  normalizeScrapeReviewNameRule,
-  ScrapeReviewSectionSchema,
-  ScrapeSelectorSchema,
-} from "./rules";
+  applyDetailPageUrlCompatibility,
+  readCompatiblePublishedDate,
+} from "./sourceCompatibility";
 import { matchFirstText, matchText } from "./textTemplate";
 
 export type ScrapeListResult = {
@@ -75,18 +75,11 @@ type LegacyPriceRules = Extract<
   StoredScrapeRules,
   { kind: "price"; list: { detailLink: unknown } }
 >;
+type EarlyRules = LegacyReviewRules | LegacyPriceRules;
 type ScrapePageReadV6 = Extract<StoredScrapePageRead, { clean: unknown }>;
 const JsonLdValueSchema = z.json();
 const JsonLdObjectSchema = z.record(z.string(), JsonLdValueSchema);
 type JsonLdValue = z.infer<typeof JsonLdValueSchema>;
-
-function usesNameBasedReviewKeys(rules: SavedReviewRules) {
-  return "addStart" in rules.article.title.try[0];
-}
-
-function usesDirectSelectors(rules: StoredScrapeRules): rules is ScrapeRules {
-  return "list" in rules && "links" in rules.list;
-}
 
 function normalizeValue(value: string | undefined) {
   return value?.replaceAll(/\s+/g, " ").trim() || null;
@@ -309,15 +302,9 @@ function sameWebsiteUrl(value: string, baseUrl: URL) {
 }
 
 function detailPageUrl(value: string, listUrl: URL) {
-  const url = new URL(sameWebsiteUrl(value, listUrl));
-  if (
-    url.hostname === "shop.theglenallachie.com" &&
-    url.pathname.startsWith("/products/")
-  ) {
-    // GlenAllachie source: its product pages require this to return UK prices.
-    url.searchParams.set("country", "GB");
-  }
-  return url.toString();
+  return applyDetailPageUrlCompatibility(
+    new URL(sameWebsiteUrl(value, listUrl)),
+  ).toString();
 }
 
 function parseSelectedLinks(
@@ -381,16 +368,26 @@ function parseSelectedLinks(
 }
 
 export function parseScrapeList(
-  rules: StoredScrapeRules,
+  rules: ScrapeRules,
   html: string,
   pageUrl: URL,
 ): ScrapeListResult {
-  if (usesDirectSelectors(rules)) {
-    return parseSelectedLinks(rules, html, pageUrl);
-  }
-  if ("articles" in rules || "products" in rules) {
-    return parseSavedList(rules, html, pageUrl);
-  }
+  return parseDirectScrapeList(rules, html, pageUrl);
+}
+
+export function parseDirectScrapeList(
+  rules: ScrapeRules,
+  html: string,
+  pageUrl: URL,
+) {
+  return parseSelectedLinks(rules, html, pageUrl);
+}
+
+export function parseEarlyScrapeList(
+  rules: EarlyRules,
+  html: string,
+  pageUrl: URL,
+): ScrapeListResult {
   const issues: ScrapeIssue[] = [];
   const links = new Set<string>();
   try {
@@ -456,7 +453,7 @@ export function parseScrapeList(
   return { links: [...links], nextPageUrl, issues };
 }
 
-function parseSavedList(
+export function parseSavedScrapeList(
   rules: SavedRules,
   html: string,
   pageUrl: URL,
@@ -761,54 +758,12 @@ function selectReviewItems(
   $: ReturnType<typeof load>,
   rule: LegacyReviewRules["detail"]["reviewItem"],
 ) {
-  const section = ScrapeReviewSectionSchema.safeParse(rule);
-  if (!section.success) {
-    return $(ScrapeSelectorSchema.parse(rule))
-      .toArray()
-      .map((element) => ({
-        body: $(element),
-        item: load($.html(element)),
-      }));
-  }
-
-  const starts = $(section.data.start).toArray();
-  return starts.map((start) => {
-    if (starts.length === 1) {
-      const parent = $(start).parent();
-      if (!section.data.endBefore) {
-        return {
-          body: parent,
-          item: load(parent.html() ?? ""),
-        };
-      }
-      const body = $($(start).prevAll().toArray().reverse())
-        .add(start)
-        .add($(start).nextUntil(section.data.endBefore));
-      return {
-        body,
-        item: load(
-          body
-            .toArray()
-            .map((element) => $.html(element))
-            .join(""),
-        ),
-      };
-    }
-
-    const stopSelector = [section.data.start, section.data.endBefore]
-      .filter(Boolean)
-      .join(", ");
-    const body = $(start).add($(start).nextUntil(stopSelector));
-    return {
-      body,
-      item: load(
-        body
-          .toArray()
-          .map((element) => $.html(element))
-          .join(""),
-      ),
-    };
-  });
+  return $(rule)
+    .toArray()
+    .map((element) => ({
+      body: $(element),
+      item: load($.html(element)),
+    }));
 }
 
 function parseReviewDetail(
@@ -929,17 +884,9 @@ function parseReviewDetail(
         ? (readValue(item, reviewerSelector) ?? pageReviewerName)
         : null;
       const scoreRule = rules.detail.score;
-      const firstReviewFallback =
-        scoreRule &&
-        "firstReviewFallback" in scoreRule &&
-        scoreRule.firstReviewFallback;
       const scoreText = scoreRule
         ? (readValue(item, scoreRule.value) ??
-          (index === 0 && firstReviewFallback
-            ? readValue($, firstReviewFallback)
-            : reviewItems.length === 1
-              ? readValue($, scoreRule.value)
-              : null))
+          (reviewItems.length === 1 ? readValue($, scoreRule.value) : null))
         : null;
       const scoreMap =
         rules.detail.score && "map" in rules.detail.score
@@ -1228,6 +1175,7 @@ function parseSavedReviewDetail(
   rules: SavedReviewRules,
   html: string,
   pageUrl: URL,
+  keysUseNameAndWriter: boolean,
 ): ScrapeDetailResult {
   const $ = load(html);
   const issues: ScrapeIssue[] = [];
@@ -1281,7 +1229,6 @@ function parseSavedReviewDetail(
   const externalReviewTexts: Record<string, string> = {};
   const externalReviewBodies: Record<string, string> = {};
   const reviewKeys = new Set<string>();
-  const keysUseNameAndWriter = usesNameBasedReviewKeys(rules);
   const reviewItems = selectSavedReviewItems($, rules.article.reviews);
   if (!reviewItems) {
     issues.push({
@@ -1595,20 +1542,7 @@ function dateFromPageUrl(pageUrl: URL) {
     );
   }
 
-  if (pageUrl.hostname.endsWith("whiskyfun.com")) {
-    // Whiskyfun source: standalone article filenames end with a MMDDYY date.
-    const compact = pageUrl.pathname.match(
-      /(?:^|\D)(\d{2})(\d{2})(\d{2})(?:\D|$)/u,
-    );
-    if (compact) {
-      return createDate(
-        2000 + Number(compact[3]),
-        Number(compact[1]),
-        Number(compact[2]),
-      );
-    }
-  }
-  return null;
+  return readCompatiblePublishedDate(pageUrl);
 }
 
 // TODO(scraper-platform): Carry RSS and Atom item dates into detail parsing
@@ -2031,29 +1965,13 @@ function parseProductPage(
       };
 }
 
-export function parseScrapeDetail(
-  rules: StoredScrapeRules,
-  html: string,
-  pageUrl: URL,
+function safelyParseScrapeDetail(
+  rules: Pick<StoredScrapeRules, "kind">,
+  field: "article" | "product" | "detail",
+  parse: () => ScrapeDetailResult,
 ): ScrapeDetailResult {
   try {
-    if (usesDirectSelectors(rules)) {
-      return rules.kind === "review"
-        ? parseReviewPage(rules, html, pageUrl)
-        : parseProductPage(rules, html, pageUrl);
-    }
-    if (rules.kind === "review" && "article" in rules) {
-      return parseSavedReviewDetail(rules, html, pageUrl);
-    }
-    if (rules.kind === "price" && "product" in rules) {
-      return parseSavedPriceDetail(rules, html, pageUrl);
-    }
-    if (rules.kind === "catalog") {
-      return parseSavedCatalogDetail(rules, html, pageUrl);
-    }
-    return rules.kind === "review"
-      ? parseReviewDetail(rules, html, pageUrl)
-      : parseStorePriceDetail(rules, html, pageUrl);
+    return parse();
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Unable to parse selector.";
@@ -2061,23 +1979,77 @@ export function parseScrapeDetail(
       return {
         kind: "review",
         value: null,
-        issues: [
-          {
-            field: "article" in rules ? "article" : "detail",
-            message,
-          },
-        ],
+        issues: [{ field, message }],
+      };
+    }
+    if (rules.kind === "price") {
+      return {
+        kind: "price",
+        value: [],
+        issues: [{ field, message }],
       };
     }
     return {
-      kind: rules.kind,
+      kind: "catalog",
       value: [],
-      issues: [
-        {
-          field: "product" in rules ? "product" : "detail",
-          message,
-        },
-      ],
+      issues: [{ field, message }],
     };
   }
+}
+
+export function parseDirectScrapeDetail(
+  rules: ScrapeRules,
+  html: string,
+  pageUrl: URL,
+) {
+  return safelyParseScrapeDetail(rules, "detail", () =>
+    rules.kind === "review"
+      ? parseReviewPage(rules, html, pageUrl)
+      : parseProductPage(rules, html, pageUrl),
+  );
+}
+
+export function parseSavedScrapeDetail(
+  rules: SavedRules,
+  html: string,
+  pageUrl: URL,
+  reviewKeys: "position" | "name-and-writer",
+) {
+  return safelyParseScrapeDetail(
+    rules,
+    rules.kind === "review" ? "article" : "product",
+    () => {
+      if (rules.kind === "review") {
+        return parseSavedReviewDetail(
+          rules,
+          html,
+          pageUrl,
+          reviewKeys === "name-and-writer",
+        );
+      }
+      return rules.kind === "price"
+        ? parseSavedPriceDetail(rules, html, pageUrl)
+        : parseSavedCatalogDetail(rules, html, pageUrl);
+    },
+  );
+}
+
+export function parseEarlyScrapeDetail(
+  rules: EarlyRules,
+  html: string,
+  pageUrl: URL,
+) {
+  return safelyParseScrapeDetail(rules, "detail", () =>
+    rules.kind === "review"
+      ? parseReviewDetail(rules, html, pageUrl)
+      : parseStorePriceDetail(rules, html, pageUrl),
+  );
+}
+
+export function parseScrapeDetail(
+  rules: ScrapeRules,
+  html: string,
+  pageUrl: URL,
+): ScrapeDetailResult {
+  return parseDirectScrapeDetail(rules, html, pageUrl);
 }

--- a/apps/server/src/scraper/configured/rules.test.ts
+++ b/apps/server/src/scraper/configured/rules.test.ts
@@ -1,20 +1,22 @@
+import type { JsonValue } from "@peated/server/scraper/types";
 import { expect, test } from "vitest";
+import { loadExecutableScrapeRules } from "./compatibility";
 import {
-  parseScrapeRules,
   SCRAPE_RULES_VERSION,
   SCRAPE_SOURCE_MAX_ITEMS,
   SCRAPE_SOURCE_MAX_LIST_PAGES,
   ScrapeRulesSchema,
   ScrapeRulesV1Schema,
-  ScrapeRulesV2Schema,
   ScrapeRulesV3Schema,
-  ScrapeRulesV4Schema,
-  ScrapeRulesV5Schema,
   ScrapeRulesV6Schema,
   ScrapeRulesV7Schema,
   ScrapeValueSchema,
   type StoredScrapeRules,
 } from "./rules";
+
+function decodeStoredRules(rulesVersion: number, storedJson: JsonValue) {
+  return loadExecutableScrapeRules(rulesVersion, storedJson).storedRules;
+}
 
 function reviewConfig(maxItems: number) {
   return {
@@ -55,8 +57,8 @@ test("bounds list and detail pages", () => {
   });
   if (rules.kind !== "review") throw new Error("Expected review rules.");
   expect(rules.list.limit).toBe(99);
-  expect(parseScrapeRules(11, rules)).toEqual(rules);
-  expect(() => parseScrapeRules(9, rules)).toThrow();
+  expect(decodeStoredRules(11, rules)).toEqual(rules);
+  expect(() => decodeStoredRules(9, rules)).toThrow();
   expect(() =>
     ScrapeRulesSchema.parse({
       ...rules,
@@ -70,17 +72,17 @@ test("bounds list and detail pages", () => {
 });
 
 test("rejects rules for an unsupported stored format", () => {
-  const rules = ScrapeRulesV5Schema.parse(reviewConfig(25));
-  expect(() => parseScrapeRules(12, rules)).toThrow(
+  const rules = ScrapeRulesV3Schema.parse(reviewConfig(25));
+  expect(() => decodeStoredRules(12, rules)).toThrow(
     "Unsupported scrape rules version: 12.",
   );
 });
 
 test("loads old rules only through the version 1 contract", () => {
   const rules = ScrapeRulesV1Schema.parse(reviewConfig(25));
-  expect(parseScrapeRules(1, rules)).toEqual(rules);
+  expect(decodeStoredRules(1, rules)).toEqual(rules);
   expect(() =>
-    parseScrapeRules(1, {
+    decodeStoredRules(1, {
       ...rules,
       list: { ...rules.list, item: ".card" },
     }),
@@ -108,8 +110,8 @@ test("adds review name matches only in version 11", () => {
   });
   if (rules.kind !== "review") throw new Error("Expected review rules.");
 
-  expect(parseScrapeRules(11, rules)).toEqual(rules);
-  expect(() => parseScrapeRules(10, rules)).toThrow();
+  expect(decodeStoredRules(11, rules)).toEqual(rules);
+  expect(() => decodeStoredRules(10, rules)).toThrow();
   expect(() =>
     ScrapeRulesSchema.parse({
       ...rules,
@@ -158,9 +160,9 @@ test("adds catalog rules only in version 7", () => {
     },
   });
 
-  expect(parseScrapeRules(7, rules)).toEqual(rules);
+  expect(decodeStoredRules(7, rules)).toEqual(rules);
   expect(() => ScrapeRulesV6Schema.parse(rules)).toThrow();
-  expect(() => parseScrapeRules(6, rules)).toThrow();
+  expect(() => decodeStoredRules(6, rules)).toThrow();
 });
 
 test("changes text matching only in version 8", () => {
@@ -216,10 +218,10 @@ test("changes text matching only in version 8", () => {
     },
   } as const satisfies StoredScrapeRules;
 
-  expect(parseScrapeRules(9, version8)).toEqual(version8);
-  expect(parseScrapeRules(8, version8)).toEqual(version8);
-  expect(() => parseScrapeRules(10, version8)).toThrow();
-  expect(() => parseScrapeRules(7, version8)).toThrow();
+  expect(decodeStoredRules(9, version8)).toEqual(version8);
+  expect(decodeStoredRules(8, version8)).toEqual(version8);
+  expect(() => decodeStoredRules(10, version8)).toThrow();
+  expect(() => decodeStoredRules(7, version8)).toThrow();
   if (version8.kind !== "price") throw new Error("Expected price rules.");
 
   const version7 = ScrapeRulesV7Schema.parse({
@@ -253,74 +255,15 @@ test("changes text matching only in version 8", () => {
       },
     },
   });
-  expect(parseScrapeRules(7, version7)).toEqual(version7);
-  expect(() => parseScrapeRules(8, version7)).toThrow();
-});
-
-test("loads version 2 rules only through their original contract", () => {
-  const rules = ScrapeRulesV2Schema.parse(reviewConfig(25));
-  expect(parseScrapeRules(2, rules)).toEqual(rules);
-  expect(() =>
-    parseScrapeRules(2, {
-      ...rules,
-      detail: {
-        ...rules.detail,
-        canonicalUrl: {
-          selector: 'link[rel="canonical"]',
-          attribute: "href",
-        },
-      },
-    }),
-  ).toThrow();
-});
-
-test("loads version 4 rules only through their original contract", () => {
-  const rules = ScrapeRulesV4Schema.parse({
-    ...reviewConfig(25),
-    detail: {
-      ...reviewConfig(25).detail,
-      canonicalUrl: {
-        selector: 'link[rel="canonical"]',
-        attribute: "href",
-        removeSuffixes: ["/"],
-      },
-      publishedAt: { urlDateFormat: "/yyyy/MM/*-MMddyy" },
-      score: {
-        value: { selector: ".rating", removePrefixes: ["Rating:"] },
-        scale: 100,
-        map: [
-          { text: "A", value: 95 },
-          { text: "B+", value: 87 },
-        ],
-      },
-    },
-  });
-
-  expect(parseScrapeRules(4, rules)).toEqual(rules);
-  expect(() =>
-    parseScrapeRules(4, {
-      ...rules,
-      detail: {
-        ...rules.detail,
-        score: {
-          value: { selector: ".rating", removePrefixes: ["Rating:"] },
-          scale: 100,
-          map: [
-            { text: "A", value: 95 },
-            { text: "B+", value: 87 },
-          ],
-          firstReviewFallback: { selector: ".article-rating" },
-        },
-      },
-    }),
-  ).toThrow();
+  expect(decodeStoredRules(7, version7)).toEqual(version7);
+  expect(() => decodeStoredRules(8, version7)).toThrow();
 });
 
 test("loads version 3 rules only through their original contract", () => {
   const rules = ScrapeRulesV3Schema.parse(reviewConfig(25));
-  expect(parseScrapeRules(3, rules)).toEqual(rules);
+  expect(decodeStoredRules(3, rules)).toEqual(rules);
   expect(() =>
-    parseScrapeRules(3, {
+    decodeStoredRules(3, {
       ...rules,
       detail: {
         ...rules.detail,
@@ -330,47 +273,6 @@ test("loads version 3 rules only through their original contract", () => {
   ).toThrow();
 });
 
-test("accepts review sections with an end selector", () => {
-  const config = reviewConfig(25);
-  const rules = ScrapeRulesV5Schema.parse({
-    ...config,
-    detail: {
-      ...config.detail,
-      reviewItem: {
-        start: ".entry-content > h2.review",
-        endBefore: ".entry-content > .related-posts",
-      },
-    },
-  });
-
-  expect(parseScrapeRules(5, rules)).toMatchObject({
-    kind: "review",
-    detail: {
-      reviewItem: {
-        start: ".entry-content > h2.review",
-        endBefore: ".entry-content > .related-posts",
-      },
-    },
-  });
-});
-
-test("accepts a separate first-review score", () => {
-  const config = reviewConfig(25);
-  const rules = ScrapeRulesV5Schema.parse({
-    ...config,
-    detail: {
-      ...config.detail,
-      score: {
-        value: { selector: ".review-score" },
-        firstReviewFallback: { selector: ".article-score" },
-        scale: 100,
-      },
-    },
-  });
-
-  expect(parseScrapeRules(5, rules)).toEqual(rules);
-});
-
 test.each([
   ["missing URL year", "/reviews/MM/dd/*"],
   ["missing URL month", "/reviews/yyyy/dd/*"],
@@ -378,7 +280,7 @@ test.each([
   ["unknown URL token", "/reviews/yyyy/MM/DD/*"],
 ])("rejects invalid URL date formats: %s", (_, urlDateFormat) => {
   expect(() =>
-    ScrapeRulesV5Schema.parse({
+    ScrapeRulesV3Schema.parse({
       ...reviewConfig(25),
       detail: {
         ...reviewConfig(25).detail,
@@ -391,7 +293,7 @@ test.each([
 test("rejects duplicate or out-of-range score mappings", () => {
   const config = reviewConfig(25);
   expect(() =>
-    ScrapeRulesV5Schema.parse({
+    ScrapeRulesV3Schema.parse({
       ...config,
       detail: {
         ...config.detail,
@@ -410,7 +312,7 @@ test("rejects duplicate or out-of-range score mappings", () => {
 
 test("accepts bounded list-card exclusion only with an item selector", () => {
   expect(
-    ScrapeRulesV5Schema.parse({
+    ScrapeRulesV3Schema.parse({
       ...reviewConfig(25),
       list: {
         ...reviewConfig(25).list,
@@ -423,7 +325,7 @@ test("accepts bounded list-card exclusion only with an item selector", () => {
     excludeWhen: { selector: ".badge", startsWith: ["Sold out"] },
   });
   expect(() =>
-    ScrapeRulesV5Schema.parse({
+    ScrapeRulesV3Schema.parse({
       ...reviewConfig(25),
       list: {
         ...reviewConfig(25).list,

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -1,21 +1,10 @@
 import { CURRENCY_LIST } from "@peated/server/constants";
-import type { JsonValue } from "@peated/server/scraper/types";
 import { z } from "zod";
 import {
   ScrapeTextMatchesSchema,
   ScrapeTextTemplateSchema,
 } from "./textTemplate";
 
-const SCRAPE_RULES_VERSION_1 = 1;
-const SCRAPE_RULES_VERSION_2 = 2;
-const SCRAPE_RULES_VERSION_3 = 3;
-const SCRAPE_RULES_VERSION_4 = 4;
-const SCRAPE_RULES_VERSION_5 = 5;
-const SCRAPE_RULES_VERSION_6 = 6;
-const SCRAPE_RULES_VERSION_7 = 7;
-const SCRAPE_RULES_VERSION_8 = 8;
-const SCRAPE_RULES_VERSION_9 = 9;
-const SCRAPE_RULES_VERSION_10 = 10;
 export const SCRAPE_RULES_VERSION = 11;
 // TODO(scraper-platform): Add event after scraped-event match and update rules are defined.
 export const SCRAPE_SOURCE_KIND_LIST = ["review", "price", "catalog"] as const;
@@ -239,17 +228,6 @@ const ScrapeScoreSchema = z
   .strict()
   .superRefine(validateScoreMap);
 
-const ScrapeScoreWithFirstReviewSchema = ScrapeScoreSchema.safeExtend({
-  firstReviewFallback: ScrapeValueSchema.optional(),
-});
-
-export const ScrapeReviewSectionSchema = z
-  .object({
-    start: ScrapeSelectorSchema,
-    endBefore: ScrapeSelectorSchema.optional(),
-  })
-  .strict();
-
 function legacyReviewRulesSchema<T extends z.ZodType, U extends z.ZodType>(
   reviewItemSchema: T,
   scoreSchema: U,
@@ -305,29 +283,8 @@ export const ScrapeRulesV1Schema = z.discriminatedUnion("kind", [
   priceRulesSchema(ScrapeValueSelectorV1Schema, ListRulesV1Schema),
 ]);
 
-export const ScrapeRulesV2Schema = z.discriminatedUnion("kind", [
-  reviewRulesSchema(ScrapeValueSchema, ListRulesSchema),
-  priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
-]);
-
 export const ScrapeRulesV3Schema = z.discriminatedUnion("kind", [
   legacyReviewRulesSchema(ScrapeSelectorSchema, ScrapeScoreSchema),
-  priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
-]);
-
-export const ScrapeRulesV4Schema = z.discriminatedUnion("kind", [
-  legacyReviewRulesSchema(
-    z.union([ScrapeSelectorSchema, ScrapeReviewSectionSchema]),
-    ScrapeScoreSchema,
-  ),
-  priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
-]);
-
-export const ScrapeRulesV5Schema = z.discriminatedUnion("kind", [
-  legacyReviewRulesSchema(
-    z.union([ScrapeSelectorSchema, ScrapeReviewSectionSchema]),
-    ScrapeScoreWithFirstReviewSchema,
-  ),
   priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
 ]);
 
@@ -802,8 +759,14 @@ const ScrapeCatalogRulesV9Schema = z
   })
   .strict();
 
-const ScrapeRulesV9Schema = z.discriminatedUnion("kind", [
+export const ScrapeRulesV9Schema = z.discriminatedUnion("kind", [
   ScrapeReviewRulesV9Schema,
+  ScrapePriceRulesV9Schema,
+  ScrapeCatalogRulesV9Schema,
+]);
+
+export const ScrapeRulesV8Schema = z.discriminatedUnion("kind", [
+  ScrapeReviewRulesV8Schema,
   ScrapePriceRulesV9Schema,
   ScrapeCatalogRulesV9Schema,
 ]);
@@ -955,7 +918,7 @@ const ScrapeCatalogRulesV10Schema = z
   })
   .strict();
 
-const ScrapeRulesV10Schema = z.discriminatedUnion("kind", [
+export const ScrapeRulesV10Schema = z.discriminatedUnion("kind", [
   ScrapeReviewRulesV10Schema,
   ScrapePriceRulesV10Schema,
   ScrapeCatalogRulesV10Schema,
@@ -964,31 +927,25 @@ const ScrapeRulesV10Schema = z.discriminatedUnion("kind", [
 export const ScrapeReviewRulesSchema = ScrapeReviewRulesV11Schema;
 export const ScrapePriceRulesSchema = ScrapePriceRulesV10Schema;
 export const ScrapeCatalogRulesSchema = ScrapeCatalogRulesV10Schema;
-export const ScrapeRulesSchema = z.discriminatedUnion("kind", [
+export const ScrapeRulesV11Schema = z.discriminatedUnion("kind", [
   ScrapeReviewRulesV11Schema,
   ScrapePriceRulesV10Schema,
   ScrapeCatalogRulesV10Schema,
 ]);
+export const ScrapeRulesSchema = ScrapeRulesV11Schema;
 
 export const StoredScrapeRulesSchema = z.union([
   ScrapeRulesV1Schema,
-  ScrapeRulesV2Schema,
   ScrapeRulesV3Schema,
-  ScrapeRulesV4Schema,
-  ScrapeRulesV5Schema,
   ScrapeRulesV6Schema,
   ScrapeRulesV7Schema,
-  z.discriminatedUnion("kind", [
-    ScrapeReviewRulesV8Schema,
-    ScrapePriceRulesV9Schema,
-    ScrapeCatalogRulesV9Schema,
-  ]),
+  ScrapeRulesV8Schema,
   ScrapeRulesV9Schema,
   ScrapeRulesV10Schema,
-  ScrapeRulesSchema,
+  ScrapeRulesV11Schema,
 ]);
 
-export type ScrapeRulesV5 = z.infer<typeof ScrapeRulesV5Schema>;
+export type ScrapeRulesV3 = z.infer<typeof ScrapeRulesV3Schema>;
 export type ScrapeRules = z.infer<typeof ScrapeRulesSchema>;
 export type StoredScrapeRules = z.infer<typeof StoredScrapeRulesSchema>;
 export type ScrapePageRead = z.infer<typeof ScrapePageReadSchema>;
@@ -1016,95 +973,4 @@ export function normalizeScrapeReviewNameRule(
         selector: ScrapeSelectorSchema.nullable().parse(name),
         match: null,
       };
-}
-
-/** Uses the rule shape that was current when the rules were saved. */
-export function parseScrapeRules(
-  rulesVersion: number,
-  rules: StoredScrapeRules | JsonValue,
-) {
-  if (rulesVersion === SCRAPE_RULES_VERSION_1) {
-    return ScrapeRulesV1Schema.parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION_2) {
-    return ScrapeRulesV2Schema.parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION_3) {
-    return ScrapeRulesV3Schema.parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION_4) {
-    return ScrapeRulesV4Schema.parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION_5) {
-    return ScrapeRulesV5Schema.parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION_6) {
-    return ScrapeRulesV6Schema.parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION_7) {
-    return ScrapeRulesV7Schema.parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION_8) {
-    return z
-      .discriminatedUnion("kind", [
-        ScrapeReviewRulesV8Schema,
-        ScrapePriceRulesV9Schema,
-        ScrapeCatalogRulesV9Schema,
-      ])
-      .parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION_9) {
-    return ScrapeRulesV9Schema.parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION_10) {
-    return ScrapeRulesV10Schema.parse(rules);
-  }
-  if (rulesVersion === SCRAPE_RULES_VERSION) {
-    return ScrapeRulesSchema.parse(rules);
-  }
-  throw new Error(`Unsupported scrape rules version: ${rulesVersion}.`);
-}
-
-export function scrapeRulesLimit(rules: StoredScrapeRules) {
-  if ("articles" in rules) return rules.articles.limit;
-  if ("products" in rules) return rules.products.limit;
-  if ("links" in rules.list) return rules.list.limit;
-  return rules.list.maxItems;
-}
-
-export function scrapeRunRequestLimit(rules: StoredScrapeRules) {
-  return scrapeRulesLimit(rules) + SCRAPE_SOURCE_MAX_LIST_PAGES;
-}
-
-export function withScrapeRulesLimit(
-  rules: StoredScrapeRules,
-  requestedLimit: number,
-): StoredScrapeRules {
-  const limit = Math.min(scrapeRulesLimit(rules), requestedLimit);
-  if ("articles" in rules) {
-    // SAFETY: All saved article rules use this number field.
-    return {
-      ...rules,
-      articles: { ...rules.articles, limit },
-    } as StoredScrapeRules;
-  }
-  if ("products" in rules) {
-    // SAFETY: All saved product rules use this number field.
-    return {
-      ...rules,
-      products: { ...rules.products, limit },
-    } as StoredScrapeRules;
-  }
-  if ("links" in rules.list) {
-    // SAFETY: This check identifies the current list shape.
-    return {
-      ...rules,
-      list: { ...rules.list, limit },
-    } as StoredScrapeRules;
-  }
-  // SAFETY: All remaining saved rules use maxItems.
-  return {
-    ...rules,
-    list: { ...rules.list, maxItems: limit },
-  } as StoredScrapeRules;
 }

--- a/apps/server/src/scraper/configured/runs.ts
+++ b/apps/server/src/scraper/configured/runs.ts
@@ -6,7 +6,8 @@ import {
   scrapeSources,
 } from "@peated/server/db/schema";
 import { and, desc, eq } from "drizzle-orm";
-import { parseScrapeRules, scrapeRunRequestLimit } from "./rules";
+import { loadExecutableScrapeRules } from "./compatibility";
+import { SCRAPE_RULES_VERSION, SCRAPE_SOURCE_MAX_LIST_PAGES } from "./rules";
 import {
   ScrapeSourceNotFoundError,
   ScrapeSourceValidationError,
@@ -57,7 +58,10 @@ export async function createPinnedScrapeSourceRun(
     );
   }
   const [{ source, revision }] = selected;
-  const rules = parseScrapeRules(revision.rulesVersion, revision.rules);
+  const rules = loadExecutableScrapeRules(
+    revision.rulesVersion,
+    revision.rules,
+  );
   const [run] = await connection
     .insert(externalSiteRuns)
     .values({
@@ -65,7 +69,7 @@ export async function createPinnedScrapeSourceRun(
       trigger: input.trigger,
       purpose: input.purpose,
       requestedById: input.requestedById,
-      requestLimit: scrapeRunRequestLimit(rules),
+      requestLimit: rules.limit + SCRAPE_SOURCE_MAX_LIST_PAGES,
       requestErrorCount: 0,
       recordType: rules.kind,
     })
@@ -94,14 +98,19 @@ export async function createScrapeSourceSuggestionRun(input: {
     const [latestRevision] = await tx
       .select({
         previewStatus: scrapeSourceRevisions.previewStatus,
+        rulesVersion: scrapeSourceRevisions.rulesVersion,
       })
       .from(scrapeSourceRevisions)
       .where(eq(scrapeSourceRevisions.scrapeSourceId, source.id))
       .orderBy(desc(scrapeSourceRevisions.revision))
       .limit(1);
-    if (latestRevision && latestRevision.previewStatus !== "failed") {
+    if (
+      latestRevision &&
+      latestRevision.rulesVersion === SCRAPE_RULES_VERSION &&
+      latestRevision.previewStatus !== "failed"
+    ) {
       throw new ScrapeSourceValidationError(
-        "AI repair is available only after the latest preview fails.",
+        "AI suggestions are available only when the saved rules need updating or the latest preview fails.",
       );
     }
     const [run] = await tx

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -718,6 +718,45 @@ test("stores safe validation issues when a selector stops matching", async () =>
   });
 });
 
+test("stores a safe preview issue when a request fails unexpectedly", async () => {
+  const { pinned, revision } = await setupPreview();
+  const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    return url.pathname === "/archive"
+      ? new Response('<a class="review" href="/one">One</a>')
+      : new Response(null, {
+          status: 302,
+          headers: { location: "https://undeclared.example/review" },
+        });
+  });
+
+  await expect(
+    runToCompletion({
+      runId: pinned.run.id,
+      fetchImpl,
+      executionToken: "failed-preview-owner",
+    }),
+  ).rejects.toThrow(
+    "Origin https://undeclared.example is not declared for scraper target preview-example.",
+  );
+
+  const [storedRevision] = await db
+    .select()
+    .from(scrapeSourceRevisions)
+    .where(eq(scrapeSourceRevisions.id, revision.id));
+  expect(storedRevision).toMatchObject({ previewStatus: "failed" });
+  expect(storedRevision?.previewResult).toEqual({
+    pages: [],
+    issues: [
+      {
+        field: "preview",
+        message:
+          "Preview stopped before it could finish. Check the run error, then try again.",
+      },
+    ],
+  });
+});
+
 test("a collection failure does not change the preview result", async () => {
   const { revision, site, source, user } = await setupSource("h3.missing");
   await markPreviewPassed(revision.id);

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -15,7 +15,9 @@ import {
 } from "@peated/server/schemas";
 import { and, eq } from "drizzle-orm";
 import { z } from "zod";
+import { ScraperCoordinationError } from "../coordinator";
 import { ScraperHttpStatusError, ScraperRequestWaitError } from "../http";
+import { ScraperRunTakenOverError } from "../session";
 import { catalogListingSink } from "../sinks/catalogListings";
 import { externalReviewSink } from "../sinks/externalReviews";
 import { createStorePriceSink } from "../sinks/storePrices";
@@ -28,24 +30,22 @@ import type {
   ScraperSourceDefinition,
 } from "../types";
 import {
+  loadExecutableScrapeRules,
+  type ExecutableScrapeRules,
+} from "./compatibility";
+import {
   MAX_LIKELY_LIST_PAGES,
   findAdvertisedSyndicationPages,
   findLikelyDetailPages,
   findLikelyListPages,
   inspectSyndicationFeed,
 } from "./discovery";
-import { parseScrapeDetail, parseScrapeList } from "./parser";
 import {
   ScrapeSourcePreviewPageSchema,
   type ScrapeIssue,
   type ScrapeSourcePreviewPage,
 } from "./preview";
-import {
-  SCRAPE_SOURCE_MAX_LIST_PAGES,
-  parseScrapeRules,
-  scrapeRulesLimit,
-  type StoredScrapeRules,
-} from "./rules";
+import { SCRAPE_SOURCE_MAX_LIST_PAGES } from "./rules";
 import { recordScrapeSourcePreview } from "./service";
 import { MAX_PAGES_TO_CHECK } from "./setupAgent";
 import { suggestScrapeSourceRevision } from "./suggestion";
@@ -145,19 +145,6 @@ type RecordScrapeSourcePreview = (input: {
   };
 }) => Promise<void>;
 
-function linkField(rules: StoredScrapeRules) {
-  if ("articles" in rules) return "articles.link";
-  if ("products" in rules) return "products.link";
-  if ("links" in rules.list) return "list.links";
-  return "list.detailLink";
-}
-
-function nextPageField(rules: StoredScrapeRules) {
-  if ("articles" in rules) return "articles.nextPage";
-  if ("products" in rules) return "products.nextPage";
-  return "list.nextPage";
-}
-
 const ConfiguredScrapeCursorSchema = z
   .object({
     listUrls: z.array(z.url()).max(SCRAPE_SOURCE_MAX_LIST_PAGES),
@@ -170,7 +157,7 @@ const ConfiguredScrapeCursorSchema = z
 
 type ConfiguredScrapeCursor = z.infer<typeof ConfiguredScrapeCursorSchema>;
 
-function observationSchemaForRules(rules: StoredScrapeRules) {
+function observationSchemaForRules(rules: ExecutableScrapeRules) {
   if (rules.kind === "review") return ExternalReviewArticleIngestionSchema;
   if (rules.kind === "catalog") return z.array(CatalogListingInputSchema);
   return z.array(StorePriceInputSchema);
@@ -180,7 +167,7 @@ function createScrapeSourceAdapter(
   input: {
     targetKey: string;
     listUrl: string;
-    rules: StoredScrapeRules;
+    rules: ExecutableScrapeRules;
   } & (
     | { purpose: "collect" }
     | { purpose: "preview"; recordPreview: RecordScrapeSourcePreview }
@@ -200,12 +187,12 @@ function createScrapeSourceAdapter(
       while (
         state.nextListUrl &&
         listUrls.size < SCRAPE_SOURCE_MAX_LIST_PAGES &&
-        detailUrls.size < scrapeRulesLimit(input.rules)
+        detailUrls.size < input.rules.limit
       ) {
         if (listUrls.has(state.nextListUrl)) {
           throw new ScrapeSourceParseError([
             {
-              field: nextPageField(input.rules),
+              field: input.rules.nextPageField,
               message: "Pagination returned a page that was already read.",
             },
           ]);
@@ -225,8 +212,7 @@ function createScrapeSourceAdapter(
           }
           throw error;
         }
-        const listResult = parseScrapeList(
-          input.rules,
+        const listResult = input.rules.parseList(
           listResponse.body,
           listResponse.url,
         );
@@ -235,7 +221,7 @@ function createScrapeSourceAdapter(
         }
         for (const link of listResult.links) {
           detailUrls.add(link);
-          if (detailUrls.size >= scrapeRulesLimit(input.rules)) break;
+          if (detailUrls.size >= input.rules.limit) break;
         }
         state = {
           ...state,
@@ -265,11 +251,7 @@ function createScrapeSourceAdapter(
           }
           throw error;
         }
-        const parsed = parseScrapeDetail(
-          input.rules,
-          response.body,
-          response.url,
-        );
+        const parsed = input.rules.parseDetail(response.body, response.url);
         if (parsed.issues.length > 0 || !parsed.value) {
           throw new ScrapeSourceParseError(parsed.issues);
         }
@@ -305,7 +287,7 @@ function createScrapeSourceAdapter(
                 ? []
                 : [
                     {
-                      field: linkField(input.rules),
+                      field: input.rules.listLinkField,
                       message: "No pages produced valid output.",
                     },
                   ],
@@ -316,11 +298,25 @@ function createScrapeSourceAdapter(
     } catch (error) {
       if (
         input.purpose === "preview" &&
-        error instanceof ScrapeSourceParseError
+        !(error instanceof ScraperRequestWaitError) &&
+        !(error instanceof ScraperCoordinationError) &&
+        !(error instanceof ScraperRunTakenOverError)
       ) {
         await input.recordPreview({
           status: "failed",
-          result: { issues: error.issues, pages: state.previewPages },
+          result: {
+            issues:
+              error instanceof ScrapeSourceParseError
+                ? error.issues
+                : [
+                    {
+                      field: "preview",
+                      message:
+                        "Preview stopped before it could finish. Check the run error, then try again.",
+                    },
+                  ],
+            pages: state.previewPages,
+          },
         });
       }
       throw error;
@@ -333,7 +329,7 @@ export function createLocalScrapeSourcePreview(input: {
   siteKey: string;
   targetKey: string;
   listUrl: string;
-  rules: StoredScrapeRules;
+  rules: ExecutableScrapeRules;
   recordPreview: RecordScrapeSourcePreview;
 }): ScraperSourceDefinition<ConfiguredScrapeCursor, unknown> {
   return {
@@ -364,7 +360,7 @@ function createScrapeSourceDefinition(input: {
   targetKey: string;
   listUrl: string;
   purpose: "collect" | "preview";
-  rules: StoredScrapeRules;
+  rules: ExecutableScrapeRules;
 }): ScraperSourceDefinition<ConfiguredScrapeCursor, unknown> {
   const observationSchema = observationSchemaForRules(input.rules);
   const sink: ScraperSink<unknown> =
@@ -694,7 +690,10 @@ export async function resolveScrapeSourceRunRegistry(
     .where(eq(scrapeSourceRuns.externalSiteRunId, runId));
   if (!row) return baseRegistry;
 
-  const rules = parseScrapeRules(row.revision.rulesVersion, row.revision.rules);
+  const rules = loadExecutableScrapeRules(
+    row.revision.rulesVersion,
+    row.revision.rules,
+  );
   if (row.run.purpose === "suggest") {
     throw new Error("An AI run cannot use saved rules.");
   }

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -201,6 +201,60 @@ test("keeps immutable revisions and only activates a passing revision", async ()
   expect(updated.source.listUrl).toBe("https://versioned.example/new-archive");
 });
 
+test("allows AI to update a healthy old rule format", async () => {
+  const user = await createUser();
+  const { source } = await createSiteWithScrapeSource({
+    name: "Old Rules",
+    kind: "review",
+    websiteUrl: "https://old-rules.example/",
+    createdById: user.id,
+  });
+  const revision = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules,
+    author: "person",
+    createdById: user.id,
+  });
+  await markPreviewPassed(revision.id);
+  await db
+    .update(scrapeSourceRevisions)
+    .set({ rulesVersion: 10 })
+    .where(eq(scrapeSourceRevisions.id, revision.id));
+
+  await expect(
+    createScrapeSourceSuggestionRun({
+      scrapeSourceId: source.id,
+      requestedById: user.id,
+    }),
+  ).resolves.toMatchObject({ purpose: "suggest", status: "queued" });
+});
+
+test("does not replace a healthy current rule format", async () => {
+  const user = await createUser();
+  const { source } = await createSiteWithScrapeSource({
+    name: "Current Rules",
+    kind: "review",
+    websiteUrl: "https://current-rules.example/",
+    createdById: user.id,
+  });
+  const revision = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules,
+    author: "person",
+    createdById: user.id,
+  });
+  await markPreviewPassed(revision.id);
+
+  await expect(
+    createScrapeSourceSuggestionRun({
+      scrapeSourceId: source.id,
+      requestedById: user.id,
+    }),
+  ).rejects.toThrow(
+    "AI suggestions are available only when the saved rules need updating or the latest preview fails.",
+  );
+});
+
 test("an old worker cannot overwrite a preview after another worker takes over", async () => {
   const user = await createUser();
   const { site, source } = await createSiteWithScrapeSource({

--- a/apps/server/src/scraper/configured/service.ts
+++ b/apps/server/src/scraper/configured/service.ts
@@ -123,7 +123,7 @@ async function keepOriginalReview(
 }
 
 /** Keeps original review IDs when new rules change how reviews are matched. */
-// TODO(scraper): Remove this repair after every review source uses version 10
+// TODO(scraper): Remove this repair after every review source uses version 11
 // and all saved reviews are matched by name and writer.
 async function prepareReviewKeysForActivation(
   tx: AnyDatabase,

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -246,6 +246,114 @@ test("returns rules only after the rule check passes", async () => {
   expect(secondRequest?.instructions).toContain("Review of {value}");
 });
 
+test("gives the agent the active setup as migration evidence", async () => {
+  const request = vi
+    .fn()
+    .mockResolvedValue(toolCallResponse("migrated", reviewRuleCheck("h1")));
+
+  await runScrapeSourceSetupAgent({
+    conversationId: "scrape_source:1",
+    externalSiteRunId: 10,
+    kind: "review",
+    scrapeSourceId: 1,
+    listPages: [
+      {
+        url: "https://example.test/reviews",
+        html: '<a class="review" href="/reviews/one">Review</a>',
+      },
+    ],
+    detailPages: [],
+    previousSetup: {
+      listPageUrl: "https://example.test/reviews",
+      rulesVersion: 6,
+      rules: {
+        kind: "review",
+        articles: {
+          oneArticlePer: "body",
+          link: "a.review",
+          skipWhen: null,
+          nextPage: null,
+          limit: 25,
+        },
+        article: {
+          canonicalUrl: null,
+          title: {
+            try: [
+              {
+                get: "text",
+                selector: "h1",
+                take: "first",
+                startsWith: null,
+                clean: null,
+              },
+            ],
+          },
+          publishedDate: {
+            try: [
+              {
+                get: "text",
+                selector: "time",
+                take: "first",
+                startsWith: null,
+                clean: null,
+              },
+            ],
+          },
+          reviews: {
+            inside: "body",
+            oneReviewPer: "element",
+            selector: "article.review",
+            name: {
+              try: [
+                {
+                  get: "text",
+                  from: "review",
+                  selector: "h2",
+                  take: "first",
+                  startsWith: null,
+                  clean: null,
+                },
+              ],
+            },
+            reviewer: null,
+            tastingNotes: null,
+            score: null,
+          },
+        },
+      },
+      matchedPageUrls: ["https://example.test/reviews/one"],
+    },
+    request,
+    checkRules: async () => ({
+      status: "passed" as const,
+      checked: "parsed review",
+    }),
+  });
+
+  const firstRequest = request.mock.calls[0]?.[0];
+  expect(firstRequest?.input).toMatchObject([
+    {
+      role: "user",
+      content: expect.stringContaining(
+        '"matchedPageUrls":["https://example.test/reviews/one"]',
+      ),
+    },
+  ]);
+  expect(firstRequest?.input).toMatchObject([
+    {
+      content: expect.stringContaining('"rulesVersion":6'),
+    },
+  ]);
+  expect(firstRequest?.input).toMatchObject([
+    {
+      content: expect.stringContaining('"link":"a.review"'),
+    },
+  ]);
+  expect(firstRequest?.instructions).toContain(
+    "preserve the kinds of items its working rules included and excluded",
+  );
+});
+
 test("accepts catalog rules without price or review fields", async () => {
   const request = vi
     .fn()

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -14,13 +14,14 @@ import {
   ScrapePriceRulesSchema,
   ScrapeReviewRulesSchema,
   type ScrapeRules,
+  type StoredScrapeRules,
 } from "./rules";
 import {
   ScrapeSourceSetupError,
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v22";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v23";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_PAGES_TO_CHECK = 3;
 const MAX_RULE_CHECKS = 3;
@@ -121,6 +122,7 @@ const RULE_INSTRUCTIONS = [
   "Set reviewer when the page shows an author or byline, including when it appears once for the whole article. Code shares one article-level reviewer across its reviews.",
   "Set tastingNotes only when a narrower selector reliably finds flavor notes. The full review body comes from the review area or item.",
   "Use an optional field only when every given page clearly provides it.",
+  "When previousSetup is given, preserve the kinds of items its working rules included and excluded. Use its rules and matchedPageUrls as evidence, but submit only fields allowed by check_rules.",
   "For catalog sources, collect only the displayed name, product URL, stable product ID, image URL, volume, ABV, age, edition, and release year.",
   "Catalog sources do not require a review, price, currency, or volume. Do not select descriptions or tasting notes.",
   "A nextPage selector must lead to a page with new links.",
@@ -244,6 +246,12 @@ type ScrapeSourceSetupAgentInput<T> = {
   scrapeSourceId: number;
   listPages: WebsitePage[];
   detailPages: WebsitePage[];
+  previousSetup?: {
+    listPageUrl: string;
+    rulesVersion: number;
+    rules: StoredScrapeRules;
+    matchedPageUrls: string[];
+  };
   request: (
     request: SetupAgentModelRequest,
   ) => Promise<SetupAgentModelResponse>;
@@ -347,6 +355,7 @@ export async function runScrapeSourceSetupAgent<T>(
     kind: input.kind,
     startPages: pages.slice(0, input.listPages.length),
     examplePages: pages.slice(input.listPages.length),
+    previousSetup: input.previousSetup,
   });
   return await runAgent({
     details: {

--- a/apps/server/src/scraper/configured/sourceCompatibility.test.ts
+++ b/apps/server/src/scraper/configured/sourceCompatibility.test.ts
@@ -1,0 +1,31 @@
+import { expect, it } from "vitest";
+import {
+  applyDetailPageUrlCompatibility,
+  readCompatiblePublishedDate,
+} from "./sourceCompatibility";
+
+it("adds the GlenAllachie UK storefront parameter to product URLs", () => {
+  expect(
+    applyDetailPageUrlCompatibility(
+      new URL("https://shop.theglenallachie.com/products/example"),
+    ).toString(),
+  ).toBe("https://shop.theglenallachie.com/products/example?country=GB");
+  expect(
+    applyDetailPageUrlCompatibility(
+      new URL("https://shop.theglenallachie.com/collections/example"),
+    ).toString(),
+  ).toBe("https://shop.theglenallachie.com/collections/example");
+});
+
+it("reads Whiskyfun's compact article date", () => {
+  expect(
+    readCompatiblePublishedDate(
+      new URL("https://www.whiskyfun.com/2026/example-article-090826.html"),
+    ),
+  ).toEqual(new Date("2026-09-08T00:00:00.000Z"));
+  expect(
+    readCompatiblePublishedDate(
+      new URL("https://example.test/2026/example-article-090826.html"),
+    ),
+  ).toBeNull();
+});

--- a/apps/server/src/scraper/configured/sourceCompatibility.ts
+++ b/apps/server/src/scraper/configured/sourceCompatibility.ts
@@ -1,0 +1,55 @@
+type SourceCompatibility = {
+  matches(url: URL): boolean;
+  detailPageUrl?(url: URL): URL;
+  publishedDateFromUrl?(url: URL): Date | null;
+};
+
+function createDate(year: number, month: number, day: number) {
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+    ? date
+    : null;
+}
+
+const SOURCE_COMPATIBILITY: SourceCompatibility[] = [
+  {
+    matches: (url) => url.hostname === "shop.theglenallachie.com",
+    detailPageUrl: (url) => {
+      if (url.pathname.startsWith("/products/")) {
+        url.searchParams.set("country", "GB");
+      }
+      return url;
+    },
+  },
+  {
+    matches: (url) => url.hostname.endsWith("whiskyfun.com"),
+    publishedDateFromUrl: (url) => {
+      const compact = url.pathname.match(
+        /(?:^|\D)(\d{2})(\d{2})(\d{2})(?:\D|$)/u,
+      );
+      return compact
+        ? createDate(
+            2000 + Number(compact[3]),
+            Number(compact[1]),
+            Number(compact[2]),
+          )
+        : null;
+    },
+  },
+];
+
+export function applyDetailPageUrlCompatibility(url: URL) {
+  const compatibility = SOURCE_COMPATIBILITY.find((candidate) =>
+    candidate.matches(url),
+  );
+  return compatibility?.detailPageUrl?.(url) ?? url;
+}
+
+export function readCompatiblePublishedDate(url: URL) {
+  const compatibility = SOURCE_COMPATIBILITY.find((candidate) =>
+    candidate.matches(url),
+  );
+  return compatibility?.publishedDateFromUrl?.(url) ?? null;
+}

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -11,9 +11,8 @@ import { and, eq } from "drizzle-orm";
 import { setTimeout as wait } from "node:timers/promises";
 import { createScraperRegistry } from "../definitions";
 import { executeScraperRun } from "../runs";
-import { parseScrapeDetail, parseScrapeList } from "./parser";
+import { loadExecutableScrapeRules } from "./compatibility";
 import { ScrapeSourcePreviewResultSchema } from "./preview";
-import { parseScrapeRules } from "./rules";
 import {
   createPinnedScrapeSourceRun,
   createScrapeSourceSuggestionRun,
@@ -240,12 +239,11 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         },
       });
 
-      const rules = parseScrapeRules(
+      const rules = loadExecutableScrapeRules(
         suggestedRevision.rulesVersion,
         suggestedRevision.rules,
       );
-      const listResult = parseScrapeList(
-        rules,
+      const listResult = rules.parseList(
         getFixtureHtml(LIST_URL),
         new URL(LIST_URL),
       );
@@ -259,11 +257,7 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         SECOND_PRODUCT_URL,
         THIRD_PRODUCT_URL,
       ].map((url) => {
-        const result = parseScrapeDetail(
-          rules,
-          getFixtureHtml(url),
-          new URL(url),
-        );
+        const result = rules.parseDetail(getFixtureHtml(url), new URL(url));
         expect(result.issues).toEqual([]);
         if (result.kind !== "price") {
           throw new Error("Generated rules did not parse a price page.");

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -13,6 +13,7 @@ import { createScraperRegistry } from "../definitions";
 import { executeScraperRun } from "../runs";
 import { loadExecutableScrapeRules } from "./compatibility";
 import { ScrapeSourcePreviewResultSchema } from "./preview";
+import type { StoredScrapeRules } from "./rules";
 import {
   createPinnedScrapeSourceRun,
   createScrapeSourceSuggestionRun,
@@ -27,6 +28,20 @@ const SECOND_LIST_URL = `${SITE_ORIGIN}/shop?page=2`;
 const FIRST_PRODUCT_URL = `${SITE_ORIGIN}/products/coastal-12`;
 const SECOND_PRODUCT_URL = `${SITE_ORIGIN}/products/orchard-blend`;
 const THIRD_PRODUCT_URL = `${SITE_ORIGIN}/products/highland-cask`;
+const BRUICHLADDICH_ORIGIN = "https://bruichladdich-fixture.test";
+const BRUICHLADDICH_HOME_URL = `${BRUICHLADDICH_ORIGIN}/`;
+const BRUICHLADDICH_LIST_URL = `${BRUICHLADDICH_ORIGIN}/collections/all-whisky`;
+const BRUICHLADDICH_PRODUCT_SLUGS = [
+  "classic-laddie",
+  "islay-barley",
+  "port-charlotte-10",
+  "octomore-15-1",
+  "bere-barley",
+] as const;
+const BRUICHLADDICH_PRODUCT_URLS = BRUICHLADDICH_PRODUCT_SLUGS.map(
+  (slug) => `${BRUICHLADDICH_ORIGIN}/products/${slug}`,
+);
+const BRUICHLADDICH_MERCH_URL = `${BRUICHLADDICH_ORIGIN}/products/laddie-t-shirt`;
 
 const WEBSITE_PAGES = new Map([
   [
@@ -126,6 +141,111 @@ const WEBSITE_PAGES = new Map([
   ],
 ]);
 
+// Regression fixture for Bruichladdich's mixed whisky and merchandise grid,
+// observed on its public shop on 2026-09-09.
+const BRUICHLADDICH_PAGES = new Map<string, string>([
+  [
+    BRUICHLADDICH_HOME_URL,
+    '<main><h1>Bruichladdich</h1><a href="/collections/all-whisky">Shop whisky</a></main>',
+  ],
+  [
+    BRUICHLADDICH_LIST_URL,
+    `<main><h1>All products</h1>
+      ${[
+        ["Bruichladdich", "classic-laddie", "The Classic Laddie", "grey"],
+        ["Bruichladdich", "islay-barley", "Islay Barley", "grey"],
+        ["Port Charlotte", "port-charlotte-10", "Port Charlotte 10", "grey"],
+        ["Octomore", "octomore-15-1", "Octomore 15.1", "grey"],
+        ["Projects", "bere-barley", "Bere Barley", "grey"],
+        ["Clothing", "laddie-t-shirt", "Laddie T-Shirt", "outline"],
+      ]
+        .map(
+          ([category, slug, name, button]) => `
+            <article class="collection-products-tile">
+              <p class="collection-products-tile__collection-title">${category}</p>
+              <div class="collection-products-tile__image-wrap">
+                <a href="/products/${slug}"><img alt="${name}"></a>
+              </div>
+              <h2>${name}</h2>
+              <div class="collection-products-tile__actions">
+                <a class="button button--${button}" href="/products/${slug}">Discover</a>
+              </div>
+            </article>`,
+        )
+        .join("")}
+    </main>`,
+  ],
+  ...BRUICHLADDICH_PRODUCT_SLUGS.map(
+    (slug, index) =>
+      [
+        `${BRUICHLADDICH_ORIGIN}/products/${slug}`,
+        `<main class="product-page">
+          <h1 class="product-title">${["The Classic Laddie", "Islay Barley", "Port Charlotte 10", "Octomore 15.1", "Bere Barley"][index]}</h1>
+          <p class="product-price">£${55 + index * 10}.00</p>
+          <p class="product-volume">700 ml</p>
+        </main>`,
+      ] as const,
+  ),
+  [
+    BRUICHLADDICH_MERCH_URL,
+    '<main class="product-page"><h1 class="product-title">Laddie T-Shirt</h1><p class="product-price">£25.00</p><label>Size</label></main>',
+  ],
+]);
+
+const BRUICHLADDICH_V6_RULES = {
+  kind: "price",
+  products: {
+    oneProductPer: ".collection-products-tile",
+    link: ".collection-products-tile__image-wrap a[href]",
+    skipWhen: {
+      selector: ".collection-products-tile__collection-title",
+      startsWith: ["Accessories", "Clothing", "Glassware"],
+    },
+    nextPage: null,
+    limit: 100,
+  },
+  product: {
+    name: {
+      try: [
+        {
+          get: "text",
+          selector: ".product-title",
+          take: "first",
+          startsWith: null,
+          clean: null,
+        },
+      ],
+    },
+    price: {
+      try: [
+        {
+          get: "text",
+          selector: ".product-price",
+          take: "first",
+          startsWith: null,
+          clean: null,
+        },
+      ],
+    },
+    currency: "gbp",
+    volume: {
+      try: [
+        {
+          get: "text",
+          selector: ".product-volume",
+          take: "first",
+          startsWith: null,
+          clean: null,
+        },
+      ],
+    },
+    url: null,
+    externalProductId: null,
+    imageUrl: null,
+    barcode: null,
+  },
+} as const satisfies StoredScrapeRules;
+
 function getFixtureHtml(url: string) {
   const html = WEBSITE_PAGES.get(url);
   if (html === undefined) {
@@ -134,12 +254,12 @@ function getFixtureHtml(url: string) {
   return html;
 }
 
-function createFixtureWebsite() {
+function createFixtureWebsite(pages = WEBSITE_PAGES) {
   const requests: string[] = [];
   const fetchImpl: typeof fetch = async (input) => {
     const url = new URL(input instanceof Request ? input.url : input);
     requests.push(url.toString());
-    const html = WEBSITE_PAGES.get(url.toString());
+    const html = pages.get(url.toString());
     if (html === undefined) {
       throw new Error(`Unexpected fixture website request: ${url.toString()}`);
     }
@@ -353,6 +473,132 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         SECOND_PRODUCT_URL,
         THIRD_PRODUCT_URL,
       ]);
+    });
+
+    test("preserves Bruichladdich whisky scope when migrating v6 rules", async () => {
+      const [admin] = await db
+        .insert(users)
+        .values({
+          admin: true,
+          email: "bruichladdich-scraper-eval@example.com",
+          username: "bruichladdich-scraper-eval",
+        })
+        .returning();
+      if (!admin) throw new Error("Failed to create eval admin.");
+
+      const { site, source } = await createSiteWithScrapeSource({
+        createdById: admin.id,
+        kind: "price",
+        websiteUrl: BRUICHLADDICH_HOME_URL,
+        name: "Bruichladdich Fixture",
+        sampleUrls: [],
+      });
+      await db
+        .update(scrapeTargets)
+        .set({ minimumSpacingMs: 1_000, requestsPerWindow: 3_600 })
+        .where(eq(scrapeTargets.key, site.type));
+      await db
+        .update(scrapeOrigins)
+        .set({
+          robotsMode: "not_applicable",
+          robotsRationale: "Reserved test origin has no network operator.",
+        })
+        .where(eq(scrapeOrigins.origin, BRUICHLADDICH_ORIGIN));
+      await db.insert(scrapeSourceRevisions).values({
+        scrapeSourceId: source.id,
+        revision: 1,
+        rulesVersion: 6,
+        listUrl: BRUICHLADDICH_LIST_URL,
+        rules: BRUICHLADDICH_V6_RULES,
+        author: "person",
+        active: true,
+        previewStatus: "passed",
+        previewResult: {
+          issues: [],
+          pages: BRUICHLADDICH_PRODUCT_URLS.map((url) => ({
+            kind: "price" as const,
+            url,
+            products: [],
+          })),
+        },
+        createdById: admin.id,
+      });
+
+      const fixtureWebsite = createFixtureWebsite(BRUICHLADDICH_PAGES);
+      const registry = createScraperRegistry({ sources: [], targets: [] });
+      const suggestionRun = await createScrapeSourceSuggestionRun({
+        requestedById: admin.id,
+        scrapeSourceId: source.id,
+      });
+      await expect(
+        executeScraperRun(
+          { runId: suggestionRun.id },
+          { fetchImpl: fixtureWebsite.fetchImpl, registry },
+        ),
+      ).resolves.toEqual({ status: "completed" });
+
+      const [suggestedRevision] = await db
+        .select()
+        .from(scrapeSourceRevisions)
+        .where(
+          and(
+            eq(scrapeSourceRevisions.scrapeSourceId, source.id),
+            eq(scrapeSourceRevisions.author, "ai"),
+          ),
+        );
+      if (!suggestedRevision) throw new Error("AI did not create a revision.");
+      expect(suggestedRevision).toMatchObject({
+        aiInstructionsVersion: AI_INSTRUCTIONS_VERSION,
+        listUrl: BRUICHLADDICH_LIST_URL,
+        rulesVersion: 11,
+      });
+
+      const rules = loadExecutableScrapeRules(
+        suggestedRevision.rulesVersion,
+        suggestedRevision.rules,
+      );
+      expect(
+        rules.parseList(
+          BRUICHLADDICH_PAGES.get(BRUICHLADDICH_LIST_URL)!,
+          new URL(BRUICHLADDICH_LIST_URL),
+        ),
+      ).toEqual({
+        issues: [],
+        links: BRUICHLADDICH_PRODUCT_URLS,
+        nextPageUrl: null,
+      });
+
+      const requestsBeforePreview = fixtureWebsite.requests.length;
+      const previewRun = await createPinnedScrapeSourceRun(db, {
+        externalSiteId: site.id,
+        purpose: "preview",
+        requestedById: admin.id,
+        revisionId: suggestedRevision.id,
+        scrapeSourceId: source.id,
+        trigger: "manual",
+      });
+      await expect(
+        completeSavedRun({
+          runId: previewRun.run.id,
+          fetchImpl: fixtureWebsite.fetchImpl,
+          registry,
+        }),
+      ).resolves.toEqual({ status: "completed" });
+
+      const [previewedRevision] = await db
+        .select()
+        .from(scrapeSourceRevisions)
+        .where(eq(scrapeSourceRevisions.id, suggestedRevision.id));
+      const preview = ScrapeSourcePreviewResultSchema.parse(
+        previewedRevision?.previewResult,
+      );
+      expect(preview.issues).toEqual([]);
+      expect(preview.pages.map((page) => page.url)).toEqual(
+        BRUICHLADDICH_PRODUCT_URLS,
+      );
+      expect(
+        fixtureWebsite.requests.slice(requestsBeforePreview),
+      ).not.toContain(BRUICHLADDICH_MERCH_URL);
     });
   },
 );

--- a/apps/server/src/scraper/configured/suggestion.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.test.ts
@@ -4,6 +4,7 @@ import {
   checkDetailPages,
   checkListPage,
   checkNextListPage,
+  sampleDetailLinks,
 } from "./suggestion";
 
 const reviewRules = {
@@ -240,4 +241,20 @@ test("rejects suggested rules that do not parse a detail page", async () => {
       }),
     }),
   ).rejects.toThrow("The rules did not read an article or product page.");
+});
+
+test("samples detail links across the full list", () => {
+  expect(
+    sampleDetailLinks([
+      "https://example.test/products/one",
+      "https://example.test/products/two",
+      "https://example.test/products/three",
+      "https://example.test/products/four",
+      "https://example.test/products/five",
+    ]),
+  ).toEqual([
+    "https://example.test/products/one",
+    "https://example.test/products/three",
+    "https://example.test/products/five",
+  ]);
 });

--- a/apps/server/src/scraper/configured/suggestion.ts
+++ b/apps/server/src/scraper/configured/suggestion.ts
@@ -1,10 +1,10 @@
 import type { BottleExtractedDetails } from "@peated/bottle-classifier/contract";
 import config from "@peated/server/config";
 import { db } from "@peated/server/db";
-import { scrapeSources } from "@peated/server/db/schema";
+import { scrapeSourceRevisions, scrapeSources } from "@peated/server/db/schema";
 import { createOpenAIAgentClient } from "@peated/server/lib/openaiClient";
 import type { Currency } from "@peated/server/types";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import type {
   ResponseCreateParamsNonStreaming,
   ResponseInput,
@@ -242,7 +242,7 @@ export async function checkDetailPages(input: {
     input.suppliedPages.map((page) => [new URL(page.url).toString(), page]),
   );
   const pages: CheckedDetailPage[] = [];
-  for (const link of input.listPage.links.slice(0, MAX_PAGES_TO_CHECK)) {
+  for (const link of sampleDetailLinks(input.listPage.links)) {
     const page =
       suppliedPages.get(link) ?? (await input.loadPage(new URL(link)));
     pages.push(parseDetailPage(input.rules, page));
@@ -261,13 +261,34 @@ export async function checkDetailPages(input: {
   return pages;
 }
 
+export function sampleDetailLinks(links: string[]) {
+  if (links.length <= MAX_PAGES_TO_CHECK) return links;
+  return Array.from({ length: MAX_PAGES_TO_CHECK }, (_, index) => {
+    const linkIndex = Math.round(
+      (index * (links.length - 1)) / (MAX_PAGES_TO_CHECK - 1),
+    );
+    return links[linkIndex]!;
+  });
+}
+
 async function loadAiSource(scrapeSourceId: number) {
   // Confirm the source still exists immediately before each AI request.
   const [source] = await db
     .select({
       kind: scrapeSources.kind,
+      previousListPageUrl: scrapeSourceRevisions.listUrl,
+      previousRulesVersion: scrapeSourceRevisions.rulesVersion,
+      previousRules: scrapeSourceRevisions.rules,
+      previousPreviewResult: scrapeSourceRevisions.previewResult,
     })
     .from(scrapeSources)
+    .leftJoin(
+      scrapeSourceRevisions,
+      and(
+        eq(scrapeSourceRevisions.scrapeSourceId, scrapeSources.id),
+        eq(scrapeSourceRevisions.active, true),
+      ),
+    )
     .where(eq(scrapeSources.id, scrapeSourceId));
   if (!source) throw new Error("Scrape source not found.");
   return source;
@@ -322,6 +343,18 @@ export async function suggestScrapeSourceRevision(input: {
     scrapeSourceId: input.scrapeSourceId,
     listPages: input.listPages,
     detailPages: input.detailPages,
+    previousSetup:
+      source.previousListPageUrl &&
+      source.previousRulesVersion &&
+      source.previousRules
+        ? {
+            listPageUrl: source.previousListPageUrl,
+            rulesVersion: source.previousRulesVersion,
+            rules: source.previousRules,
+            matchedPageUrls:
+              source.previousPreviewResult?.pages.map((page) => page.url) ?? [],
+          }
+        : undefined,
     request: async (request) => {
       await loadAiSource(input.scrapeSourceId);
       return await requestAi({

--- a/apps/server/src/scraper/localPreview.ts
+++ b/apps/server/src/scraper/localPreview.ts
@@ -10,12 +10,9 @@ import { syncExternalSites } from "@peated/server/lib/externalSites";
 import { ExternalSiteKeySchema } from "@peated/server/schemas/externalSites";
 import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
+import { loadExecutableScrapeRules } from "./configured/compatibility";
 import type { ScrapeSourcePreviewResult } from "./configured/preview";
-import {
-  parseScrapeRules,
-  scrapeRunRequestLimit,
-  withScrapeRulesLimit,
-} from "./configured/rules";
+import { SCRAPE_SOURCE_MAX_LIST_PAGES } from "./configured/rules";
 import { createLocalScrapeSourcePreview } from "./configured/runtime";
 import { loadScrapeSourceTarget } from "./configured/target";
 import { defineScrapeTarget } from "./definitions";
@@ -102,9 +99,12 @@ export async function runLocalScrapeSourcePreview(
 ) {
   const parsed = InputSchema.parse(input);
   const clock = options.clock ?? scraperSystemClock;
-  const parsedRules = parseScrapeRules(parsed.rulesVersion, parsed.rules);
+  const parsedRules = loadExecutableScrapeRules(
+    parsed.rulesVersion,
+    parsed.rules,
+  );
   const rules = parsed.limit
-    ? withScrapeRulesLimit(parsedRules, parsed.limit)
+    ? parsedRules.withLimit(parsed.limit)
     : parsedRules;
 
   await syncExternalSites();
@@ -202,7 +202,7 @@ export async function runLocalScrapeSourcePreview(
       externalSiteId: site.id,
       trigger: "manual",
       purpose: "preview",
-      requestLimit: scrapeRunRequestLimit(rules),
+      requestLimit: rules.limit + SCRAPE_SOURCE_MAX_LIST_PAGES,
       requestErrorCount: 0,
     })
     .returning();

--- a/apps/server/src/scraper/sinks/externalReviews.test.ts
+++ b/apps/server/src/scraper/sinks/externalReviews.test.ts
@@ -19,7 +19,6 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { parseDramfaceArticle } from "../adapters/dramface";
 import { parseWhiskyNotesArticle } from "../adapters/whiskyNotes";
 import { parseWordsOfWhiskyArticle } from "../adapters/wordsOfWhisky";
-import { parseScrapeDetail } from "../configured/parser";
 import { externalReviewSink } from "./externalReviews";
 
 const wordsOfWhiskyPolicy: ExternalReviewScoringPolicy = {
@@ -78,48 +77,6 @@ const wordsOfWhiskyCapture: CapturedReviewCase = {
 
 const captures: CapturedReviewCase[] = [
   wordsOfWhiskyCapture,
-  {
-    ...wordsOfWhiskyCapture,
-    label: "Words of Whisky saved scraper rules",
-    parse: (html, url) => {
-      const result = parseScrapeDetail(
-        {
-          kind: "review",
-          list: {
-            detailLink: {
-              selector: "article.category-tastingnotes a",
-              attribute: "href",
-            },
-            maxItems: 20,
-          },
-          detail: {
-            title: { selector: ".post-wrap .entry-title" },
-            publishedAt: {
-              selector: ".post-wrap time.entry-date",
-              attribute: "datetime",
-            },
-            reviewItem: ".post-wrap .entry-content",
-            name: { selector: "h2" },
-            reviewerName: { selector: ".side-author__wrap .side-meta .title" },
-            score: {
-              value: { selector: ".lets-review-block__final-score" },
-              scale: 10,
-            },
-          },
-        },
-        html,
-        url,
-      );
-      expect(result.issues).toEqual([]);
-      if (result.kind !== "review" || !result.value)
-        throw new Error("Expected a parsed review.");
-      return result.value;
-    },
-    reviews: wordsOfWhiskyCapture.reviews.map((review) => ({
-      ...review,
-      nativeScore: { ...review.nativeScore, display: "8.7" },
-    })),
-  },
   {
     label: "Dramface published score with a different hypothetical score",
     site: "dramface",

--- a/apps/server/src/serializers/scrapeSource.ts
+++ b/apps/server/src/serializers/scrapeSource.ts
@@ -10,8 +10,8 @@ import type {
   ScrapeSourceRevisionSchema,
   ScrapeSourceSchema,
 } from "../schemas";
+import { loadExecutableScrapeRules } from "../scraper/configured/compatibility";
 import { ScrapeSourcePreviewResultSchema } from "../scraper/configured/preview";
-import { parseScrapeRules } from "../scraper/configured/rules";
 import { serializeExternalSite } from "./externalSite";
 
 function serializeRevisionAuthor(revision: ScrapeSourceRevision) {
@@ -41,7 +41,8 @@ function revisionItem(
     revision: revision.revision,
     rulesVersion: revision.rulesVersion,
     listUrl: revision.listUrl,
-    rules: parseScrapeRules(revision.rulesVersion, revision.rules),
+    rules: loadExecutableScrapeRules(revision.rulesVersion, revision.rules)
+      .storedRules,
     active: revision.active,
     ...serializeRevisionAuthor(revision),
     previewStatus: revision.previewStatus,

--- a/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
+++ b/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
@@ -23,7 +23,10 @@ import {
   AdminTextField,
 } from "./adminForm.stylex";
 import { AdminEmptyActivity } from "./adminUtility.stylex";
-import { getSetupAfterLatestVersion } from "./scraperParsingStatus";
+import {
+  getSetupAfterLatestVersion,
+  needsScrapeRulesUpdate,
+} from "./scraperParsingStatus";
 import { ScraperPreviewResult } from "./scraperPreviewResult.stylex";
 
 type Source = Outputs["externalSites"]["scrapeSources"]["list"][number];
@@ -100,9 +103,10 @@ export function ScraperParsingEditor({
     (revision) => revision.id === source.activeRevisionId,
   );
   const setup = getSetupAfterLatestVersion(source);
+  const needsRulesUpdate = needsScrapeRulesUpdate(source);
   const canSuggest =
     (!setup || setup.status === "failed") &&
-    (!latest || latest.previewStatus === "failed");
+    (!latest || latest.previewStatus === "failed" || needsRulesUpdate);
   const setupSteps = getSetupSteps(source);
   const setupDescription = getSetupDescription(source);
   const previewRevisionId =
@@ -182,11 +186,13 @@ export function ScraperParsingEditor({
                 })
               }
             >
-              {latest
-                ? "Ask AI to repair"
-                : setup
-                  ? "Retry AI setup"
-                  : "Start AI setup"}
+              {needsRulesUpdate
+                ? "Update parsing rules"
+                : latest
+                  ? "Ask AI to repair"
+                  : setup
+                    ? "Retry AI setup"
+                    : "Start AI setup"}
             </AdminButton>
           ) : undefined
         }
@@ -460,6 +466,9 @@ function getSetupDescription(source: Source) {
       : "The generated version is loading.";
   }
   const latest = source.revisions[0];
+  if (needsScrapeRulesUpdate(source)) {
+    return "This source uses an older rule format. Create and test an updated version before activating it.";
+  }
   if (latest?.previewStatus === "failed") {
     return "The latest version needs repair.";
   }

--- a/apps/web/src/components/admin/scraperParsingStatus.test.ts
+++ b/apps/web/src/components/admin/scraperParsingStatus.test.ts
@@ -1,5 +1,9 @@
+import { SCRAPE_RULES_VERSION } from "@peated/server/schemas";
 import { describe, expect, it } from "vitest";
-import { getSetupAfterLatestVersion } from "./scraperParsingStatus";
+import {
+  getSetupAfterLatestVersion,
+  needsScrapeRulesUpdate,
+} from "./scraperParsingStatus";
 
 const failedSetup = {
   runId: 1,
@@ -32,5 +36,24 @@ describe("getSetupAfterLatestVersion", () => {
     expect(
       getSetupAfterLatestVersion({ setup: failedSetup, revisions: [] }),
     ).toEqual(failedSetup);
+  });
+});
+
+describe("needsScrapeRulesUpdate", () => {
+  it("finds a latest version that predates the current rule format", () => {
+    expect(
+      needsScrapeRulesUpdate({
+        revisions: [{ rulesVersion: SCRAPE_RULES_VERSION - 1 }],
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts the current rule format and an empty history", () => {
+    expect(
+      needsScrapeRulesUpdate({
+        revisions: [{ rulesVersion: SCRAPE_RULES_VERSION }],
+      }),
+    ).toBe(false);
+    expect(needsScrapeRulesUpdate({ revisions: [] })).toBe(false);
   });
 });

--- a/apps/web/src/components/admin/scraperParsingStatus.ts
+++ b/apps/web/src/components/admin/scraperParsingStatus.ts
@@ -1,4 +1,5 @@
 import type { Outputs } from "@peated/server/orpc/router";
+import { SCRAPE_RULES_VERSION } from "@peated/server/schemas";
 
 type Source = Outputs["externalSites"]["scrapeSources"]["list"][number];
 type Setup = Source["setup"];
@@ -16,4 +17,11 @@ export function getSetupAfterLatestVersion(source: {
   return Date.parse(setup.createdAt) > Date.parse(latest.createdAt)
     ? setup
     : null;
+}
+
+export function needsScrapeRulesUpdate(source: {
+  revisions: { rulesVersion: number }[];
+}) {
+  const latest = source.revisions[0];
+  return Boolean(latest && latest.rulesVersion < SCRAPE_RULES_VERSION);
 }


### PR DESCRIPTION
Saved parsing-rule revisions now load through one versioned executable contract. Each production-backed version owns its validation and historical review-key behavior; versions 2, 4, and 5 are removed because production has no revisions using them. The generic parser no longer infers historical behavior from JSON shape, and source-specific exceptions now live in an explicit compatibility registry.

When Peated suggests a current replacement, the setup agent now receives the active rules and prior matched page URLs as migration evidence. Validation samples the first, middle, and last matched pages, so a selector cannot pass merely because the first few products are valid. A live mixed whisky-and-merchandise storefront eval covers this regression and verifies the generated v11 rules through a saved preview.

Legacy sources can request a v11 replacement even when their active revision is healthy, with the admin UI presenting that action as an update. Unexpected preview errors now persist a failed result instead of leaving a revision pending, while coordination and takeover errors retain their existing retry behavior. Saved revisions remain immutable and every replacement must still pass preview before activation.

Closes #1197
Refs #1210
