### PR TITLE
fix(scraper): serialize Decadent Drinks requests

### DIFF
--- a/apps/server/src/scraper/adapters/legacy/scrapeDecadentDrinks.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeDecadentDrinks.test.ts
@@ -1,5 +1,6 @@
 import { loadFixture } from "@peated/server/lib/test/fixtures";
 import { StorePriceInputSchema } from "@peated/server/schemas";
+import { runLegacyRequestContext } from "../../legacy/requestContext";
 import {
   parseExplicitReleaseYear,
   parseSitemapUpdatedYears,
@@ -84,4 +85,56 @@ test("accepts a SKU year only when the sitemap year agrees", async ({
   );
 
   expect(identities).toMatchObject([{ release_year: 2024 }]);
+});
+
+test("does not overlap product page requests", async () => {
+  const listUrl = "https://decadent-drinks.com/shop?category=5&page=0";
+  const productUrls = [
+    "https://decadent-drinks.com/shop/first",
+    "https://decadent-drinks.com/shop/second",
+  ];
+  const list = `
+    <div class="catalog-results">
+      <div class="view-content">
+        ${productUrls
+          .map(
+            (productUrl, index) => `
+              <div class="col">
+                <div class="product-card">
+                  <div class="product-card__title">
+                    <a href="${productUrl}">Bottle ${index + 1}</a>
+                  </div>
+                  <div class="product-card__price">£100.00</div>
+                </div>
+              </div>
+            `,
+          )
+          .join("")}
+      </div>
+    </div>
+  `;
+  let activeProductRequests = 0;
+
+  await runLegacyRequestContext({
+    targetKey: "decadentdrinks",
+    session: {
+      request: async ({ url }) => {
+        if (url.toString() === listUrl) {
+          return { url, status: 200, headers: {}, body: list };
+        }
+        activeProductRequests += 1;
+        expect(activeProductRequests).toBe(1);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        activeProductRequests -= 1;
+        return { url, status: 200, headers: {}, body: '{"SKU":"BDS2401"}' };
+      },
+    },
+    run: async () => {
+      await scrapeProducts(
+        listUrl,
+        async () => {},
+        new Map(productUrls.map((url) => [url, 2024])),
+      );
+    },
+  });
 });

--- a/apps/server/src/scraper/adapters/legacy/scrapeDecadentDrinks.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeDecadentDrinks.ts
@@ -90,25 +90,24 @@ export async function scrapeProducts(
   const data = await getUrl(url);
   const $ = cheerio(data);
 
-  const promises: Promise<void>[] = [];
   const cards = $(PRODUCT_CARD_SELECTOR);
-  cards.each((_, el) => {
+  for (const el of cards.toArray()) {
     const rawName = $(".product-card__title", el).first().text().trim();
     if (!rawName) {
       logScrapeWarning(SITE, "Unable to identify product name");
-      return;
+      continue;
     }
 
     const productUrl = $(".product-card__title a", el).first().attr("href");
     if (!productUrl) {
       logScrapeWarning(SITE, "Unable to identify product URL", { rawName });
-      return;
+      continue;
     }
 
     const [nameWithoutVolume, volume] = extractVolume(rawName);
     if (!ALLOWED_VOLUMES.includes(volume)) {
       logScrapeWarning(SITE, "Invalid product size", { volume, rawName });
-      return;
+      continue;
     }
     const { name } = normalizeBottleInput({ name: nameWithoutVolume });
 
@@ -116,7 +115,7 @@ export async function scrapeProducts(
     const price = parsePrice(priceRaw);
     if (!price) {
       logScrapeWarning(SITE, "Invalid product price", { priceRaw, rawName });
-      return;
+      continue;
     }
 
     const imageUrl = $(".product-card__media img", el).first().attr("src");
@@ -124,35 +123,28 @@ export async function scrapeProducts(
     logScrapedProduct(SITE, { name, price });
 
     const productPageUrl = absoluteUrl(url, productUrl);
-    promises.push(
-      (async () => {
-        let releaseYear = parseExplicitReleaseYear(nameWithoutVolume);
-        const updatedYear = sitemapUpdatedYears.get(
-          productUrlKey(productPageUrl),
-        );
-        if (releaseYear === null && updatedYear !== undefined) {
-          const skuYear = parseSkuReleaseYear(await getUrl(productPageUrl));
-          if (skuYear === updatedYear) releaseYear = skuYear;
-        }
+    let releaseYear = parseExplicitReleaseYear(nameWithoutVolume);
+    const updatedYear = sitemapUpdatedYears.get(productUrlKey(productPageUrl));
+    if (releaseYear === null && updatedYear !== undefined) {
+      const skuYear = parseSkuReleaseYear(await getUrl(productPageUrl));
+      if (skuYear === updatedYear) releaseYear = skuYear;
+    }
 
-        await cb({
-          name,
-          price,
-          currency: "gbp",
-          volume,
-          url: productPageUrl,
-          imageUrl: imageUrl ? absoluteUrl(url, imageUrl) : null,
-          sourceBottleIdentity: BottleExtractedDetailsSchema.parse({
-            bottler: "Decadent Drinks",
-            expression: name,
-            release_year: releaseYear,
-          }),
-        });
-      })(),
-    );
-  });
+    await cb({
+      name,
+      price,
+      currency: "gbp",
+      volume,
+      url: productPageUrl,
+      imageUrl: imageUrl ? absoluteUrl(url, imageUrl) : null,
+      sourceBottleIdentity: BottleExtractedDetailsSchema.parse({
+        bottler: "Decadent Drinks",
+        expression: name,
+        release_year: releaseYear,
+      }),
+    });
+  }
 
-  await Promise.all(promises);
   return { hasSourceProducts: cards.length > 0 };
 }
 


### PR DESCRIPTION
Decadent Drinks product-detail requests now run sequentially so they respect the scraper runtime's single-flight target lease. This prevents normal release-year lookups from being treated as busy-target resumptions and exhausting the run's ten-attempt limit, while preserving sitemap/SKU year validation and price ingestion.

Regression coverage executes two product-detail lookups through the legacy request context and fails if they overlap.
