### PR TITLE
fix(admin): separate moderation from background work

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/(overview)/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/(overview)/page.tsx
@@ -12,11 +12,16 @@ import { useSuspenseQueries } from "@tanstack/react-query";
 
 export default function Page() {
   const orpc = useORPC();
-  const [scraperQuery, operationsQuery] = useSuspenseQueries({
+  const [scraperQuery, operationsQuery, inboxQuery] = useSuspenseQueries({
     queries: [
       orpc.admin.scraperActivity.queryOptions({ refetchInterval: 60_000 }),
       orpc.admin.moderation.automation.queryOptions({
         refetchInterval: 5_000,
+      }),
+      orpc.admin.moderation.listTasks.queryOptions({
+        input: { limit: 1 },
+        refetchOnMount: "always",
+        staleTime: 0,
       }),
     ],
   });
@@ -27,7 +32,7 @@ export default function Page() {
     <AdminPage>
       <AdminPageHeader
         title="Operations"
-        description="See what Peated is processing and what needs attention."
+        description="Review open decisions, check background work, and track incoming data."
         metadata={
           <>
             Updated <TimeSince date={operations.generatedAt} />
@@ -37,6 +42,7 @@ export default function Page() {
       <OperationsOverview
         bottleResolution={scraperActivity.bottleResolution}
         data={operations}
+        inboxCounts={inboxQuery.data.counts}
       />
       <ScraperActivity data={scraperActivity} />
     </AdminPage>

--- a/apps/web/src/components/admin/adminContent.stylex.tsx
+++ b/apps/web/src/components/admin/adminContent.stylex.tsx
@@ -147,9 +147,25 @@ export function AdminOverviewPageLoading() {
       <AdminPage>
         <AdminPageHeader
           title="Operations"
-          description="See what Peated is processing and what needs attention."
+          description="Review open decisions, check background work, and track incoming data."
           metadata={<LoadingPlaceholder preset="pageMetadata" />}
         />
+        <div {...stylex.props(styles.loadingWorkGrid)}>
+          <AdminSection title="Moderation inbox">
+            <LoadingList
+              label="Loading moderation inbox totals"
+              rows={3}
+              variant="text"
+            />
+          </AdminSection>
+          <AdminSection title="Background work">
+            <LoadingList
+              label="Loading background work totals"
+              rows={3}
+              variant="text"
+            />
+          </AdminSection>
+        </div>
         <div {...stylex.props(styles.loadingOverviewGrid)}>
           <AdminSection title="Bottle resolution">
             <LoadingList
@@ -158,9 +174,9 @@ export function AdminOverviewPageLoading() {
               variant="text"
             />
           </AdminSection>
-          <AdminSection title="System status">
+          <AdminSection title="Price matching">
             <LoadingList
-              label="Loading system status"
+              label="Loading price matching"
               rows={4}
               variant="text"
             />
@@ -454,6 +470,13 @@ const styles = stylex.create({
     display: "grid",
     minWidth: 0,
     gridTemplateColumns: "minmax(0, 1.3fr) minmax(280px, 0.7fr)",
+    gap: space.x4,
+    "@media (max-width: 839px)": { gridTemplateColumns: "minmax(0, 1fr)" },
+  },
+  loadingWorkGrid: {
+    display: "grid",
+    minWidth: 0,
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
     gap: space.x4,
     "@media (max-width: 839px)": { gridTemplateColumns: "minmax(0, 1fr)" },
   },

--- a/apps/web/src/components/admin/moderation/automationPage.tsx
+++ b/apps/web/src/components/admin/moderation/automationPage.tsx
@@ -111,7 +111,7 @@ export default function AutomationPage() {
       ) : null}
       {error ? <Alert type="error">{error}</Alert> : null}
       <AdminSection
-        title="Needs attention"
+        title="Stopped work"
         description={`${data.needsAttention.length} items`}
       >
         {data.needsAttention.length ? (
@@ -135,7 +135,7 @@ export default function AutomationPage() {
             ]}
           />
         ) : (
-          "No background work needs attention."
+          "No background work has stopped."
         )}
       </AdminSection>
       <AdminSection

--- a/apps/web/src/components/admin/operationsOverview.stories.tsx
+++ b/apps/web/src/components/admin/operationsOverview.stories.tsx
@@ -18,11 +18,18 @@ const meta = {
     docs: {
       description: {
         component:
-          "Summarizes live background work and recent price matching on the admin overview.",
+          "Separates moderation decisions from background work, then summarizes Bottle resolution and recent price matching.",
       },
     },
   },
   args: {
+    inboxCounts: {
+      all: 23,
+      listing: 18,
+      catalog: 5,
+      blocked: 2,
+      inconclusive: 7,
+    },
     bottleResolution: {
       unknown: 8,
       created: 6,
@@ -74,6 +81,13 @@ export const Overview: Story = {};
 
 export const Quiet: Story = {
   args: {
+    inboxCounts: {
+      all: 0,
+      listing: 0,
+      catalog: 0,
+      blocked: 0,
+      inconclusive: 0,
+    },
     bottleResolution: {
       unknown: 0,
       created: 0,

--- a/apps/web/src/components/admin/operationsOverview.stylex.tsx
+++ b/apps/web/src/components/admin/operationsOverview.stylex.tsx
@@ -14,10 +14,12 @@ import {
 import { SectionHeading } from "../sectionHeading.stylex";
 
 type OperationsData = Outputs["admin"]["moderation"]["automation"];
+type InboxCounts = Outputs["admin"]["moderation"]["listTasks"]["counts"];
 type BottleResolution = Outputs["admin"]["scraperActivity"]["bottleResolution"];
 type OperationsOverviewProps = {
   bottleResolution: BottleResolution;
   data: OperationsData;
+  inboxCounts: InboxCounts;
 };
 
 const proposalTypeLabels = {
@@ -99,10 +101,37 @@ function StatusRow({
   );
 }
 
-/** Prioritizes Bottle outcomes, live work, and recent price matching. */
+function SummaryCount({
+  label,
+  tone = "default",
+  value,
+}: {
+  label: string;
+  tone?: "default" | "danger";
+  value: number;
+}) {
+  return (
+    <p {...stylex.props(styles.summaryCount)}>
+      <strong
+        {...stylex.props(
+          styles.summaryValue,
+          tone === "danger" && styles.danger,
+        )}
+      >
+        {formatCount(value)}
+      </strong>
+      <span {...stylex.props(foundationStyles.body, styles.summaryLabel)}>
+        {label}
+      </span>
+    </p>
+  );
+}
+
+/** Separates human decisions from background work before showing data health. */
 export default function OperationsOverview({
   bottleResolution,
   data,
+  inboxCounts,
 }: OperationsOverviewProps) {
   const resolutionTotal =
     bottleResolution.unknown +
@@ -110,101 +139,130 @@ export default function OperationsOverview({
     bottleResolution.matched;
 
   return (
-    <div {...stylex.props(styles.overviewGrid)}>
-      <section
-        aria-labelledby="bottle-resolution-heading"
-        {...stylex.props(styles.resolutionPanel)}
-      >
-        <div {...stylex.props(styles.panelHeading)}>
-          <SectionHeading id="bottle-resolution-heading">
-            Bottle resolution
-          </SectionHeading>
-          <p {...stylex.props(foundationStyles.body, styles.panelDescription)}>
-            New reviews and prices from the last 30 days, grouped by their
-            current Bottle match.
-          </p>
-        </div>
-
-        {resolutionTotal ? (
-          <>
-            <div aria-hidden="true" {...stylex.props(styles.resolutionTrack)}>
-              {bottleResolution.unknown ? (
-                <span
-                  style={{ flexGrow: bottleResolution.unknown }}
-                  {...stylex.props(styles.resolutionSegment, styles.unknown)}
-                />
-              ) : null}
-              {bottleResolution.created ? (
-                <span
-                  style={{ flexGrow: bottleResolution.created }}
-                  {...stylex.props(styles.resolutionSegment, styles.created)}
-                />
-              ) : null}
-              {bottleResolution.matched ? (
-                <span
-                  style={{ flexGrow: bottleResolution.matched }}
-                  {...stylex.props(styles.resolutionSegment, styles.matched)}
-                />
-              ) : null}
-            </div>
-            <dl {...stylex.props(styles.resolutionList)}>
-              <ResolutionItem
-                label="Unknown"
-                value={bottleResolution.unknown}
-                total={resolutionTotal}
-                detail="no Bottle match yet"
-                tone="unknown"
-              />
-              <ResolutionItem
-                label="New bottles"
-                value={bottleResolution.created}
-                total={resolutionTotal}
-                detail="added to Peated"
-                tone="created"
-              />
-              <ResolutionItem
-                label="Existing matches"
-                value={bottleResolution.matched}
-                total={resolutionTotal}
-                detail="matched to Bottles in Peated"
-                tone="matched"
-              />
-            </dl>
-          </>
-        ) : (
-          <p {...stylex.props(foundationStyles.body, styles.empty)}>
-            No new reviews or prices in the last 30 days.
-          </p>
-        )}
-      </section>
-
-      <section
-        aria-labelledby="system-status-heading"
-        {...stylex.props(styles.statusPanel)}
-      >
-        <div {...stylex.props(styles.statusHeader)}>
-          <SectionHeading id="system-status-heading">
-            System status
-          </SectionHeading>
-          <TextLink href="/admin/moderation/automation">View work</TextLink>
-        </div>
-
-        <dl {...stylex.props(styles.statusList)}>
-          <StatusRow
-            label="Needs attention"
-            value={data.counts.failed}
-            tone={data.counts.failed > 0 ? "danger" : "default"}
+    <div {...stylex.props(styles.root)}>
+      <div {...stylex.props(styles.workGrid)}>
+        <section
+          aria-labelledby="moderation-inbox-heading"
+          {...stylex.props(styles.moderationPanel)}
+        >
+          <div {...stylex.props(styles.panelHeader)}>
+            <SectionHeading id="moderation-inbox-heading">
+              Moderation inbox
+            </SectionHeading>
+            <TextLink href="/admin/moderation/inbox">Open inbox</TextLink>
+          </div>
+          <SummaryCount
+            label={inboxCounts.all === 1 ? "open decision" : "open decisions"}
+            value={inboxCounts.all}
           />
-          <StatusRow label="In progress" value={data.counts.processing} />
-          <StatusRow label="Waiting" value={data.counts.waiting} />
-          <StatusRow label="Finished today" value={data.counts.clearedToday} />
-        </dl>
+          <dl {...stylex.props(styles.statusList)}>
+            <StatusRow label="Listings" value={inboxCounts.listing} />
+            <StatusRow label="Catalog" value={inboxCounts.catalog} />
+          </dl>
+        </section>
 
-        <div {...stylex.props(styles.matching)}>
+        <section
+          aria-labelledby="background-work-heading"
+          {...stylex.props(styles.backgroundPanel)}
+        >
+          <div {...stylex.props(styles.panelHeader)}>
+            <SectionHeading id="background-work-heading">
+              Background work
+            </SectionHeading>
+            <TextLink href="/admin/moderation/automation">
+              View background work
+            </TextLink>
+          </div>
+          <SummaryCount
+            label={data.counts.failed === 1 ? "failed item" : "failed items"}
+            tone={data.counts.failed > 0 ? "danger" : "default"}
+            value={data.counts.failed}
+          />
+          <dl {...stylex.props(styles.statusList)}>
+            <StatusRow label="In progress" value={data.counts.processing} />
+            <StatusRow label="Waiting" value={data.counts.waiting} />
+          </dl>
+        </section>
+      </div>
+
+      <div {...stylex.props(styles.insightsGrid)}>
+        <section
+          aria-labelledby="bottle-resolution-heading"
+          {...stylex.props(styles.resolutionPanel)}
+        >
+          <div {...stylex.props(styles.panelHeading)}>
+            <SectionHeading id="bottle-resolution-heading">
+              Bottle resolution
+            </SectionHeading>
+            <p
+              {...stylex.props(foundationStyles.body, styles.panelDescription)}
+            >
+              New reviews and prices from the last 30 days, grouped by their
+              current Bottle match.
+            </p>
+          </div>
+
+          {resolutionTotal ? (
+            <>
+              <div aria-hidden="true" {...stylex.props(styles.resolutionTrack)}>
+                {bottleResolution.unknown ? (
+                  <span
+                    style={{ flexGrow: bottleResolution.unknown }}
+                    {...stylex.props(styles.resolutionSegment, styles.unknown)}
+                  />
+                ) : null}
+                {bottleResolution.created ? (
+                  <span
+                    style={{ flexGrow: bottleResolution.created }}
+                    {...stylex.props(styles.resolutionSegment, styles.created)}
+                  />
+                ) : null}
+                {bottleResolution.matched ? (
+                  <span
+                    style={{ flexGrow: bottleResolution.matched }}
+                    {...stylex.props(styles.resolutionSegment, styles.matched)}
+                  />
+                ) : null}
+              </div>
+              <dl {...stylex.props(styles.resolutionList)}>
+                <ResolutionItem
+                  label="Unknown"
+                  value={bottleResolution.unknown}
+                  total={resolutionTotal}
+                  detail="no Bottle match yet"
+                  tone="unknown"
+                />
+                <ResolutionItem
+                  label="New bottles"
+                  value={bottleResolution.created}
+                  total={resolutionTotal}
+                  detail="added to Peated"
+                  tone="created"
+                />
+                <ResolutionItem
+                  label="Existing matches"
+                  value={bottleResolution.matched}
+                  total={resolutionTotal}
+                  detail="matched to Bottles in Peated"
+                  tone="matched"
+                />
+              </dl>
+            </>
+          ) : (
+            <p {...stylex.props(foundationStyles.body, styles.empty)}>
+              No new reviews or prices in the last 30 days.
+            </p>
+          )}
+        </section>
+
+        <section
+          aria-labelledby="price-matching-heading"
+          {...stylex.props(styles.matchingPanel)}
+        >
           <div {...stylex.props(styles.matchingHeader)}>
-            <h3 {...stylex.props(foundationStyles.compactRowTitle)}>
+            <SectionHeading id="price-matching-heading">
               Price matching
-            </h3>
+            </SectionHeading>
             {data.listingAutomation.sampleSize ? (
               <strong {...stylex.props(styles.matchingRate)}>
                 {data.listingAutomation.rate ?? 0}% automatic
@@ -229,8 +287,8 @@ export default function OperationsOverview({
                   {formatCount(data.listingAutomation.failed)} failed
                 </span>
                 <br />
-                Last {formatCount(data.listingAutomation.sampleSize)} prices
-                checked
+                Last {formatCount(data.listingAutomation.sampleSize)} completed
+                checks
               </p>
               <dl
                 aria-label="Price matching by decision"
@@ -259,14 +317,30 @@ export default function OperationsOverview({
               No completed price checks yet.
             </p>
           )}
-        </div>
-      </section>
+        </section>
+      </div>
     </div>
   );
 }
 
 const styles = stylex.create({
-  overviewGrid: {
+  root: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x6,
+  },
+  workGrid: {
+    display: "grid",
+    minWidth: 0,
+    alignItems: "start",
+    gridTemplateColumns: {
+      default: "repeat(2, minmax(0, 1fr))",
+      "@media (max-width: 839px)": "1fr",
+    },
+    gap: space.x4,
+  },
+  insightsGrid: {
     display: "grid",
     minWidth: 0,
     alignItems: "start",
@@ -274,21 +348,39 @@ const styles = stylex.create({
       default: "minmax(0, 1.7fr) minmax(280px, 1fr)",
       "@media (max-width: 839px)": "1fr",
     },
-    gap: space.x4,
+    gap: space.x6,
+    paddingTop: space.x6,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.sectionRule,
   },
-  resolutionPanel: {
+  moderationPanel: {
     minWidth: 0,
     padding: { default: space.x6, "@media (max-width: 639px)": space.x4 },
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.surface,
   },
-  statusPanel: {
+  backgroundPanel: {
     minWidth: 0,
     padding: { default: space.x6, "@media (max-width: 639px)": space.x4 },
     borderWidth: "1px",
     borderStyle: "solid",
     borderColor: colors.hairline,
     borderRadius: controlMetrics.radius,
+  },
+  resolutionPanel: { minWidth: 0 },
+  matchingPanel: { minWidth: 0 },
+  panelHeader: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space.x3,
+    "@media (max-width: 479px)": {
+      alignItems: "flex-start",
+      flexDirection: "column",
+      gap: space.x2,
+    },
   },
   panelHeading: {
     display: "flex",
@@ -370,13 +462,23 @@ const styles = stylex.create({
     borderTopColor: colors.hairline,
     color: colors.inkMuted,
   },
-  statusHeader: {
+  summaryCount: {
     display: "flex",
-    minWidth: 0,
     alignItems: "baseline",
-    justifyContent: "space-between",
-    gap: space.x3,
+    gap: space.x2,
+    margin: 0,
+    marginTop: space.x6,
   },
+  summaryValue: {
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "32px",
+    fontWeight: 700,
+    letterSpacing: "-0.04em",
+    lineHeight: 1,
+    fontVariantNumeric: "tabular-nums",
+  },
+  summaryLabel: { color: colors.inkMuted },
   statusList: {
     display: "flex",
     minWidth: 0,
@@ -411,12 +513,6 @@ const styles = stylex.create({
     fontVariantNumeric: "tabular-nums",
   },
   danger: { color: colors.critical },
-  matching: {
-    marginTop: space.x4,
-    padding: space.x3,
-    borderRadius: controlMetrics.radiusSmall,
-    backgroundColor: colors.surface,
-  },
   matchingHeader: {
     display: "flex",
     minWidth: 0,
@@ -431,7 +527,7 @@ const styles = stylex.create({
     fontWeight: 700,
     lineHeight: 1.2,
   },
-  matchingDetail: { marginTop: space.x2, color: colors.inkMuted },
+  matchingDetail: { marginTop: space.x4, color: colors.inkMuted },
   matchingBreakdown: {
     display: "grid",
     gap: space.x1,

--- a/apps/web/src/components/admin/operationsOverview.test.tsx
+++ b/apps/web/src/components/admin/operationsOverview.test.tsx
@@ -40,15 +40,35 @@ const operations = {
   recentRuns: [],
 };
 
+const inboxCounts = {
+  all: 23,
+  listing: 18,
+  catalog: 5,
+  blocked: 2,
+  inconclusive: 7,
+};
+
 describe("OperationsOverview", () => {
   it("distinguishes unknown, new, and matched Bottles", () => {
     const html = renderToStaticMarkup(
       <OperationsOverview
         bottleResolution={{ unknown: 8, created: 6, matched: 75 }}
         data={operations}
+        inboxCounts={inboxCounts}
       />,
     );
 
+    expect(html).toContain("Moderation inbox");
+    expect(html).toContain("open decisions");
+    expect(html).toContain(">23</strong>");
+    expect(html).toContain('href="/admin/moderation/inbox"');
+    expect(html).toContain("Open inbox");
+    expect(html).toContain("Background work");
+    expect(html).toContain("failed items");
+    expect(html).toContain('href="/admin/moderation/automation"');
+    expect(html).toContain("View background work");
+    expect(html).not.toContain("Needs attention");
+    expect(html).not.toContain("System status");
     expect(html).toContain("Bottle resolution");
     expect(html).toContain("Unknown");
     expect(html).toContain("New bottles");
@@ -59,7 +79,6 @@ describe("OperationsOverview", () => {
     expect(html).toContain("90% · 72 checked");
     expect(html).toContain("New Bottles");
     expect(html).toContain("29% · 28 checked");
-    expect(html).toContain("View work");
   });
 
   it("uses a compact empty state when there are no new source items", () => {
@@ -67,6 +86,7 @@ describe("OperationsOverview", () => {
       <OperationsOverview
         bottleResolution={{ unknown: 0, created: 0, matched: 0 }}
         data={operations}
+        inboxCounts={inboxCounts}
       />,
     );
 

--- a/docs/features/moderation-workspace.md
+++ b/docs/features/moderation-workspace.md
@@ -31,7 +31,8 @@ History combines completed listing decisions, reviewed catalog changes, and
 closed checks. Show only facts recorded by those sources. Label a missing actor
 or reason as unavailable.
 
-The admin overview shows live queue totals, recent price-matching results, and
-the current Bottle resolution of review and price inputs added in the last 30
-days. Background work shows retry runs and catalog changes that stopped. It is
-not a measure of decision accuracy and cannot approve a catalog change.
+The admin overview shows open Inbox decisions separately from failed and active
+background work. It also shows recent price-matching results and the current
+Bottle resolution of review and price inputs added in the last 30 days.
+Background work shows retry runs and catalog changes that stopped. It is not a
+measure of decision accuracy and cannot approve a catalog change.


### PR DESCRIPTION
The Operations dashboard now leads with two separate work summaries: the Moderation inbox shows the live count of human decisions, while Background work shows failed, active, and waiting automated work. Each summary links directly to its owning workspace, and the Bottle resolution and price-matching metrics remain available below as secondary context.

This removes the ambiguous “Needs attention” label and the mixed “Finished today” total that made moderation progress look unrelated to completed decisions. The Background work page also calls its failure list “Stopped work,” keeping the same distinction after navigation. The responsive layout was reviewed in the real admin route at desktop and phone widths.
