### PR TITLE
feat(scraper): prepare Decadent Drinks saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -134,6 +134,15 @@ function prepareCompassBox(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareDecadentDrinks(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "decadentdrinks", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareCadenheads(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "cadenheads", ...input },
@@ -215,6 +224,7 @@ function codeOwnedSource(
     | "bruichladdich"
     | "cadenheads"
     | "compassbox"
+    | "decadentdrinks"
     | "dramface"
     | "edradour"
     | "glenallachie"
@@ -301,6 +311,11 @@ const edradourRegistry = createScraperRegistry({
 const compassBoxRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("compassbox")!],
   sources: [codeOwnedSource("compassbox")],
+});
+
+const decadentDrinksRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("decadentdrinks")!],
+  sources: [codeOwnedSource("decadentdrinks")],
 });
 
 const cadenheadsRegistry = createScraperRegistry({
@@ -852,6 +867,25 @@ async function setupCompassBoxMigration() {
     })
     .returning();
   await syncScraperDefinitions(compassBoxRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
+}
+
+async function setupDecadentDrinksMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "decadentdrinks",
+      name: "Decadent Drinks",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(decadentDrinksRegistry);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "succeeded",
@@ -1896,6 +1930,105 @@ describe("POST /admin/scrape-sources/prepare", () => {
     await expect(prepareThompsonBros({ apply: true })).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: expect.stringContaining("Check Thompson Bros. price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares Decadent Drinks without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupDecadentDrinksMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: null,
+      name: "Decadent Drams Dailuaine 19-year-old",
+      price: 14500,
+      currency: "gbp",
+      volume: 700,
+      url: "https://decadent-drinks.com/shop/decadent-drams-dailauine-19-years-old",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: null,
+      name: "Whisky Sponge Edition No. 82",
+      price: 6500,
+      currency: "gbp",
+      volume: 500,
+      url: "https://decadent-drinks.com/shop/whisky-sponge-edition-no-82/",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareDecadentDrinks()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareDecadentDrinks({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(decadentDrinksRegistry);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl: "https://decadent-drinks.com/shop/category/whisky",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+    await expect(prepareDecadentDrinks({ apply: true })).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Decadent Drinks is already prepared for saved scraping rules.",
+    });
+  });
+
+  test("refuses an unexpected Decadent Drinks price without changing records", async ({
+    fixtures,
+  }) => {
+    const site = await setupDecadentDrinksMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      externalProductId: "BDS26053",
+      name: "Decadent Drams Dailuaine 19-year-old",
+      currency: "gbp",
+      volume: 700,
+      url: "https://example.com/shop/decadent-drams-dailuaine-19-years-old",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareDecadentDrinks({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check Decadent Drinks price"),
     });
     expect(await db.select().from(storePrices)).toEqual(prices);
     expect(await db.select().from(scrapeTargets)).toEqual(targets);

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -5,6 +5,7 @@ import { prepareBourbonCultureSource } from "@peated/server/scraper/configured/p
 import { prepareBruichladdichSource } from "@peated/server/scraper/configured/prepareBruichladdich";
 import { prepareCadenheadsSource } from "@peated/server/scraper/configured/prepareCadenheads";
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
+import { prepareDecadentDrinksSource } from "@peated/server/scraper/configured/prepareDecadentDrinks";
 import { prepareDramfaceSource } from "@peated/server/scraper/configured/prepareDramface";
 import { prepareEdradourSource } from "@peated/server/scraper/configured/prepareEdradour";
 import { prepareGlenAllachieSource } from "@peated/server/scraper/configured/prepareGlenAllachie";
@@ -43,7 +44,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, dramface, edradour, glenallachie, gordonmacphail, kilchoman, ncnean, northstarspirits, thompsonbros, whiskeyreviewer, whiskyfun, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
+          "The existing site's key. Currently supports bourbonculture, bruichladdich, cadenheads, compassbox, decadentdrinks, dramface, edradour, glenallachie, gordonmacphail, kilchoman, ncnean, northstarspirits, thompsonbros, whiskeyreviewer, whiskyfun, whiskynotes, whiskysaga, whiskystudy, and wordsofwhisky.",
         ),
         apply: z
           .boolean()
@@ -78,6 +79,7 @@ export default procedure
       bruichladdich: prepareBruichladdichSource,
       cadenheads: prepareCadenheadsSource,
       compassbox: prepareCompassBoxSource,
+      decadentdrinks: prepareDecadentDrinksSource,
       dramface: prepareDramfaceSource,
       edradour: prepareEdradourSource,
       glenallachie: prepareGlenAllachieSource,

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -133,6 +133,47 @@ it("reads price fields from text and their usual HTML attributes", () => {
   });
 });
 
+it("uses the customer price when a page also shows an ex-VAT amount", () => {
+  const rules = {
+    kind: "price",
+    list: { links: "a.product", nextPage: null, limit: 10 },
+    detail: {
+      name: "h1",
+      url: null,
+      id: null,
+      image: null,
+      volume: 700,
+      price: ".price",
+      currency: "gbp",
+      barcode: null,
+    },
+  } satisfies ScrapeRules;
+  const pageUrl = new URL("https://example.test/whisky/one");
+
+  expect(
+    parseScrapeDetail(
+      rules,
+      '<h1>Example Whisky</h1><p class="price">£145.00 <span>(£120.83 exvat)</span></p>',
+      pageUrl,
+    ),
+  ).toMatchObject({
+    kind: "price",
+    issues: [],
+    value: [{ price: 14500 }],
+  });
+  expect(
+    parseScrapeDetail(
+      rules,
+      '<h1>Example Whisky</h1><p class="price">£120.83 ex VAT</p>',
+      pageUrl,
+    ),
+  ).toMatchObject({
+    kind: "price",
+    issues: [],
+    value: [{ price: 12083 }],
+  });
+});
+
 it("reports an invalid list selector", () => {
   const rules = {
     kind: "catalog",

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -663,13 +663,19 @@ function parsePriceInSmallestUnit(value: string | null) {
 
 function parseDisplayedPrice(value: string | null) {
   if (!value) return null;
-  const amounts = [
-    ...value
-      .replaceAll(",", "")
-      .matchAll(
-        /(?:[$£€]\s*(\d+(?:\.\d+)?)|(\d+(?:\.\d+)?)\s*(?:USD|GBP|EUR)\b)/giu,
-      ),
-  ].map((match) => Number(match[1] ?? match[2]));
+  const normalized = value.replaceAll(",", "");
+  const matches = [
+    ...normalized.matchAll(
+      /(?:[$£€]\s*(\d+(?:\.\d+)?)|(\d+(?:\.\d+)?)\s*(?:USD|GBP|EUR)\b)/giu,
+    ),
+  ];
+  const customerAmounts = matches.filter((match) => {
+    const offset = (match.index ?? 0) + match[0].length;
+    return !/^\s*ex(?:cluding)?\.?\s*vat\b/iu.test(normalized.slice(offset));
+  });
+  const amounts = (customerAmounts.length > 0 ? customerAmounts : matches).map(
+    (match) => Number(match[1] ?? match[2]),
+  );
   const number = amounts.at(-1) ?? parseNumber(value);
   if (number === null || number <= 0) return null;
   return Math.round(number * 100);

--- a/apps/server/src/scraper/configured/prepareDecadentDrinks.ts
+++ b/apps/server/src/scraper/configured/prepareDecadentDrinks.ts
@@ -1,0 +1,26 @@
+import { ALLOWED_VOLUMES } from "@peated/server/constants";
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks Decadent Drinks by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareDecadentDrinksSource(
+  input: PreparePriceSourceInput,
+) {
+  return preparePriceSource(input, {
+    siteKey: "decadentdrinks",
+    siteName: "Decadent Drinks",
+    targetKey: "decadentdrinks",
+    origin: "https://decadent-drinks.com",
+    listUrl: "https://decadent-drinks.com/shop/category/whisky",
+    isExpectedPrice: (price) =>
+      /^https:\/\/decadent-drinks\.com\/shop\/[a-z0-9][a-z0-9-]*\/?$/i.test(
+        price.url,
+      ) &&
+      price.externalProductId === null &&
+      price.name.trim().length > 0 &&
+      price.currency === "gbp" &&
+      ALLOWED_VOLUMES.includes(price.volume),
+  });
+}

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -249,6 +249,36 @@ preview. Activate only exact output, trigger one manual collection, and confirm
 that it updates the same price IDs and Bottle matches. Check the run and Sentry
 before restoring the saved schedule.
 
+## Decadent Drinks
+
+Use the preparation endpoint with `{"site": "decadentdrinks"}`. The check-only
+request inventories every stored price without changing it. It stops if a row
+has a product ID or does not use a Decadent Drinks shop URL, non-empty name,
+GBP currency, or supported bottle size. Applying transfers the existing request
+settings and creates a paused price source for
+`https://decadent-drinks.com/shop/category/whisky`. It does not change price
+rows or history.
+
+Before applying, stop the `decadentdrinks` weekly schedule and wait for active
+collection to finish. Save every price ID, product URL, name, price, currency,
+volume, image URL, Bottle link, hidden state, source identity and fingerprint,
+history, request setting, and run. Run version 11 rules through the full local
+no-write preview. The list rules must select only product-title links from the
+whisky catalog, follow its next-page link, and stop at 99 products. Product
+pages must read the exact displayed name, customer price including VAT, bottle
+size, canonical URL, and main image. Leave the product ID empty so collection
+continues to find existing rows by exact URL. When the same price element also
+shows a lower amount marked `ex VAT`, the parsed price must remain the customer
+price.
+
+Compare the full preview with the code scraper before applying. Existing rows
+must keep their stored source identity when saved rules omit it. After applying,
+save and preview the reviewed revision. Activate only exact output, trigger one
+manual collection, and confirm that it updates the same price IDs, Bottle links,
+source fingerprints, and hidden rows. Check the run and Sentry before restoring
+the weekly schedule. Keep the built-in adapter until that production run is
+verified; remove it in a later cleanup.
+
 ## Bruichladdich
 
 Use the preparation endpoint with `{"site": "bruichladdich"}`. The check-only
@@ -452,9 +482,10 @@ handles reviews added after the switch. Do not delete source or run history.
 ## Other sources
 
 The preparation API is shared. It currently supports Bourbon Culture,
-Bruichladdich, Cadenhead's, Compass Box, Dramface, Edradour, GlenAllachie,
-Gordon & MacPhail, Kilchoman, Nc'nean, North Star, Thompson Bros., The Whiskey Reviewer,
-Whiskyfun, WhiskyNotes, Whisky Saga, The Whisky Study, and Words of Whisky.
+Bruichladdich, Cadenhead's, Compass Box, Decadent Drinks, Dramface, Edradour,
+GlenAllachie, Gordon & MacPhail, Kilchoman, Nc'nean, North Star, Thompson Bros.,
+The Whiskey Reviewer, Whiskyfun, WhiskyNotes, Whisky Saga, The Whisky Study,
+and Words of Whisky.
 Other sites are rejected without changing records. Add each site's conversion
 behind this route as its existing records are reviewed.
 


### PR DESCRIPTION
Decadent Drinks can now be transferred from its code-managed scraper to a paused saved-rules price source without replacing stored prices, histories, Bottle matches, or request state. Preparation validates every stored row and transfers target ownership only after the schedule is stopped and active runs have finished.

The saved price parser now ignores a secondary amount labeled `ex VAT` when the same field contains a customer price, while still accepting a lone ex-VAT amount. Decadent Drinks renders both amounts in one element, so this prevents the migration from silently storing the lower tax-exclusive price. A full local no-write preview traversed all five current catalog pages and parsed 54 products in one attempt with no request errors or retries. The rollout guide keeps the legacy adapter in place until a post-deploy production preview and manual collection preserve existing IDs, Bottle links, fingerprints, and hidden rows.
