### PR TITLE
fix(scraper): preserve v11 migration behavior

### DIFF
--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -90,8 +90,9 @@ the run. The check and save happen together. If another worker has taken over,
 the old worker cannot overwrite the preview or add another version.
 
 Older rule versions remain supported so saved sources keep working. New
-sources use version 11. Most rule fields are CSS selectors. `list.links` finds article
-or product links. `list.nextPage` can find the next page of links. Links must
+sources use version 11. Most rule fields are CSS selectors supported by Cheerio,
+including relational selectors such as `:has()`. `list.links` finds article or
+product links. `list.nextPage` can find the next page of links. Links must
 stay on the source website. Code reads at most five list pages and stops at
 `list.limit`. It reads `href` from HTML links and text from XML links.
 

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -23,6 +23,7 @@ import {
   parseScrapeList,
 } from "./parser";
 import {
+  ScrapeRulesSchema,
   type ScrapeRules,
   type ScrapeRulesV3,
   type StoredScrapeRules,
@@ -159,6 +160,58 @@ it("reports an invalid list selector", () => {
     links: [],
     nextPageUrl: null,
     issues: [{ field: "list.links", message: "CSS selector is not valid." }],
+  });
+});
+
+it("uses supported relational selectors and Whiskyfun date attributes", () => {
+  const rules = ScrapeRulesSchema.parse({
+    kind: "review",
+    list: { links: "item > link", nextPage: null, limit: 20 },
+    detail: {
+      url: null,
+      title: "title",
+      date: "a[name]",
+      reviews: {
+        area: "main",
+        item: "td.TextenormalNEW:has(.textegrandfoncegras)",
+        name: ".textegrandfoncegras",
+        reviewer: null,
+        tastingNotes: null,
+        score: { selector: "strong", outOf: 100 },
+      },
+    },
+  });
+
+  expect(
+    parseScrapeDetail(
+      rules,
+      `<head><title>A pair of malts</title></head><body>
+        <a name="090926"></a>
+        <main>
+          <table><tr><td class="TextenormalNEW">Introduction.</td></tr></table>
+          <table><tr><td class="TextenormalNEW">
+            <span class="textegrandfoncegras">Coastal Malt 12 yo</span>
+            Orange and oak. <strong>SGP:561 - 88 points.</strong>
+          </td></tr></table>
+          <table><tr><td class="TextenormalNEW">Conclusion.</td></tr></table>
+        </main>
+      </body>`,
+      new URL("https://www.whiskyfun.com/2026/A-pair-of-malts.html"),
+    ),
+  ).toMatchObject({
+    kind: "review",
+    issues: [],
+    value: {
+      article: {
+        publishedAt: new Date("2026-09-09T00:00:00.000Z"),
+        externalReviews: [
+          {
+            name: "Coastal Malt 12 yo",
+            nativeScore: { value: 88, scale: 100 },
+          },
+        ],
+      },
+    },
   });
 });
 

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -24,6 +24,7 @@ import { normalizeScrapeReviewNameRule } from "./rules";
 import {
   applyDetailPageUrlCompatibility,
   readCompatiblePublishedDate,
+  readCompatiblePublishedDateValue,
 } from "./sourceCompatibility";
 import { matchFirstText, matchText } from "./textTemplate";
 
@@ -1553,7 +1554,12 @@ function readPublishedDate(
   pageUrl: URL,
 ) {
   if (selector) {
-    return parseDate(readSelectedValue($, selector, "date"));
+    const value = readSelectedValue($, selector, "date");
+    const compatibleValue = normalizeValue($(selector).first().attr("name"));
+    const compatibleDate = compatibleValue
+      ? readCompatiblePublishedDateValue(compatibleValue, pageUrl)
+      : null;
+    return compatibleDate ?? parseDate(value);
   }
   const selectors = [
     'meta[property="article:published_time"]',

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -18,14 +18,7 @@ const SCRAPE_LITERAL_MAX_LENGTH = 100;
 const SCRAPE_LITERAL_MAX_ITEMS = 10;
 const SCRAPE_SCORE_MAP_MAX_ITEMS = 25;
 
-export const ScrapeSelectorSchema = z
-  .string()
-  .trim()
-  .min(1)
-  .max(500)
-  .refine((value) => !value.includes(":has("), {
-    message: "The :has selector is not supported.",
-  });
+export const ScrapeSelectorSchema = z.string().trim().min(1).max(500);
 
 const ScrapeAttributeSchema = z.string().trim().min(1).max(100);
 

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -21,7 +21,7 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v24";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v25";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_PAGES_TO_CHECK = 3;
 const MAX_RULE_CHECKS = 3;
@@ -118,12 +118,14 @@ const RULE_INSTRUCTIONS = [
   'For reviews, prefer a start page marked document "xml". It is a public RSS, Atom, or RDF feed advertised by the website and already checked for usable same-site article links.',
   "Use the feed only to find article links. Read review details from the linked HTML pages.",
   "Use short CSS selectors that work on every given page.",
+  "Selectors may use any syntax supported by Cheerio, including :has() and :contains().",
   "For several reviews on one page, select the HTML element around each review. If there is no such element, set item to null; each name then starts a review.",
   "Set the review name to null when one review uses the article title. If fixed text surrounds the Bottle name, use a name match such as `Review of {value}`. Set its selector to null to match the title.",
   "Set reviewer when the page shows an author or byline, including when it appears once for the whole article. Code shares one article-level reviewer across its reviews.",
   "Set tastingNotes only when a narrower selector reliably finds flavor notes. The full review body comes from the review area or item.",
   "Use an optional field only when every given page clearly provides it.",
   "When previousSetup is given, preserve the kinds of items its working rules included and excluded. Use its rules and matchedPageUrls as evidence, but submit only fields allowed by check_rules.",
+  "If previousSetup used skipWhen, preserve those exclusions inside list.links.",
   "For catalog sources, collect only the displayed name, product URL, stable product ID, image URL, volume, ABV, age, edition, and release year.",
   "Catalog sources do not require a review, price, currency, or volume. Do not select descriptions or tasting notes.",
   "A nextPage selector must lead to a page with new links.",

--- a/apps/server/src/scraper/configured/sourceCompatibility.test.ts
+++ b/apps/server/src/scraper/configured/sourceCompatibility.test.ts
@@ -2,6 +2,7 @@ import { expect, it } from "vitest";
 import {
   applyDetailPageUrlCompatibility,
   readCompatiblePublishedDate,
+  readCompatiblePublishedDateValue,
 } from "./sourceCompatibility";
 
 it("adds the GlenAllachie UK storefront parameter to product URLs", () => {
@@ -26,6 +27,18 @@ it("reads Whiskyfun's compact article date", () => {
   expect(
     readCompatiblePublishedDate(
       new URL("https://example.test/2026/example-article-090826.html"),
+    ),
+  ).toBeNull();
+  expect(
+    readCompatiblePublishedDateValue(
+      "090926",
+      new URL("https://www.whiskyfun.com/2026/example-article.html"),
+    ),
+  ).toEqual(new Date("2026-09-09T00:00:00.000Z"));
+  expect(
+    readCompatiblePublishedDateValue(
+      "090926",
+      new URL("https://example.test/2026/example-article.html"),
     ),
   ).toBeNull();
 });

--- a/apps/server/src/scraper/configured/sourceCompatibility.ts
+++ b/apps/server/src/scraper/configured/sourceCompatibility.ts
@@ -1,6 +1,7 @@
 type SourceCompatibility = {
   matches(url: URL): boolean;
   detailPageUrl?(url: URL): URL;
+  publishedDateFromValue?(value: string): Date | null;
   publishedDateFromUrl?(url: URL): Date | null;
 };
 
@@ -25,6 +26,16 @@ const SOURCE_COMPATIBILITY: SourceCompatibility[] = [
   },
   {
     matches: (url) => url.hostname.endsWith("whiskyfun.com"),
+    publishedDateFromValue: (value) => {
+      const compact = /^(\d{2})(\d{2})(\d{2})$/u.exec(value);
+      return compact
+        ? createDate(
+            2000 + Number(compact[3]),
+            Number(compact[2]),
+            Number(compact[1]),
+          )
+        : null;
+    },
     publishedDateFromUrl: (url) => {
       const compact = url.pathname.match(
         /(?:^|\D)(\d{2})(\d{2})(\d{2})(?:\D|$)/u,
@@ -52,4 +63,11 @@ export function readCompatiblePublishedDate(url: URL) {
     candidate.matches(url),
   );
   return compatibility?.publishedDateFromUrl?.(url) ?? null;
+}
+
+export function readCompatiblePublishedDateValue(value: string, url: URL) {
+  const compatibility = SOURCE_COMPATIBILITY.find((candidate) =>
+    candidate.matches(url),
+  );
+  return compatibility?.publishedDateFromValue?.(value) ?? null;
 }

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -45,9 +45,13 @@ const BRUICHLADDICH_MERCH_URL = `${BRUICHLADDICH_ORIGIN}/products/laddie-t-shirt
 const WHISKYFUN_ORIGIN = "https://www.whiskyfun.com";
 const WHISKYFUN_FEED_URL = `${WHISKYFUN_ORIGIN}/whatsnew.xml`;
 const WHISKYFUN_ARTICLE_URLS = [
-  `${WHISKYFUN_ORIGIN}/2026/A-trio-of-coastal-malts-090826.html`,
-  `${WHISKYFUN_ORIGIN}/2026/Two-old-island-malts-080826.html`,
-  `${WHISKYFUN_ORIGIN}/2026/A-pair-of-highlanders-070826.html`,
+  `${WHISKYFUN_ORIGIN}/2026/A-trio-of-coastal-malts.html`,
+  `${WHISKYFUN_ORIGIN}/2026/Two-old-island-malts.html`,
+  `${WHISKYFUN_ORIGIN}/2026/A-pair-of-highlanders.html`,
+] as const;
+const WHISKYFUN_EXCLUDED_URLS = [
+  `${WHISKYFUN_ORIGIN}/2026/A-few-more-rums.html`,
+  `${WHISKYFUN_ORIGIN}/2026/Cognacs-are-back.html`,
 ] as const;
 
 const WEBSITE_PAGES = new Map([
@@ -255,19 +259,25 @@ const BRUICHLADDICH_V6_RULES = {
 
 function whiskyfunArticle(
   title: string,
+  date: string,
   reviews: Array<[name: string, notes: string, score: number]>,
 ) {
   const oversizedMapName = "Map".repeat(30_000);
   return `<!doctype html><html><head><title>${title}</title></head><body>
     <map name="${oversizedMapName}"><area href="#reviews"></map>
-    <table id="reviews"><tbody>${reviews
-      .map(
-        ([name, notes, score]) => `<tr><td class="TextenormalNEW">
-          <span class="textegrandfoncegras">${name}</span>
-          <p>${notes}</p><strong>SGP:561 - ${score} points.</strong>
-        </td></tr>`,
-      )
-      .join("")}</tbody></table>
+    <a name="${date}"></a>
+    <table><tr><td bgcolor="#FFFF99">
+      <table><tr><td class="TextenormalNEW">An introduction without a review heading.</td></tr></table>
+      ${reviews
+        .map(
+          ([name, notes, score]) => `<table><tr><td class="TextenormalNEW">
+            <span class="textegrandfoncegras">${name}</span>
+            <p>${notes}</p><strong>SGP:561 - ${score} points.</strong>
+          </td></tr></table>`,
+        )
+        .join("")}
+      <table><tr><td class="TextenormalNEW">A conclusion without a review heading.</td></tr></table>
+    </td></tr></table>
   </body></html>`;
 }
 
@@ -280,10 +290,13 @@ const WHISKYFUN_REVIEWS = [
 const WHISKYFUN_PAGES = new Map<string, string>([
   [
     WHISKYFUN_FEED_URL,
-    `<?xml version="1.0"?><rss><channel>${WHISKYFUN_ARTICLE_URLS.map(
-      (url, index) =>
-        `<item><title>Whisky article ${index + 1}</title><link>${url}</link></item>`,
-    ).join("")}</channel></rss>`,
+    `<?xml version="1.0"?><rss><channel>
+      <item><title>Whisky article 1</title><link>${WHISKYFUN_ARTICLE_URLS[0]}</link></item>
+      <item><title>Whisky article 2</title><link>${WHISKYFUN_ARTICLE_URLS[1]}</link></item>
+      <item><title>Whisky article 3</title><link>${WHISKYFUN_ARTICLE_URLS[2]}</link></item>
+      <item><title>A few more rums</title><link>${WHISKYFUN_EXCLUDED_URLS[0]}</link></item>
+      <item><title>Cognacs are back</title><link>${WHISKYFUN_EXCLUDED_URLS[1]}</link></item>
+    </channel></rss>`,
   ],
   ...WHISKYFUN_ARTICLE_URLS.map(
     (url, index) =>
@@ -291,6 +304,7 @@ const WHISKYFUN_PAGES = new Map<string, string>([
         url,
         whiskyfunArticle(
           `Whisky article ${index + 1}`,
+          `${String(9 - index).padStart(2, "0")}0926`,
           WHISKYFUN_REVIEWS[index]!.map((name, reviewIndex) => [
             name,
             `Tasting notes for ${name}.`,
@@ -307,7 +321,10 @@ const WHISKYFUN_V9_RULES = {
     document: "xml",
     oneArticlePer: "item",
     link: "link",
-    skipWhen: null,
+    skipWhen: {
+      selector: "title",
+      match: ["{anything}rum{anything}", "{anything}cognac{anything}"],
+    },
     nextPage: null,
     limit: 25,
   },
@@ -326,7 +343,14 @@ const WHISKYFUN_V9_RULES = {
       ],
     },
     publishedDate: {
-      try: [{ get: "dateFromUrl", format: "*ddMMyy.html" }],
+      try: [
+        {
+          get: "dateFromAttribute",
+          selector: "a[name]",
+          attribute: "name",
+          format: "ddMMyy",
+        },
+      ],
     },
     reviews: {
       inside: "body",
@@ -824,6 +848,9 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         if (parsed.kind !== "review" || !parsed.value) {
           throw new Error("Generated rules did not parse a review page.");
         }
+        expect(parsed.value.article.publishedAt).toEqual(
+          new Date(Date.UTC(2026, 8, 9 - index)),
+        );
         expect(
           parsed.value.article.externalReviews.map((review) => review.name),
         ).toEqual([...WHISKYFUN_REVIEWS[index]!]);

--- a/apps/server/src/scraper/configured/suggestion.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.test.ts
@@ -4,6 +4,7 @@ import {
   checkDetailPages,
   checkListPage,
   checkNextListPage,
+  checkPreviousListPage,
   sampleDetailLinks,
 } from "./suggestion";
 
@@ -87,6 +88,52 @@ test("checks that pagination adds detail links", async () => {
     "https://example.test/reviews/one",
     "https://example.test/reviews/two",
   ]);
+});
+
+test("rejects list rules that drop the working filters", () => {
+  const page = checkListPage({
+    listPageUrl: "https://example.test/feed.xml",
+    rules: {
+      ...reviewRules,
+      list: { links: "item > link", nextPage: null, limit: 20 },
+    },
+    pages: [
+      {
+        url: "https://example.test/feed.xml",
+        html: `<rss><channel>
+          <item><title>Two malts</title><link>/reviews/malts</link></item>
+          <item><title>A few rums</title><link>/reviews/rums</link></item>
+        </channel></rss>`,
+      },
+    ],
+  });
+  const previousRules = {
+    parseList: () => ({
+      links: ["https://example.test/reviews/malts"],
+      nextPageUrl: null,
+      issues: [],
+    }),
+  };
+
+  expect(() =>
+    checkPreviousListPage({ listPage: page, previousRules }),
+  ).toThrow("The rules changed which pages the working setup includes.");
+
+  const filteredPage = checkListPage({
+    listPageUrl: page.url,
+    rules: {
+      ...reviewRules,
+      list: {
+        links: 'item:not(:has(title:contains("rum"))) > link',
+        nextPage: null,
+        limit: 20,
+      },
+    },
+    pages: [page],
+  });
+  expect(() =>
+    checkPreviousListPage({ listPage: filteredPage, previousRules }),
+  ).not.toThrow();
 });
 
 test("rejects a list page that was not supplied", () => {

--- a/apps/server/src/scraper/configured/suggestion.ts
+++ b/apps/server/src/scraper/configured/suggestion.ts
@@ -10,6 +10,10 @@ import type {
   ResponseInput,
   Tool,
 } from "openai/resources/responses/responses";
+import {
+  loadExecutableScrapeRules,
+  type ExecutableScrapeRules,
+} from "./compatibility";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
 import type { ScrapeRules } from "./rules";
 import { saveScrapeSourceSuggestion } from "./service";
@@ -118,6 +122,43 @@ export function checkListPage(input: {
     nextPageUrl: result.nextPageUrl,
     nextPage: null,
   };
+}
+
+export function checkPreviousListPage(input: {
+  listPage: SelectedListPage;
+  previousRules: Pick<ExecutableScrapeRules, "parseList">;
+}) {
+  const previous = input.previousRules.parseList(
+    input.listPage.html,
+    new URL(input.listPage.url),
+  );
+  if (previous.issues.length > 0) return;
+
+  const previousLinks = new Set(previous.links);
+  const proposedLinks = new Set(input.listPage.firstPageLinks);
+  const unexpected = input.listPage.firstPageLinks.filter(
+    (url) => !previousLinks.has(url),
+  );
+  const missing = previous.links.filter((url) => !proposedLinks.has(url));
+  if (unexpected.length === 0 && missing.length === 0) return;
+
+  const changes = [
+    unexpected.length > 0
+      ? `${unexpected.length} previously excluded page${unexpected.length === 1 ? "" : "s"} included`
+      : null,
+    missing.length > 0
+      ? `${missing.length} previously included page${missing.length === 1 ? "" : "s"} missing`
+      : null,
+  ].filter(Boolean);
+  throw new ScrapeSourceSetupError(
+    "The rules changed which pages the working setup includes.",
+    [
+      {
+        field: "list.links",
+        message: `Preserve the previousSetup list filters: ${changes.join(", ")}.`,
+      },
+    ],
+  );
 }
 
 export async function checkNextListPage(input: {
@@ -332,6 +373,17 @@ export async function suggestScrapeSourceRevision(input: {
   loadPage: (url: URL) => Promise<WebsitePage>;
 }) {
   const source = await loadAiSource(input.scrapeSourceId);
+  let previousRules: ExecutableScrapeRules | null = null;
+  if (source.previousRulesVersion && source.previousRules) {
+    try {
+      previousRules = loadExecutableScrapeRules(
+        source.previousRulesVersion,
+        source.previousRules,
+      );
+    } catch {
+      // Invalid legacy rules must not block the suggestion that replaces them.
+    }
+  }
   const pageCache = new Map(
     [...input.listPages, ...input.detailPages].map((page) => [
       new URL(page.url).toString(),
@@ -392,6 +444,13 @@ export async function suggestScrapeSourceRevision(input: {
           rules: submittedRules.rules,
           pages: input.listPages,
         });
+        if (
+          previousRules &&
+          source.previousListPageUrl &&
+          new URL(source.previousListPageUrl).toString() === firstListPage.url
+        ) {
+          checkPreviousListPage({ listPage: firstListPage, previousRules });
+        }
         const listPage = await checkNextListPage({
           rules: submittedRules.rules,
           listPage: firstListPage,


### PR DESCRIPTION
Scrape-source setup can now use any CSS selector supported by Cheerio, including `:has()`, while keeping the v11 JSON contract and rules version unchanged. When replacing executable rules, `check_rules` also rejects proposals that change the active list's included or excluded links; invalid legacy rules remain replaceable instead of blocking setup.

Whiskyfun's compact publication date remains a source-specific interpretation of its existing date selector. Its regression eval now mirrors the noisy table markup, anchor dates, and non-whisky feed entries that exposed the failure, and the broader suggestion eval remains green.

Refs #1210
