### PR TITLE
fix(scraper): preserve useful setup evidence

### DIFF
--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -126,6 +126,31 @@ test("keeps links and review facts after a large page header", () => {
   expect(pages[0]!.html).toContain("/* page script */");
 });
 
+test("keeps review facts after abnormally large HTML attributes", () => {
+  const oversizedMapName = "Map".repeat(30_000);
+  const [prepared] = preparePagesForSetup([
+    {
+      url: "https://example.test/reviews/one",
+      html: `<html><body>
+        <map name="${oversizedMapName}"><area href="#reviews"></map>
+        <article class="review">
+          <h1>Autumn reviews</h1>
+          <time datetime="2026-09-08">September 8</time>
+          <h2 class="bottle-name">North Coast 12</h2>
+          <p>Orange and oak.</p>
+        </article>
+      </body></html>`,
+    },
+  ]);
+  const $ = load(prepared!.html);
+
+  expect(prepared!.html.length).toBeLessThanOrEqual(75_000);
+  expect($("map").attr("name")).toHaveLength(500);
+  expect($("article.review .bottle-name").text()).toBe("North Coast 12");
+  expect($("article.review time").attr("datetime")).toBe("2026-09-08");
+  expect($("article.review p").text()).toBe("Orange and oak.");
+});
+
 test("keeps feed links visible to the setup agent", () => {
   const [prepared] = preparePagesForSetup([
     {

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -21,11 +21,12 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v23";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v24";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_PAGES_TO_CHECK = 3;
 const MAX_RULE_CHECKS = 3;
 const MAX_AI_PAGE_CHARS = 75_000;
+const MAX_AI_ATTRIBUTE_CHARS = 500;
 const CHECK_RULES_TOOL_NAME = "check_rules";
 const CHECK_RULES_TOOL_DESCRIPTION =
   "Try a complete set of rules on the given website pages. Rules that pass are ready to save.";
@@ -166,6 +167,14 @@ export function preparePagesForSetup(pages: WebsitePage[]) {
     );
     // Remove page code before shortening the HTML so the useful content remains.
     $("script, style").remove();
+    $("*").each((_, element) => {
+      if (element.type !== "tag") return;
+      for (const [name, value] of Object.entries(element.attribs)) {
+        if (value.length > MAX_AI_ATTRIBUTE_CHARS) {
+          element.attribs[name] = value.slice(0, MAX_AI_ATTRIBUTE_CHARS);
+        }
+      }
+    });
     return {
       url: page.url,
       html: $.html().slice(0, charsPerPage),

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -42,6 +42,13 @@ const BRUICHLADDICH_PRODUCT_URLS = BRUICHLADDICH_PRODUCT_SLUGS.map(
   (slug) => `${BRUICHLADDICH_ORIGIN}/products/${slug}`,
 );
 const BRUICHLADDICH_MERCH_URL = `${BRUICHLADDICH_ORIGIN}/products/laddie-t-shirt`;
+const WHISKYFUN_ORIGIN = "https://www.whiskyfun.com";
+const WHISKYFUN_FEED_URL = `${WHISKYFUN_ORIGIN}/whatsnew.xml`;
+const WHISKYFUN_ARTICLE_URLS = [
+  `${WHISKYFUN_ORIGIN}/2026/A-trio-of-coastal-malts-090826.html`,
+  `${WHISKYFUN_ORIGIN}/2026/Two-old-island-malts-080826.html`,
+  `${WHISKYFUN_ORIGIN}/2026/A-pair-of-highlanders-070826.html`,
+] as const;
 
 const WEBSITE_PAGES = new Map([
   [
@@ -246,6 +253,120 @@ const BRUICHLADDICH_V6_RULES = {
   },
 } as const satisfies StoredScrapeRules;
 
+function whiskyfunArticle(
+  title: string,
+  reviews: Array<[name: string, notes: string, score: number]>,
+) {
+  const oversizedMapName = "Map".repeat(30_000);
+  return `<!doctype html><html><head><title>${title}</title></head><body>
+    <map name="${oversizedMapName}"><area href="#reviews"></map>
+    <table id="reviews"><tbody>${reviews
+      .map(
+        ([name, notes, score]) => `<tr><td class="TextenormalNEW">
+          <span class="textegrandfoncegras">${name}</span>
+          <p>${notes}</p><strong>SGP:561 - ${score} points.</strong>
+        </td></tr>`,
+      )
+      .join("")}</tbody></table>
+  </body></html>`;
+}
+
+const WHISKYFUN_REVIEWS = [
+  ["Coastal Malt 12 yo", "Coastal Malt 18 yo", "Coastal Malt 25 yo"],
+  ["Island Malt 10 yo", "Island Malt 21 yo"],
+  ["Highland Malt 8 yo", "Highland Malt 30 yo"],
+] as const;
+
+const WHISKYFUN_PAGES = new Map<string, string>([
+  [
+    WHISKYFUN_FEED_URL,
+    `<?xml version="1.0"?><rss><channel>${WHISKYFUN_ARTICLE_URLS.map(
+      (url, index) =>
+        `<item><title>Whisky article ${index + 1}</title><link>${url}</link></item>`,
+    ).join("")}</channel></rss>`,
+  ],
+  ...WHISKYFUN_ARTICLE_URLS.map(
+    (url, index) =>
+      [
+        url,
+        whiskyfunArticle(
+          `Whisky article ${index + 1}`,
+          WHISKYFUN_REVIEWS[index]!.map((name, reviewIndex) => [
+            name,
+            `Tasting notes for ${name}.`,
+            87 + reviewIndex,
+          ]),
+        ),
+      ] as const,
+  ),
+]);
+
+const WHISKYFUN_V9_RULES = {
+  kind: "review",
+  articles: {
+    document: "xml",
+    oneArticlePer: "item",
+    link: "link",
+    skipWhen: null,
+    nextPage: null,
+    limit: 25,
+  },
+  article: {
+    canonicalUrl: null,
+    title: {
+      try: [
+        {
+          get: "text",
+          selector: "title",
+          take: "first",
+          match: null,
+          addStart: null,
+          addEnd: null,
+        },
+      ],
+    },
+    publishedDate: {
+      try: [{ get: "dateFromUrl", format: "*ddMMyy.html" }],
+    },
+    reviews: {
+      inside: "body",
+      oneReviewPer: "element",
+      selector: "td.TextenormalNEW",
+      contains: ".textegrandfoncegras",
+      name: {
+        try: [
+          {
+            get: "text",
+            from: "review",
+            selector: ".textegrandfoncegras",
+            take: "first",
+            match: null,
+            addStart: null,
+            addEnd: null,
+          },
+        ],
+      },
+      reviewer: null,
+      tastingNotes: null,
+      score: {
+        try: [
+          {
+            get: "text",
+            from: "review",
+            selector: "strong",
+            take: "first",
+            match: null,
+            addStart: null,
+            addEnd: null,
+          },
+        ],
+        scale: 100,
+        map: null,
+      },
+    },
+  },
+} as const satisfies StoredScrapeRules;
+
 function getFixtureHtml(url: string) {
   const html = WEBSITE_PAGES.get(url);
   if (html === undefined) {
@@ -291,7 +412,7 @@ async function completeSavedRun({
 }
 
 describe.skipIf(!isAIGatewayConfigured("scraper"))(
-  "price rule suggestion eval",
+  "rule suggestion eval",
   () => {
     test("generated selectors extract the exact price fields", async () => {
       const [admin] = await db
@@ -599,6 +720,121 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
       expect(
         fixtureWebsite.requests.slice(requestsBeforePreview),
       ).not.toContain(BRUICHLADDICH_MERCH_URL);
+    });
+
+    test("migrates noisy multi-review pages to working v11 rules", async () => {
+      const [admin] = await db
+        .insert(users)
+        .values({
+          admin: true,
+          email: "whiskyfun-scraper-eval@example.com",
+          username: "whiskyfun-scraper-eval",
+        })
+        .returning();
+      if (!admin) throw new Error("Failed to create eval admin.");
+
+      const { site, source } = await createSiteWithScrapeSource({
+        createdById: admin.id,
+        kind: "review",
+        websiteUrl: WHISKYFUN_FEED_URL,
+        name: "Whiskyfun Fixture",
+        sampleUrls: [],
+      });
+      await db
+        .update(scrapeTargets)
+        .set({ minimumSpacingMs: 1_000, requestsPerWindow: 3_600 })
+        .where(eq(scrapeTargets.key, site.type));
+      await db
+        .update(scrapeOrigins)
+        .set({
+          robotsMode: "not_applicable",
+          robotsRationale: "The eval intercepts this public origin.",
+        })
+        .where(eq(scrapeOrigins.origin, WHISKYFUN_ORIGIN));
+      await db.insert(scrapeSourceRevisions).values({
+        scrapeSourceId: source.id,
+        revision: 1,
+        rulesVersion: 9,
+        listUrl: WHISKYFUN_FEED_URL,
+        rules: WHISKYFUN_V9_RULES,
+        author: "person",
+        active: true,
+        previewStatus: "passed",
+        previewResult: {
+          issues: [],
+          pages: WHISKYFUN_ARTICLE_URLS.map((url) => ({
+            kind: "review" as const,
+            url,
+            title: "Prior preview",
+            publishedAt: null,
+            reviews: [],
+          })),
+        },
+        createdById: admin.id,
+      });
+
+      const fixtureWebsite = createFixtureWebsite(WHISKYFUN_PAGES);
+      const registry = createScraperRegistry({ sources: [], targets: [] });
+      const suggestionRun = await createScrapeSourceSuggestionRun({
+        requestedById: admin.id,
+        scrapeSourceId: source.id,
+      });
+      await expect(
+        executeScraperRun(
+          { runId: suggestionRun.id },
+          { fetchImpl: fixtureWebsite.fetchImpl, registry },
+        ),
+      ).resolves.toEqual({ status: "completed" });
+
+      const [suggestedRevision] = await db
+        .select()
+        .from(scrapeSourceRevisions)
+        .where(
+          and(
+            eq(scrapeSourceRevisions.scrapeSourceId, source.id),
+            eq(scrapeSourceRevisions.author, "ai"),
+          ),
+        );
+      if (!suggestedRevision) throw new Error("AI did not create a revision.");
+      expect(suggestedRevision).toMatchObject({
+        aiInstructionsVersion: AI_INSTRUCTIONS_VERSION,
+        listUrl: WHISKYFUN_FEED_URL,
+        rulesVersion: 11,
+      });
+
+      const rules = loadExecutableScrapeRules(
+        suggestedRevision.rulesVersion,
+        suggestedRevision.rules,
+      );
+      expect(
+        rules.parseList(
+          WHISKYFUN_PAGES.get(WHISKYFUN_FEED_URL)!,
+          new URL(WHISKYFUN_FEED_URL),
+        ),
+      ).toMatchObject({
+        issues: [],
+        links: [...WHISKYFUN_ARTICLE_URLS],
+      });
+      for (const [index, url] of WHISKYFUN_ARTICLE_URLS.entries()) {
+        const parsed = rules.parseDetail(
+          WHISKYFUN_PAGES.get(url)!,
+          new URL(url),
+        );
+        expect(parsed.issues).toEqual([]);
+        if (parsed.kind !== "review" || !parsed.value) {
+          throw new Error("Generated rules did not parse a review page.");
+        }
+        expect(
+          parsed.value.article.externalReviews.map((review) => review.name),
+        ).toEqual([...WHISKYFUN_REVIEWS[index]!]);
+        expect(
+          parsed.value.article.externalReviews.map(
+            (review) => review.nativeScore?.value,
+          ),
+        ).toEqual(
+          WHISKYFUN_REVIEWS[index]!.map((_, reviewIndex) => 87 + reviewIndex),
+        );
+      }
     });
   },
 );

--- a/apps/server/src/scraper/configured/suggestion.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.test.ts
@@ -243,6 +243,34 @@ test("rejects suggested rules that do not parse a detail page", async () => {
   ).rejects.toThrow("The rules did not read an article or product page.");
 });
 
+test("reports a supplied detail page before its rules fail", async () => {
+  const checkedPages: string[] = [];
+  await expect(
+    checkDetailPages({
+      rules: reviewRules,
+      listPage: {
+        url: "https://example.test/reviews",
+        html: '<a class="review" href="/reviews/one">One</a>',
+        links: ["https://example.test/reviews/one"],
+        firstPageLinks: ["https://example.test/reviews/one"],
+        nextPageUrl: null,
+        nextPage: null,
+      },
+      suppliedPages: [
+        {
+          url: "https://example.test/reviews/one",
+          html: "<main>Unrelated page</main>",
+        },
+      ],
+      loadPage: async () => {
+        throw new Error("A supplied detail page must not be fetched again.");
+      },
+      onCheckPage: (page) => checkedPages.push(page.url),
+    }),
+  ).rejects.toThrow("The rules did not read an article or product page.");
+  expect(checkedPages).toEqual(["https://example.test/reviews/one"]);
+});
+
 test("samples detail links across the full list", () => {
   expect(
     sampleDetailLinks([

--- a/apps/server/src/scraper/configured/suggestion.ts
+++ b/apps/server/src/scraper/configured/suggestion.ts
@@ -237,6 +237,7 @@ export async function checkDetailPages(input: {
   listPage: SelectedListPage;
   suppliedPages: WebsitePage[];
   loadPage: (url: URL) => Promise<WebsitePage>;
+  onCheckPage?: (page: WebsitePage) => void;
 }): Promise<CheckedDetailPage[]> {
   const suppliedPages = new Map(
     input.suppliedPages.map((page) => [new URL(page.url).toString(), page]),
@@ -245,6 +246,7 @@ export async function checkDetailPages(input: {
   for (const link of sampleDetailLinks(input.listPage.links)) {
     const page =
       suppliedPages.get(link) ?? (await input.loadPage(new URL(link)));
+    input.onCheckPage?.(page);
     pages.push(parseDetailPage(input.rules, page));
   }
   if (pages.length === 0) {
@@ -366,17 +368,25 @@ export async function suggestScrapeSourceRevision(input: {
       });
     },
     checkRules: async (submittedRules) => {
-      const inspectedPages: WebsitePage[] = [];
+      const checkedPages = new Map<string, WebsitePage>();
+      const rememberCheckedPage = (page: WebsitePage) => {
+        checkedPages.set(new URL(page.url).toString(), page);
+      };
       const loadPage = async (url: URL) => {
         const key = url.toString();
         const cached = pageCache.get(key);
-        if (cached) return cached;
-        const page = await input.loadPage(url);
-        pageCache.set(new URL(page.url).toString(), page);
-        inspectedPages.push(page);
+        const page = cached ?? (await input.loadPage(url));
+        if (!cached) pageCache.set(new URL(page.url).toString(), page);
+        rememberCheckedPage(page);
         return page;
       };
       try {
+        const selectedListPage = input.listPages.find(
+          (page) =>
+            new URL(page.url).toString() ===
+            new URL(submittedRules.listPageUrl).toString(),
+        );
+        if (selectedListPage) rememberCheckedPage(selectedListPage);
         const firstListPage = checkListPage({
           listPageUrl: submittedRules.listPageUrl,
           rules: submittedRules.rules,
@@ -392,6 +402,7 @@ export async function suggestScrapeSourceRevision(input: {
           listPage,
           suppliedPages: [...pageCache.values()],
           loadPage,
+          onCheckPage: rememberCheckedPage,
         });
         return {
           status: "passed" as const,
@@ -402,7 +413,7 @@ export async function suggestScrapeSourceRevision(input: {
         return {
           status: "failed" as const,
           feedback: error.feedback(),
-          inspectedPages,
+          inspectedPages: [...checkedPages.values()],
         };
       }
     },


### PR DESCRIPTION
Scraper setup now shortens abnormally large HTML attribute values before applying the model input limit, so generated page metadata cannot hide later review or product markup. Failed rule checks also return every page they examined, including cached examples, giving the next attempt the evidence it needs to repair its selectors.

The existing bounded single-agent loop, production parser check, inactive suggestion, preview requirement, and manual activation remain unchanged. A Whiskyfun-shaped migration check exercises the real model from v9 input through generated v11 rules across noisy multi-review pages.

Refs #1210
