### PR TITLE
feat(scraper): repair broken rules once before requiring review

### DIFF
--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -142,14 +142,26 @@ source needs one of those features.
 Adding a source starts AI setup. The server reads the main page, up to four
 likely list pages on the same website, and any optional example review or
 product pages. AI calls `check_rules` with the list page and article or product
-page rules. Code checks the list page, one next page when present, and up to
-three article or product pages using the same code as collection. When a check
-fails, AI gets the errors and pages so it can fix the rules. Setup allows three
-checks and saves a version only after a check passes. Final rule errors are
+page rules. Code checks the list page, one next page when present, and all
+selected article or product links using the collection parser. When a check
+fails, AI gets the errors and pages so it can fix the rules. Each setup or repair
+run allows three model calls total, including resumed jobs, and saves a version
+only after a check passes. Final rule errors are
 saved with the run and shown in Admin. Problems with the AI service, database,
 job runner, or network remain system errors. The AI service does not store
-request content. An admin must still preview and turn on the new version. AI
-never changes the version in use.
+request content. A passing check saves the preview result with the new version.
+An admin turns on versions requested through setup.
+
+A collection failure caused by broken rules marks the active version failed,
+which stops further collection. The source gets one automatic repair attempt.
+The agent receives the failing page, errors, saved rules, and previous matches.
+Passing repair rules activate automatically unless an admin paused the source
+or changed its active version. Network failures do not start repairs.
+
+If repair fails, or its replacement rules fail collection, collection stays
+stopped for admin review. Run history allows another automatic repair only after
+a complete successful collection—not after time passes, a preview passes, or a
+new version is saved. An admin can still request another suggestion.
 
 Before shortening pages for AI, setup removes scripts and styles from its copy.
 This keeps links and article content from being cut off. Rule checks and

--- a/apps/server/src/scraper/configured/createScraper.eval.test.ts
+++ b/apps/server/src/scraper/configured/createScraper.eval.test.ts
@@ -173,23 +173,7 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         expect(await db.select().from(externalReviews)).toEqual([]);
 
         const revisionInput = { id: source.id, revisionId: revision.id };
-        await expect(
-          routerClient.externalSites.scrapeSources.activate(
-            revisionInput,
-            context,
-          ),
-        ).rejects.toThrow("Preview this version successfully");
-        await routerClient.externalSites.scrapeSources.preview(
-          revisionInput,
-          context,
-        );
-        await waitForWorker();
-        const [previewed] = await routerClient.externalSites.scrapeSources.list(
-          { site: source.site.type },
-          context,
-        );
-        const preview = previewed.revisions[0].previewResult;
-        expect(previewed.revisions[0].previewStatus).toBe("passed");
+        const preview = revision.previewResult;
         expect(preview.issues).toEqual([]);
         expect(preview.pages).toHaveLength(
           new Set(website.reviews.map((review) => review.url)).size,
@@ -218,10 +202,12 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
           });
         }
         expect(await db.select().from(externalReviews)).toEqual([]);
-        await routerClient.externalSites.scrapeSources.activate(
-          revisionInput,
-          context,
-        );
+        await expect(
+          routerClient.externalSites.scrapeSources.activate(
+            revisionInput,
+            context,
+          ),
+        ).resolves.toEqual({ activeRevisionId: revision.id });
         await routerClient.externalSites.reviewPublication.update(
           { site: source.site.type, publication: { approved: true } },
           context,

--- a/apps/server/src/scraper/configured/createScraper.eval.test.ts
+++ b/apps/server/src/scraper/configured/createScraper.eval.test.ts
@@ -162,7 +162,7 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         expect(revision).toMatchObject({
           author: "ai",
           aiInstructionsVersion: AI_INSTRUCTIONS_VERSION,
-          previewStatus: "pending",
+          previewStatus: "passed",
           active: false,
         });
         if (website.key === "rss") {

--- a/apps/server/src/scraper/configured/preview.ts
+++ b/apps/server/src/scraper/configured/preview.ts
@@ -2,7 +2,7 @@ import { BottleExtractedDetailsSchema } from "@peated/bottle-classifier/contract
 import { CURRENCY_LIST } from "@peated/server/constants";
 import { z } from "zod";
 
-const ScrapeIssueSchema = z
+export const ScrapeIssueSchema = z
   .object({
     field: z.string(),
     message: z.string(),

--- a/apps/server/src/scraper/configured/repair.test.ts
+++ b/apps/server/src/scraper/configured/repair.test.ts
@@ -1,0 +1,630 @@
+import { db } from "@peated/server/db";
+import {
+  externalSiteRuns,
+  scrapeOrigins,
+  scrapeSourceRevisions,
+  scrapeSourceRuns,
+  scrapeTargets,
+  users,
+} from "@peated/server/db/schema";
+import { and, eq } from "drizzle-orm";
+import { beforeEach, expect, test, vi } from "vitest";
+import { z } from "zod";
+import { createScraperRegistry } from "../definitions";
+import type { ScraperHttpClock } from "../http";
+import { createScraperLifecycle, type ScraperEnqueue } from "../lifecycle";
+import { executeScraperRun } from "../runs";
+import type { ScrapeRules } from "./rules";
+import {
+  createPinnedScrapeSourceRun,
+  createScrapeSourceSuggestionRun,
+} from "./runs";
+import {
+  activateScrapeSourceRevision,
+  createScrapeSourceRevision,
+  createSiteWithScrapeSource,
+  pauseScrapeSource,
+} from "./service";
+import type { RequestScrapeSourceModel } from "./suggestion";
+
+const requestModel = vi.fn<RequestScrapeSourceModel>();
+
+const oldRules = {
+  kind: "review",
+  list: {
+    links: "a.review",
+    nextPage: null,
+    limit: 5,
+  },
+  detail: {
+    url: null,
+    title: "h1",
+    date: "time",
+    reviews: {
+      area: "body",
+      item: "article.review",
+      name: "h3",
+      reviewer: null,
+      tastingNotes: ".body",
+      score: null,
+    },
+  },
+} as const satisfies ScrapeRules;
+
+const repairedRules = {
+  ...oldRules,
+  detail: { ...oldRules.detail, title: "h1, h2.page-title" },
+} as const satisfies ScrapeRules;
+
+type TestClock = ScraperHttpClock & { advanceTo(value: Date): void };
+
+function testClock(start = "2026-09-09T12:00:00Z"): TestClock {
+  let now = new Date(start);
+  return {
+    now: () => now,
+    sleep: async (milliseconds) => {
+      now = new Date(now.getTime() + milliseconds);
+    },
+    random: () => 0,
+    advanceTo: (value) => {
+      now = value;
+    },
+  };
+}
+
+async function runToCompletion(input: {
+  runId: number;
+  fetchImpl: typeof fetch;
+  clock: TestClock;
+  executionToken: string;
+}) {
+  const registry = createScraperRegistry({ targets: [], sources: [] });
+  for (let attempt = 1; attempt <= 20; attempt += 1) {
+    const result = await executeScraperRun(
+      { runId: input.runId },
+      {
+        registry,
+        fetchImpl: input.fetchImpl,
+        clock: input.clock,
+        executionToken: `${input.executionToken}-${attempt}`,
+        requestModel,
+      },
+    );
+    if (result.status === "completed") return result;
+    if (result.status !== "waiting") {
+      throw new Error("The test run is already owned by another worker.");
+    }
+    input.clock.advanceTo(result.nextAttemptAt);
+  }
+  throw new Error("The test run did not finish within 20 attempts.");
+}
+
+async function setupSource() {
+  const [user] = await db
+    .insert(users)
+    .values({
+      username: "repair-admin",
+      email: "repair-admin@example.com",
+      admin: true,
+    })
+    .returning();
+  if (!user) throw new Error("Failed to create test user.");
+  const created = await createSiteWithScrapeSource({
+    name: "Repair Reviews",
+    kind: "review",
+    websiteUrl: "https://repair.example/archive",
+    createdById: user.id,
+  });
+  const revision = await createScrapeSourceRevision({
+    scrapeSourceId: created.source.id,
+    author: "person",
+    createdById: user.id,
+    rules: oldRules,
+  });
+  await db
+    .update(scrapeSourceRevisions)
+    .set({
+      previewStatus: "passed",
+      previewResult: { issues: [], pages: [] },
+      previewedAt: new Date(),
+    })
+    .where(eq(scrapeSourceRevisions.id, revision.id));
+  await activateScrapeSourceRevision({
+    scrapeSourceId: created.source.id,
+    revisionId: revision.id,
+  });
+  await db
+    .update(scrapeOrigins)
+    .set({
+      robotsMode: "not_applicable",
+      robotsRationale: "Reserved test origin has no network operator.",
+    })
+    .where(eq(scrapeOrigins.origin, "https://repair.example"));
+  return { ...created, revision, user };
+}
+
+function sitePages() {
+  return vi.fn<typeof fetch>(async (input) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.pathname === "/archive") {
+      return new Response(
+        '<a class="review" href="/one">One</a><a class="review" href="/legacy">Legacy</a>',
+      );
+    }
+    if (url.pathname === "/one") {
+      return new Response(
+        '<h1>Current reviews</h1><time datetime="2026-09-08"></time><article class="review"><h3>Current Malt</h3><div class="body">Fresh fruit.</div></article>',
+      );
+    }
+    if (url.pathname === "/legacy") {
+      return new Response(
+        '<h2 class="page-title">Legacy reviews</h2><time datetime="2026-09-07"></time><article class="review"><h3>Legacy Malt</h3><div class="body">Soft smoke.</div></article>',
+      );
+    }
+    throw new Error(`Unexpected URL: ${url.toString()}`);
+  });
+}
+
+function ruleResponse(rules: ScrapeRules) {
+  return {
+    model: "test-model",
+    output: [
+      {
+        type: "function_call" as const,
+        call_id: "repair-rules",
+        name: "check_rules",
+        arguments: JSON.stringify({
+          listPageUrl: "https://repair.example/archive",
+          rules,
+        }),
+      },
+    ],
+  };
+}
+
+async function startRepair() {
+  const created = await setupSource();
+  const collection = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: created.site.id,
+    trigger: "scheduled",
+    purpose: "collect",
+  });
+  const result = await runToCompletion({
+    runId: collection.run.id,
+    fetchImpl: sitePages(),
+    clock: testClock(),
+    executionToken: "broken-collection",
+  });
+  if (result.nextRunId === undefined) {
+    throw new Error("Failed collection did not create a repair run.");
+  }
+  return { ...created, repairRunId: result.nextRunId };
+}
+
+async function expectCollectionStopped(siteId: number) {
+  const enqueue = vi.fn<ScraperEnqueue>();
+  const lifecycle = createScraperLifecycle({
+    registry: createScraperRegistry({ targets: [], sources: [] }),
+    enqueue,
+  });
+  await expect(
+    lifecycle.queueScheduledExternalSiteRun(siteId),
+  ).resolves.toBeNull();
+  expect(enqueue).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  requestModel.mockReset();
+});
+
+test("repairs, checks, and activates broken rules without another model call", async () => {
+  const { revision, site, source, user, repairRunId } = await startRepair();
+  const fetchImpl = sitePages();
+  expect(requestModel).not.toHaveBeenCalled();
+
+  const [broken] = await db
+    .select()
+    .from(scrapeSourceRevisions)
+    .where(eq(scrapeSourceRevisions.id, revision.id));
+  expect(broken).toMatchObject({ previewStatus: "failed", active: true });
+  const [repairRun] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, repairRunId));
+  expect(repairRun).toMatchObject({
+    status: "queued",
+    purpose: "suggest",
+    requestedById: null,
+    requestLimit: 309,
+    cursor: {
+      repair: {
+        revisionId: revision.id,
+        pageUrl: "https://repair.example/legacy",
+      },
+    },
+  });
+
+  await expectCollectionStopped(site.id);
+  requestModel.mockResolvedValue(ruleResponse(repairedRules));
+  await expect(
+    runToCompletion({
+      runId: repairRunId,
+      fetchImpl,
+      clock: testClock(),
+      executionToken: "repair-owner",
+    }),
+  ).resolves.toEqual({ status: "completed" });
+
+  const revisions = await db
+    .select()
+    .from(scrapeSourceRevisions)
+    .where(eq(scrapeSourceRevisions.scrapeSourceId, source.id));
+  expect(revisions).toHaveLength(2);
+  const repaired = revisions.find((candidate) => candidate.id !== revision.id);
+  expect(repaired).toMatchObject({
+    author: "ai",
+    createdById: null,
+    active: true,
+    previewStatus: "passed",
+    previewResult: {
+      issues: [],
+      pages: [
+        { url: "https://repair.example/one" },
+        { url: "https://repair.example/legacy" },
+      ],
+    },
+  });
+  expect(
+    revisions.find((candidate) => candidate.id === revision.id),
+  ).toMatchObject({ active: false });
+  expect(requestModel).toHaveBeenCalledTimes(1);
+  const firstInput = requestModel.mock.calls[0]?.[0].input[0];
+  const { content } = z.object({ content: z.string() }).parse(firstInput);
+  expect(JSON.parse(content)).toMatchObject({
+    failure: {
+      url: "https://repair.example/legacy",
+      html: expect.stringContaining("Legacy reviews"),
+      issues: expect.any(Array),
+    },
+    previousSetup: {
+      rules: oldRules,
+    },
+  });
+
+  await expect(
+    runToCompletion({
+      runId: repairRunId,
+      fetchImpl,
+      clock: testClock(),
+      executionToken: "duplicate-repair",
+    }),
+  ).resolves.toEqual({ status: "completed" });
+  expect(requestModel).toHaveBeenCalledTimes(1);
+
+  const healthy = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    requestedById: user.id,
+    trigger: "scheduled",
+    purpose: "collect",
+  });
+  await expect(
+    runToCompletion({
+      runId: healthy.run.id,
+      fetchImpl,
+      clock: testClock(),
+      executionToken: "healthy-owner",
+    }),
+  ).resolves.toEqual({ status: "completed" });
+  expect(requestModel).toHaveBeenCalledTimes(1);
+  expect(
+    await db
+      .select()
+      .from(scrapeSourceRuns)
+      .where(
+        and(
+          eq(scrapeSourceRuns.scrapeSourceId, source.id),
+          eq(scrapeSourceRuns.purpose, "suggest"),
+        ),
+      ),
+  ).toHaveLength(1);
+
+  // A completed collection proves recovery, even if the next break is the same day.
+  const later = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    trigger: "scheduled",
+    purpose: "collect",
+  });
+  await expect(
+    runToCompletion({
+      runId: later.run.id,
+      fetchImpl: vi.fn<typeof fetch>(
+        async () => new Response("<main>Changed page</main>"),
+      ),
+      clock: testClock("2026-09-09T18:00:00Z"),
+      executionToken: "new-break",
+    }),
+  ).resolves.toMatchObject({ nextRunId: expect.any(Number) });
+  expect(requestModel).toHaveBeenCalledTimes(1);
+  expect(
+    await db
+      .select()
+      .from(scrapeSourceRuns)
+      .where(eq(scrapeSourceRuns.purpose, "suggest")),
+  ).toHaveLength(2);
+});
+
+test("does not ask the model to repair a network failure", async () => {
+  const { site, user } = await setupSource();
+  await db.update(scrapeTargets).set({ maxRetries: 0 });
+  const collection = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    requestedById: user.id,
+    trigger: "scheduled",
+    purpose: "collect",
+  });
+
+  await expect(
+    runToCompletion({
+      runId: collection.run.id,
+      fetchImpl: vi.fn<typeof fetch>(async () => {
+        throw new TypeError("Connection closed");
+      }),
+      clock: testClock(),
+      executionToken: "network-failure-owner",
+    }),
+  ).rejects.toThrow("Scraper request failed: transport");
+  expect(requestModel).not.toHaveBeenCalled();
+  expect(
+    await db
+      .select()
+      .from(scrapeSourceRuns)
+      .where(eq(scrapeSourceRuns.purpose, "suggest")),
+  ).toEqual([]);
+});
+
+test("a repaired version that fails collection cannot start another repair days later", async () => {
+  const { site, source, repairRunId } = await startRepair();
+  requestModel.mockResolvedValue(ruleResponse(repairedRules));
+  await runToCompletion({
+    runId: repairRunId,
+    fetchImpl: sitePages(),
+    clock: testClock(),
+    executionToken: "repair-owner",
+  });
+  const preview = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    trigger: "manual",
+    purpose: "preview",
+  });
+  await runToCompletion({
+    runId: preview.run.id,
+    fetchImpl: sitePages(),
+    clock: testClock(),
+    executionToken: "passing-preview",
+  });
+  await db.update(scrapeTargets).set({ maxRetries: 0 });
+  const networkFailure = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    trigger: "scheduled",
+    purpose: "collect",
+  });
+  await expect(
+    runToCompletion({
+      runId: networkFailure.run.id,
+      fetchImpl: vi.fn<typeof fetch>(async () => {
+        throw new TypeError("Connection closed");
+      }),
+      clock: testClock(),
+      executionToken: "network-failure-after-repair",
+    }),
+  ).rejects.toThrow("Scraper request failed: transport");
+  const collection = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    trigger: "scheduled",
+    purpose: "collect",
+  });
+  await db
+    .update(externalSiteRuns)
+    .set({ createdAt: new Date("2026-09-15T12:00:00Z") })
+    .where(eq(externalSiteRuns.id, collection.run.id));
+  await expect(
+    runToCompletion({
+      runId: collection.run.id,
+      fetchImpl: vi.fn<typeof fetch>(
+        async () => new Response("<main>Changed page</main>"),
+      ),
+      clock: testClock("2026-09-15T12:00:00Z"),
+      executionToken: "failed-repaired-version",
+    }),
+  ).resolves.toEqual({ status: "completed" });
+  for (const runId of [repairRunId, collection.run.id]) {
+    await runToCompletion({
+      runId,
+      fetchImpl: sitePages(),
+      clock: testClock("2026-10-01T12:00:00Z"),
+      executionToken: "redelivered-job",
+    });
+  }
+  await expectCollectionStopped(site.id);
+  expect(requestModel).toHaveBeenCalledTimes(1);
+  expect(
+    await db
+      .select()
+      .from(scrapeSourceRuns)
+      .where(eq(scrapeSourceRuns.purpose, "suggest")),
+  ).toHaveLength(1);
+  expect(
+    await db
+      .select()
+      .from(scrapeSourceRevisions)
+      .where(
+        and(
+          eq(scrapeSourceRevisions.scrapeSourceId, source.id),
+          eq(scrapeSourceRevisions.active, true),
+        ),
+      ),
+  ).toMatchObject([{ previewStatus: "failed" }]);
+});
+
+test("failed repair stops after three model calls and allows an explicit manual retry", async () => {
+  const { site, source, user, revision, repairRunId } = await startRepair();
+  requestModel.mockResolvedValue(ruleResponse(oldRules));
+  await runToCompletion({
+    runId: repairRunId,
+    fetchImpl: sitePages(),
+    clock: testClock(),
+    executionToken: "failed-repair",
+  });
+  expect(requestModel).toHaveBeenCalledTimes(3);
+  expect(
+    await db
+      .select()
+      .from(externalSiteRuns)
+      .where(eq(externalSiteRuns.id, repairRunId)),
+  ).toMatchObject([{ status: "failed" }]);
+  expect(await db.select().from(scrapeSourceRevisions)).toMatchObject([
+    { id: revision.id, active: true, previewStatus: "failed" },
+  ]);
+  await runToCompletion({
+    runId: repairRunId,
+    fetchImpl: sitePages(),
+    clock: testClock("2026-10-01T12:00:00Z"),
+    executionToken: "redelivered-failed-repair",
+  });
+  await expectCollectionStopped(site.id);
+  expect(requestModel).toHaveBeenCalledTimes(3);
+
+  const manual = await createScrapeSourceSuggestionRun({
+    scrapeSourceId: source.id,
+    requestedById: user.id,
+  });
+  requestModel.mockResolvedValue(ruleResponse(repairedRules));
+  await runToCompletion({
+    runId: manual.id,
+    fetchImpl: sitePages(),
+    clock: testClock(),
+    executionToken: "manual-retry",
+  });
+  expect(requestModel).toHaveBeenCalledTimes(4);
+  expect(
+    await db
+      .select()
+      .from(scrapeSourceRevisions)
+      .where(eq(scrapeSourceRevisions.author, "ai")),
+  ).toMatchObject([{ active: false, previewStatus: "passed" }]);
+});
+
+test("pausing while repair is running prevents automatic activation", async () => {
+  const { site, source, revision, repairRunId } = await startRepair();
+  requestModel.mockImplementation(async () => {
+    await pauseScrapeSource(source.id);
+    return ruleResponse(repairedRules);
+  });
+  await runToCompletion({
+    runId: repairRunId,
+    fetchImpl: sitePages(),
+    clock: testClock(),
+    executionToken: "paused-repair",
+  });
+  expect(requestModel).toHaveBeenCalledTimes(1);
+  expect(
+    await db
+      .select()
+      .from(scrapeSourceRevisions)
+      .where(eq(scrapeSourceRevisions.active, true)),
+  ).toMatchObject([{ id: revision.id }]);
+  await expectCollectionStopped(site.id);
+});
+
+test("waiting during a rule check does not give the repair a new model budget", async () => {
+  const { site, repairRunId } = await startRepair();
+  requestModel.mockResolvedValue(ruleResponse(repairedRules));
+  const pages = sitePages();
+  const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.pathname === "/archive") {
+      return new Response(
+        '<a class="review" href="/one">One</a><a class="review" href="/legacy">Two</a><a class="review" href="/third">Three</a><a class="review" href="/blocked">Four</a>',
+      );
+    }
+    if (url.pathname === "/third") return pages("https://repair.example/one");
+    if (url.pathname === "/blocked") {
+      return new Response(null, {
+        status: 429,
+        headers: { "retry-after": "60" },
+      });
+    }
+    return pages(input, init);
+  });
+
+  await runToCompletion({
+    runId: repairRunId,
+    fetchImpl,
+    clock: testClock(),
+    executionToken: "waiting-repair",
+  });
+
+  expect(requestModel).toHaveBeenCalledTimes(3);
+  expect(
+    await db
+      .select()
+      .from(externalSiteRuns)
+      .where(eq(externalSiteRuns.id, repairRunId)),
+  ).toMatchObject([
+    {
+      status: "failed",
+      cursor: { modelCallCount: 3 },
+      error: expect.stringContaining("rule check limit"),
+    },
+  ]);
+  expect(
+    await db
+      .select()
+      .from(scrapeSourceRuns)
+      .where(eq(scrapeSourceRuns.purpose, "suggest")),
+  ).toHaveLength(1);
+  await expectCollectionStopped(site.id);
+});
+
+test("duplicate delivery while the model is running cannot start another repair", async () => {
+  const { repairRunId } = await startRepair();
+  const enteredModel = Promise.withResolvers<void>();
+  const finishModel = Promise.withResolvers<void>();
+  requestModel.mockImplementation(async () => {
+    enteredModel.resolve();
+    await finishModel.promise;
+    return ruleResponse(repairedRules);
+  });
+  const clock = testClock();
+  const running = runToCompletion({
+    runId: repairRunId,
+    fetchImpl: sitePages(),
+    clock,
+    executionToken: "first-worker",
+  });
+  await enteredModel.promise;
+  try {
+    await expect(
+      executeScraperRun(
+        { runId: repairRunId },
+        {
+          registry: createScraperRegistry({ targets: [], sources: [] }),
+          fetchImpl: sitePages(),
+          clock,
+          executionToken: "duplicate-worker",
+          requestModel,
+        },
+      ),
+    ).resolves.toEqual({ status: "duplicate" });
+    expect(requestModel).toHaveBeenCalledTimes(1);
+  } finally {
+    finishModel.resolve();
+    await running;
+  }
+  expect(
+    await db
+      .select()
+      .from(scrapeSourceRevisions)
+      .where(eq(scrapeSourceRevisions.author, "ai")),
+  ).toMatchObject([{ active: true, previewStatus: "passed" }]);
+});

--- a/apps/server/src/scraper/configured/runs.ts
+++ b/apps/server/src/scraper/configured/runs.ts
@@ -1,18 +1,75 @@
-import { type AnyDatabase, db } from "@peated/server/db";
+import { db, type AnyDatabase } from "@peated/server/db";
 import {
   externalSiteRuns,
   scrapeSourceRevisions,
   scrapeSourceRuns,
   scrapeSources,
 } from "@peated/server/db/schema";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, or } from "drizzle-orm";
+import { z } from "zod";
+import { ScraperRunTakenOverError } from "../session";
 import { loadExecutableScrapeRules } from "./compatibility";
+import { ScrapeIssueSchema, type ScrapeIssue } from "./preview";
 import { SCRAPE_RULES_VERSION, SCRAPE_SOURCE_MAX_LIST_PAGES } from "./rules";
 import {
   ScrapeSourceNotFoundError,
   ScrapeSourceValidationError,
 } from "./service";
-import { setupRequestLimit } from "./setupAgent";
+import { MAX_RULE_CHECKS, setupRequestLimit } from "./setupAgent";
+import { ScrapeSourceSetupError } from "./setupError";
+
+export const ScrapeSourceSuggestionCursorSchema = z.union([
+  z.null(),
+  z
+    .object({
+      repair: z
+        .object({
+          revisionId: z.number().int().positive(),
+          pageUrl: z.url(),
+          issues: z.array(ScrapeIssueSchema),
+        })
+        .strict()
+        .optional(),
+      modelCallCount: z.number().int().min(0).max(MAX_RULE_CHECKS).default(0),
+    })
+    .strict(),
+]);
+
+export type ScrapeSourceSuggestionCursor = z.infer<
+  typeof ScrapeSourceSuggestionCursorSchema
+>;
+
+/** Setup counts calls before sending them so a resumed job keeps the same limit. */
+export async function reserveScrapeSourceModelCall(
+  runId: number,
+  executionToken: string,
+) {
+  await db.transaction(async (tx) => {
+    const [run] = await tx
+      .select()
+      .from(externalSiteRuns)
+      .where(eq(externalSiteRuns.id, runId))
+      .for("update");
+    if (
+      !run ||
+      run.status !== "running" ||
+      run.executionToken !== executionToken
+    ) {
+      throw new ScraperRunTakenOverError();
+    }
+    const cursor = ScrapeSourceSuggestionCursorSchema.parse(run.cursor);
+    const count = cursor?.modelCallCount ?? 0;
+    if (count >= MAX_RULE_CHECKS) {
+      throw new ScrapeSourceSetupError(
+        "The rule check limit was reached. Review the source before trying again.",
+      );
+    }
+    await tx
+      .update(externalSiteRuns)
+      .set({ cursor: { ...cursor, modelCallCount: count + 1 } })
+      .where(eq(externalSiteRuns.id, runId));
+  });
+}
 
 export async function createPinnedScrapeSourceRun(
   connection: AnyDatabase,
@@ -133,4 +190,114 @@ export async function createScrapeSourceSuggestionRun(input: {
     });
     return run;
   });
+}
+
+/** Stops broken rules and allows one repair between successful collections. */
+export async function createScrapeSourceRepairRun(
+  connection: AnyDatabase,
+  input: {
+    failedRunId: number;
+    pageUrl: string;
+    issues: ScrapeIssue[];
+    now: Date;
+  },
+) {
+  const [sourceRun] = await connection
+    .select({
+      purpose: scrapeSourceRuns.purpose,
+      revisionId: scrapeSourceRuns.revisionId,
+      scrapeSourceId: scrapeSourceRuns.scrapeSourceId,
+    })
+    .from(scrapeSourceRuns)
+    .where(eq(scrapeSourceRuns.externalSiteRunId, input.failedRunId));
+  if (sourceRun?.purpose !== "collect" || sourceRun.revisionId === null) {
+    return null;
+  }
+
+  const [source] = await connection
+    .select()
+    .from(scrapeSources)
+    .where(eq(scrapeSources.id, sourceRun.scrapeSourceId))
+    .for("update");
+  if (!source?.enabled) return null;
+
+  const [revision] = await connection
+    .select()
+    .from(scrapeSourceRevisions)
+    .where(
+      and(
+        eq(scrapeSourceRevisions.id, sourceRun.revisionId),
+        eq(scrapeSourceRevisions.scrapeSourceId, source.id),
+        eq(scrapeSourceRevisions.active, true),
+      ),
+    );
+  if (!revision) return null;
+
+  await connection
+    .update(scrapeSourceRevisions)
+    .set({
+      previewStatus: "failed",
+      previewResult: {
+        issues: input.issues,
+        pages: revision.previewResult.pages,
+      },
+      previewedAt: input.now,
+    })
+    .where(eq(scrapeSourceRevisions.id, revision.id));
+
+  // Repair eligibility belongs to the source. A new version or a passing preview
+  // cannot restore it; only a complete collection proves the source recovered.
+  const [lastRepairOrSuccess] = await connection
+    .select({ purpose: scrapeSourceRuns.purpose })
+    .from(scrapeSourceRuns)
+    .innerJoin(
+      externalSiteRuns,
+      eq(externalSiteRuns.id, scrapeSourceRuns.externalSiteRunId),
+    )
+    .where(
+      and(
+        eq(scrapeSourceRuns.scrapeSourceId, source.id),
+        or(
+          and(
+            eq(scrapeSourceRuns.purpose, "suggest"),
+            eq(externalSiteRuns.trigger, "scheduled"),
+          ),
+          and(
+            eq(scrapeSourceRuns.purpose, "collect"),
+            eq(externalSiteRuns.status, "succeeded"),
+          ),
+        ),
+      ),
+    )
+    .orderBy(desc(externalSiteRuns.id))
+    .limit(1);
+  if (lastRepairOrSuccess?.purpose === "suggest") return null;
+
+  const cursor = ScrapeSourceSuggestionCursorSchema.parse({
+    repair: {
+      revisionId: revision.id,
+      pageUrl: input.pageUrl,
+      issues: input.issues,
+    },
+  });
+  const [run] = await connection
+    .insert(externalSiteRuns)
+    .values({
+      externalSiteId: source.externalSiteId,
+      trigger: "scheduled",
+      purpose: "suggest",
+      requestLimit: setupRequestLimit(source.sampleUrls.length),
+      requestErrorCount: 0,
+      cursor,
+      createdAt: input.now,
+    })
+    .returning();
+  if (!run) throw new Error("Failed to create AI repair run.");
+  await connection.insert(scrapeSourceRuns).values({
+    externalSiteRunId: run.id,
+    scrapeSourceId: source.id,
+    revisionId: null,
+    purpose: "suggest",
+  });
+  return run;
 }

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -757,7 +757,7 @@ test("stores a safe preview issue when a request fails unexpectedly", async () =
   });
 });
 
-test("a collection failure does not change the preview result", async () => {
+test("a collection parse failure marks the rules broken and queues repair", async () => {
   const { revision, site, source, user } = await setupSource("h3.missing");
   await markPreviewPassed(revision.id);
   await activateScrapeSourceRevision({
@@ -777,16 +777,32 @@ test("a collection failure does not change the preview result", async () => {
       fetchImpl: previewFetch(),
       executionToken: "collection-owner",
     }),
-  ).rejects.toThrow("The page did not match the saved rules.");
+  ).resolves.toEqual({ status: "completed", nextRunId: 2 });
 
   const [storedRevision] = await db
     .select()
     .from(scrapeSourceRevisions)
     .where(eq(scrapeSourceRevisions.id, revision.id));
   expect(storedRevision).toMatchObject({
-    previewStatus: "passed",
-    previewResult: { issues: [], pages: [] },
+    previewStatus: "failed",
+    previewResult: {
+      issues: [
+        {
+          field: "detail.title",
+          message: "Required value was not found.",
+        },
+      ],
+      pages: [],
+    },
   });
+  expect(await db.select().from(scrapeSourceRuns)).toContainEqual(
+    expect.objectContaining({
+      externalSiteRunId: 2,
+      scrapeSourceId: source.id,
+      revisionId: null,
+      purpose: "suggest",
+    }),
+  );
 });
 
 test("a resumed suggestion run reuses its saved revision", async () => {

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -46,15 +46,25 @@ import {
   type ScrapeSourcePreviewPage,
 } from "./preview";
 import { SCRAPE_SOURCE_MAX_LIST_PAGES } from "./rules";
+import {
+  ScrapeSourceSuggestionCursorSchema,
+  type ScrapeSourceSuggestionCursor,
+} from "./runs";
 import { recordScrapeSourcePreview } from "./service";
-import { MAX_PAGES_TO_CHECK } from "./setupAgent";
-import { suggestScrapeSourceRevision } from "./suggestion";
+import { MAX_EXAMPLE_PAGES } from "./setupAgent";
+import {
+  suggestScrapeSourceRevision,
+  type RequestScrapeSourceModel,
+} from "./suggestion";
 import { loadScrapeSourceTarget } from "./target";
 
-class ScrapeSourceParseError extends Error {
+export class ScrapeSourceParseError extends Error {
   override name = "ScrapeSourceParseError";
 
-  constructor(readonly issues: ScrapeIssue[]) {
+  constructor(
+    readonly pageUrl: string,
+    readonly issues: ScrapeIssue[],
+  ) {
     super("The page did not match the saved rules.");
   }
 }
@@ -190,7 +200,7 @@ function createScrapeSourceAdapter(
         detailUrls.size < input.rules.limit
       ) {
         if (listUrls.has(state.nextListUrl)) {
-          throw new ScrapeSourceParseError([
+          throw new ScrapeSourceParseError(state.nextListUrl, [
             {
               field: input.rules.nextPageField,
               message: "Pagination returned a page that was already read.",
@@ -217,7 +227,10 @@ function createScrapeSourceAdapter(
           listResponse.url,
         );
         if (listResult.issues.length > 0) {
-          throw new ScrapeSourceParseError(listResult.issues);
+          throw new ScrapeSourceParseError(
+            listResponse.url.toString(),
+            listResult.issues,
+          );
         }
         for (const link of listResult.links) {
           detailUrls.add(link);
@@ -253,7 +266,10 @@ function createScrapeSourceAdapter(
         }
         const parsed = input.rules.parseDetail(response.body, response.url);
         if (parsed.issues.length > 0 || !parsed.value) {
-          throw new ScrapeSourceParseError(parsed.issues);
+          throw new ScrapeSourceParseError(
+            response.url.toString(),
+            parsed.issues,
+          );
         }
         const observation = {
           sourceKey: response.url.toString(),
@@ -444,6 +460,7 @@ export async function resolveScrapeSourceRunRegistry(
   runId: number,
   baseRegistry: ScraperRegistry,
   executionToken: string,
+  requestModel?: RequestScrapeSourceModel,
 ): Promise<ScraperRegistry> {
   const [suggestion] = await db
     .select({
@@ -488,22 +505,54 @@ export async function resolveScrapeSourceRunRegistry(
     );
   if (suggestion) {
     const requestedById = suggestion.requestedById;
-    if (suggestion.run.revisionId === null && !requestedById) {
-      throw new Error("AI suggestion run has no requesting admin.");
-    }
     const target = await loadScrapeSourceTarget(suggestion.target);
-    const adapter: ScraperAdapter<null, unknown> =
+    const adapter: ScraperAdapter<ScrapeSourceSuggestionCursor, unknown> =
       suggestion.run.revisionId !== null
         ? // A linked revision means the suggestion finished before the run was retried.
           async () => {}
-        : async ({ session }) => {
-            if (!requestedById) {
+        : async ({ cursor, session }) => {
+            const repair = cursor?.repair;
+            if (!requestedById && !repair) {
               throw new Error("AI suggestion run has no requesting admin.");
             }
-            const entryResponse = await session.request({
-              target: target.key,
-              url: new URL(suggestion.source.listUrl),
-            });
+
+            if (repair) {
+              const [current] = await db
+                .select({
+                  enabled: scrapeSources.enabled,
+                  revisionId: scrapeSourceRevisions.id,
+                })
+                .from(scrapeSources)
+                .leftJoin(
+                  scrapeSourceRevisions,
+                  and(
+                    eq(scrapeSourceRevisions.scrapeSourceId, scrapeSources.id),
+                    eq(scrapeSourceRevisions.active, true),
+                  ),
+                )
+                .where(eq(scrapeSources.id, suggestion.source.id));
+              if (
+                !current?.enabled ||
+                current.revisionId !== repair.revisionId
+              ) {
+                return;
+              }
+            }
+
+            const entryUrl = new URL(suggestion.source.listUrl).toString();
+            const failureResponse = repair
+              ? await session.request({
+                  target: target.key,
+                  url: new URL(repair.pageUrl),
+                })
+              : null;
+            const entryResponse =
+              failureResponse?.url.toString() === entryUrl
+                ? failureResponse
+                : await session.request({
+                    target: target.key,
+                    url: new URL(entryUrl),
+                  });
             const sampleUrls = new Set(
               suggestion.source.sampleUrls.map((value) =>
                 new URL(value).toString(),
@@ -580,10 +629,13 @@ export async function resolveScrapeSourceRunRegistry(
             const detailPages = [];
             for (const value of sampleUrls) {
               if (value === entryResponse.url.toString()) continue;
-              const response = await session.request({
-                target: target.key,
-                url: new URL(value),
-              });
+              const response =
+                failureResponse?.url.toString() === value
+                  ? failureResponse
+                  : await session.request({
+                      target: target.key,
+                      url: new URL(value),
+                    });
               detailPages.push({
                 url: response.url.toString(),
                 html: response.body,
@@ -595,7 +647,7 @@ export async function resolveScrapeSourceRunRegistry(
             );
             const likelyDetailPages = findLikelyDetailPages({
               kind: suggestion.source.kind,
-              limit: MAX_PAGES_TO_CHECK,
+              limit: MAX_EXAMPLE_PAGES,
               pages: listPages,
             }).filter((value) => !suppliedDetailUrls.has(value));
             for (const value of likelyDetailPages) {
@@ -619,32 +671,47 @@ export async function resolveScrapeSourceRunRegistry(
                 throw error;
               }
             }
-            await suggestScrapeSourceRevision({
-              scrapeSourceId: suggestion.source.id,
-              externalSiteRunId: runId,
-              executionToken,
-              createdById: requestedById,
-              listPages,
-              detailPages,
-              loadPage: async (url) => {
-                const response = await session.request({
-                  target: target.key,
-                  url,
-                });
-                return {
-                  url: response.url.toString(),
-                  html: response.body,
-                  document: "html" as const,
-                };
+            await suggestScrapeSourceRevision(
+              {
+                scrapeSourceId: suggestion.source.id,
+                externalSiteRunId: runId,
+                executionToken,
+                createdById: requestedById ?? undefined,
+                listPages,
+                detailPages,
+                failure:
+                  repair && failureResponse
+                    ? {
+                        url: failureResponse.url.toString(),
+                        html: failureResponse.body,
+                        document: "html",
+                        issues: repair.issues,
+                      }
+                    : undefined,
+                loadPage: async (url) => {
+                  const response = await session.request({
+                    target: target.key,
+                    url,
+                  });
+                  return {
+                    url: response.url.toString(),
+                    html: response.body,
+                    document: "html" as const,
+                  };
+                },
               },
-            });
+              requestModel,
+            );
           };
-    const source: ScraperSourceDefinition<null, unknown> = {
+    const source: ScraperSourceDefinition<
+      ScrapeSourceSuggestionCursor,
+      unknown
+    > = {
       key: `source-${suggestion.source.id}`,
       externalSiteKey: suggestion.siteKey,
       targetKeys: [target.key],
       resumeFromLastRun: false,
-      cursorSchema: z.null(),
+      cursorSchema: ScrapeSourceSuggestionCursorSchema,
       observationSchema: z.unknown(),
       sink: async () => {},
       adapter,

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -29,6 +29,7 @@ import {
   listScrapeSourceRevisions,
   recordScrapeSourcePreview,
   saveScrapeSourceSuggestion,
+  ScrapeSourceChangedError,
   ScrapeSourceConflictError,
   ScrapeSourceValidationError,
 } from "./service";
@@ -332,6 +333,7 @@ test("an old worker cannot add an AI version after another worker takes over", a
     createdById: user.id,
     aiModel: "test-model",
     aiInstructionsVersion: "test-instructions",
+    previewResult: { issues: [], pages: [] },
   };
 
   await expect(
@@ -346,6 +348,10 @@ test("an old worker cannot add an AI version after another worker takes over", a
     ...input,
     executionToken: "new-worker",
   });
+  expect(revision).toMatchObject({
+    previewStatus: "passed",
+    previewResult: { issues: [], pages: [] },
+  });
   await expect(
     saveScrapeSourceSuggestion({
       ...input,
@@ -359,6 +365,60 @@ test("an old worker cannot add an AI version after another worker takes over", a
       revisionId: revision.id,
     }),
   ]);
+});
+
+test("does not activate an automatic repair after the active version changed", async () => {
+  const user = await createUser();
+  const { source } = await createSiteWithScrapeSource({
+    name: "Changed Source",
+    kind: "review",
+    websiteUrl: "https://changed-source.example/",
+    createdById: user.id,
+  });
+  const first = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules,
+    author: "person",
+    createdById: user.id,
+  });
+  await markPreviewPassed(first.id);
+  await activateScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    revisionId: first.id,
+  });
+  const replacement = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules: { ...rules, detail: { ...rules.detail, title: "article h1" } },
+    author: "person",
+    createdById: user.id,
+  });
+  await markPreviewPassed(replacement.id);
+  await activateScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    revisionId: replacement.id,
+  });
+  const repair = await createScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    rules: { ...rules, detail: { ...rules.detail, title: "main h1" } },
+    author: "ai",
+    aiModel: "test-model",
+    aiInstructionsVersion: "test-instructions",
+  });
+  await markPreviewPassed(repair.id);
+
+  await expect(
+    activateScrapeSourceRevision({
+      scrapeSourceId: source.id,
+      revisionId: repair.id,
+      expectedActiveRevisionId: first.id,
+    }),
+  ).rejects.toBeInstanceOf(ScrapeSourceChangedError);
+  expect(
+    await db
+      .select({ id: scrapeSourceRevisions.id })
+      .from(scrapeSourceRevisions)
+      .where(eq(scrapeSourceRevisions.active, true)),
+  ).toEqual([{ id: replacement.id }]);
 });
 
 test("keeps the original review and the newer scraped data", async ({

--- a/apps/server/src/scraper/configured/service.ts
+++ b/apps/server/src/scraper/configured/service.ts
@@ -55,6 +55,10 @@ export class ScrapeSourceValidationError extends Error {
   override name = "ScrapeSourceValidationError";
 }
 
+export class ScrapeSourceChangedError extends Error {
+  override name = "ScrapeSourceChangedError";
+}
+
 export const SCRAPE_SOURCE_PAUSED_ERROR = "The source was paused.";
 
 const DatabaseErrorSchema = z.object({ code: z.string() });
@@ -321,10 +325,14 @@ export type CreateScrapeSourceRevisionInput = {
   scrapeSourceId: number;
   listUrl?: string;
   rules: ScrapeRules;
-  createdById: number;
 } & (
-  | { author: "person" }
-  | { author: "ai"; aiModel: string; aiInstructionsVersion: string }
+  | { author: "person"; createdById: number }
+  | {
+      author: "ai";
+      createdById?: number;
+      aiModel: string;
+      aiInstructionsVersion: string;
+    }
 );
 
 export async function createScrapeSourceRevision(
@@ -340,6 +348,7 @@ async function insertScrapeSourceRevision(
   tx: AnyTransaction,
   input: CreateScrapeSourceRevisionInput,
   rules: ScrapeRules,
+  previewResult?: ScrapeSourcePreviewResult,
 ) {
   const [source] = await tx
     .select()
@@ -374,7 +383,9 @@ async function insertScrapeSourceRevision(
       aiModel: input.author === "ai" ? input.aiModel : null,
       aiInstructionsVersion:
         input.author === "ai" ? input.aiInstructionsVersion : null,
-      previewResult: { issues: [], pages: [] },
+      previewStatus: previewResult ? "passed" : "pending",
+      previewResult: previewResult ?? { issues: [], pages: [] },
+      previewedAt: previewResult ? new Date() : null,
       createdById: input.createdById,
     })
     .returning();
@@ -386,6 +397,7 @@ export async function saveScrapeSourceSuggestion(
   input: CreateScrapeSourceRevisionInput & {
     externalSiteRunId: number;
     executionToken: string;
+    previewResult: ScrapeSourcePreviewResult;
   },
 ) {
   const rules = ScrapeRulesSchema.parse(input.rules);
@@ -421,7 +433,12 @@ export async function saveScrapeSourceSuggestion(
       return revision;
     }
 
-    const revision = await insertScrapeSourceRevision(tx, input, rules);
+    const revision = await insertScrapeSourceRevision(
+      tx,
+      input,
+      rules,
+      input.previewResult,
+    );
     const [linked] = await tx
       .update(scrapeSourceRuns)
       .set({ revisionId: revision.id })
@@ -524,6 +541,8 @@ export async function recordScrapeSourcePreview(input: {
 export async function activateScrapeSourceRevision(input: {
   scrapeSourceId: number;
   revisionId: number;
+  expectedActiveRevisionId?: number;
+  currentRun?: { id: number; executionToken: string };
 }) {
   const activated = await db.transaction(async (tx) => {
     const [source] = await tx
@@ -532,6 +551,21 @@ export async function activateScrapeSourceRevision(input: {
       .where(eq(scrapeSources.id, input.scrapeSourceId))
       .for("update");
     if (!source) throw new ScrapeSourceNotFoundError();
+
+    if (input.expectedActiveRevisionId !== undefined) {
+      const [current] = await tx
+        .select({ id: scrapeSourceRevisions.id })
+        .from(scrapeSourceRevisions)
+        .where(
+          and(
+            eq(scrapeSourceRevisions.scrapeSourceId, source.id),
+            eq(scrapeSourceRevisions.active, true),
+          ),
+        );
+      if (!source.enabled || current?.id !== input.expectedActiveRevisionId) {
+        throw new ScrapeSourceChangedError();
+      }
+    }
 
     const [revision] = await tx
       .select()
@@ -556,7 +590,10 @@ export async function activateScrapeSourceRevision(input: {
       .where(eq(externalSites.id, source.externalSiteId))
       .for("update");
     const [activeRun] = await tx
-      .select({ id: externalSiteRuns.id })
+      .select({
+        id: externalSiteRuns.id,
+        executionToken: externalSiteRuns.executionToken,
+      })
       .from(externalSiteRuns)
       .where(
         and(
@@ -565,7 +602,11 @@ export async function activateScrapeSourceRevision(input: {
         ),
       )
       .limit(1);
-    if (activeRun) {
+    if (
+      activeRun &&
+      (activeRun.id !== input.currentRun?.id ||
+        activeRun.executionToken !== input.currentRun.executionToken)
+    ) {
       throw new ScrapeSourceValidationError(
         "Wait for the current run to finish before activating this version.",
       );

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -73,8 +73,8 @@ function toolCallResponse<T extends object>(callId: string, ruleCheck: T) {
 }
 
 test("reserves requests for discovery and three rule checks", () => {
-  expect(setupRequestLimit(0)).toBe(20);
-  expect(setupRequestLimit(2)).toBe(22);
+  expect(setupRequestLimit(0)).toBe(309);
+  expect(setupRequestLimit(2)).toBe(311);
 });
 
 test("bounds total AI input while keeping every sample page", () => {

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { MAX_LIKELY_LIST_PAGES } from "./discovery";
 import type { ScrapeIssue } from "./preview";
 import {
+  SCRAPE_SOURCE_MAX_ITEMS,
   ScrapeCatalogRulesSchema,
   ScrapePriceRulesSchema,
   ScrapeReviewRulesSchema,
@@ -21,10 +22,10 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v25";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v26";
 const MAX_AI_INPUT_CHARS = 200_000;
-export const MAX_PAGES_TO_CHECK = 3;
-const MAX_RULE_CHECKS = 3;
+export const MAX_EXAMPLE_PAGES = 3;
+export const MAX_RULE_CHECKS = 3;
 const MAX_AI_PAGE_CHARS = 75_000;
 const MAX_AI_ATTRIBUTE_CHARS = 500;
 const CHECK_RULES_TOOL_NAME = "check_rules";
@@ -38,14 +39,15 @@ export type WebsitePage = {
   document?: "html" | "xml";
 };
 
-/** Counts requests needed to find pages and try three sets of rules. */
+/** Bounds one setup run even when every rule check finds different pages. */
 export function setupRequestLimit(samplePageCount: number) {
+  // Setup keeps one request for the page that triggered an automatic repair.
   return (
     samplePageCount +
-    1 +
+    2 +
     MAX_LIKELY_LIST_PAGES +
-    MAX_PAGES_TO_CHECK +
-    MAX_RULE_CHECKS * (1 + MAX_PAGES_TO_CHECK)
+    MAX_EXAMPLE_PAGES +
+    MAX_RULE_CHECKS * (1 + SCRAPE_SOURCE_MAX_ITEMS)
   );
 }
 
@@ -93,13 +95,13 @@ type RuleCheckResult<T> =
       inspectedPages: WebsitePage[];
     };
 
-type SetupAgentModelRequest = {
+export type SetupAgentModelRequest = {
   instructions: string;
   input: ResponseInput;
   tools: Tool[];
 };
 
-type SetupAgentModelResponse = {
+export type SetupAgentModelResponse = {
   model: string;
   output: ResponseOutputItem[];
 };
@@ -126,6 +128,7 @@ const RULE_INSTRUCTIONS = [
   "Use an optional field only when every given page clearly provides it.",
   "When previousSetup is given, preserve the kinds of items its working rules included and excluded. Use its rules and matchedPageUrls as evidence, but submit only fields allowed by check_rules.",
   "If previousSetup used skipWhen, preserve those exclusions inside list.links.",
+  "When failure is given, fix the saved rules so they handle that page if the list still includes it.",
   "For catalog sources, collect only the displayed name, product URL, stable product ID, image URL, volume, ABV, age, edition, and release year.",
   "Catalog sources do not require a review, price, currency, or volume. Do not select descriptions or tasting notes.",
   "A nextPage selector must lead to a page with new links.",
@@ -263,6 +266,9 @@ type ScrapeSourceSetupAgentInput<T> = {
     rules: StoredScrapeRules;
     matchedPageUrls: string[];
   };
+  failure?: WebsitePage & {
+    issues: ScrapeIssue[];
+  };
   request: (
     request: SetupAgentModelRequest,
   ) => Promise<SetupAgentModelResponse>;
@@ -358,15 +364,22 @@ export async function runScrapeSourceSetupAgent<T>(
   input: ScrapeSourceSetupAgentInput<T>,
 ) {
   const tool = createCheckRulesTool(input.kind);
+  const pageCount = input.listPages.length + input.detailPages.length;
   const pages = preparePagesForSetup([
     ...input.listPages,
     ...input.detailPages,
+    ...(input.failure ? [input.failure] : []),
   ]);
+  const failurePage = input.failure ? pages[pageCount] : undefined;
   const initialInput = JSON.stringify({
     kind: input.kind,
     startPages: pages.slice(0, input.listPages.length),
-    examplePages: pages.slice(input.listPages.length),
+    examplePages: pages.slice(input.listPages.length, pageCount),
     previousSetup: input.previousSetup,
+    failure:
+      input.failure && failurePage
+        ? { ...failurePage, issues: input.failure.issues }
+        : undefined,
   });
   return await runAgent({
     details: {

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -491,7 +491,7 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         aiInstructionsVersion: AI_INSTRUCTIONS_VERSION,
         author: "ai",
         listUrl: LIST_URL,
-        previewStatus: "pending",
+        previewStatus: "passed",
       });
       if (!suggestedRevision) throw new Error("AI did not create a revision.");
       expect(suggestedRevision.aiModel).toBeTruthy();

--- a/apps/server/src/scraper/configured/suggestion.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from "vitest";
+import { expect, test, vi } from "vitest";
 import type { ScrapeRules } from "./rules";
 import {
   checkDetailPages,
   checkListPage,
   checkNextListPage,
   checkPreviousListPage,
-  sampleDetailLinks,
 } from "./suggestion";
 
 const reviewRules = {
@@ -318,18 +317,33 @@ test("reports a supplied detail page before its rules fail", async () => {
   expect(checkedPages).toEqual(["https://example.test/reviews/one"]);
 });
 
-test("samples detail links across the full list", () => {
-  expect(
-    sampleDetailLinks([
-      "https://example.test/products/one",
-      "https://example.test/products/two",
-      "https://example.test/products/three",
-      "https://example.test/products/four",
-      "https://example.test/products/five",
-    ]),
-  ).toEqual([
+test("checks every detail link selected by the rules", async () => {
+  const links = [
     "https://example.test/products/one",
+    "https://example.test/products/two",
     "https://example.test/products/three",
+    "https://example.test/products/four",
     "https://example.test/products/five",
-  ]);
+  ];
+  const loadPage = vi.fn(async (url: URL) => ({
+    url: url.toString(),
+    html: '<h1>Reviews</h1><time datetime="2026-09-01"></time><article class="review"><h2>Whisky</h2><p class="body">Notes.</p></article>',
+  }));
+
+  const pages = await checkDetailPages({
+    rules: reviewRules,
+    listPage: {
+      url: "https://example.test/products",
+      html: "",
+      links,
+      firstPageLinks: links,
+      nextPageUrl: null,
+      nextPage: null,
+    },
+    suppliedPages: [],
+    loadPage,
+  });
+
+  expect(pages.map((page) => page.url)).toEqual(links);
+  expect(loadPage).toHaveBeenCalledTimes(5);
 });

--- a/apps/server/src/scraper/configured/suggestion.ts
+++ b/apps/server/src/scraper/configured/suggestion.ts
@@ -5,22 +5,20 @@ import { scrapeSourceRevisions, scrapeSources } from "@peated/server/db/schema";
 import { createOpenAIAgentClient } from "@peated/server/lib/openaiClient";
 import type { Currency } from "@peated/server/types";
 import { and, eq } from "drizzle-orm";
-import type {
-  ResponseCreateParamsNonStreaming,
-  ResponseInput,
-  Tool,
-} from "openai/resources/responses/responses";
 import {
   loadExecutableScrapeRules,
   type ExecutableScrapeRules,
 } from "./compatibility";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
+import type { ScrapeIssue, ScrapeSourcePreviewResult } from "./preview";
 import type { ScrapeRules } from "./rules";
+import { reserveScrapeSourceModelCall } from "./runs";
 import { saveScrapeSourceSuggestion } from "./service";
 import {
   AI_INSTRUCTIONS_VERSION,
-  MAX_PAGES_TO_CHECK,
   runScrapeSourceSetupAgent,
+  type SetupAgentModelRequest,
+  type SetupAgentModelResponse,
   type WebsitePage,
 } from "./setupAgent";
 import { ScrapeSourceSetupError } from "./setupError";
@@ -284,7 +282,7 @@ export async function checkDetailPages(input: {
     input.suppliedPages.map((page) => [new URL(page.url).toString(), page]),
   );
   const pages: CheckedDetailPage[] = [];
-  for (const link of sampleDetailLinks(input.listPage.links)) {
+  for (const link of input.listPage.links) {
     const page =
       suppliedPages.get(link) ?? (await input.loadPage(new URL(link)));
     input.onCheckPage?.(page);
@@ -304,14 +302,28 @@ export async function checkDetailPages(input: {
   return pages;
 }
 
-export function sampleDetailLinks(links: string[]) {
-  if (links.length <= MAX_PAGES_TO_CHECK) return links;
-  return Array.from({ length: MAX_PAGES_TO_CHECK }, (_, index) => {
-    const linkIndex = Math.round(
-      (index * (links.length - 1)) / (MAX_PAGES_TO_CHECK - 1),
-    );
-    return links[linkIndex]!;
-  });
+function createCheckedPreview(
+  detailPages: CheckedDetailPage[],
+): ScrapeSourcePreviewResult {
+  return {
+    issues: [],
+    pages: detailPages.map((page) => {
+      if (page.output.kind === "review") {
+        return {
+          kind: "review",
+          url: page.url,
+          title: page.output.title,
+          publishedAt: page.output.publishedAt,
+          reviews: page.output.reviews.map((review) => ({
+            name: review.name,
+            reviewerName: review.reviewerName,
+            nativeScore: review.nativeScore,
+          })),
+        };
+      }
+      return { ...page.output, url: page.url };
+    }),
+  };
 }
 
 async function loadAiSource(scrapeSourceId: number) {
@@ -337,41 +349,40 @@ async function loadAiSource(scrapeSourceId: number) {
   return source;
 }
 
+export type RequestScrapeSourceModel = (
+  request: SetupAgentModelRequest,
+) => Promise<SetupAgentModelResponse>;
+
 /** Keeps provider storage off and records complete public-site model calls. */
-async function requestAi(input: {
-  model: string;
-  instructions: string;
-  request: ResponseInput;
-  tools?: Tool[];
-  maxOutputTokens: number;
-}) {
+async function requestAi(input: SetupAgentModelRequest) {
   const client = createOpenAIAgentClient({ workload: "scraper" });
-  const request: ResponseCreateParamsNonStreaming = {
-    model: input.model,
+  return await client.responses.create({
+    model: config.SCRAPER_SETUP_MODEL,
     instructions: input.instructions,
-    input: input.request,
-    max_output_tokens: input.maxOutputTokens,
+    input: input.input,
+    max_output_tokens: 8_000,
     store: false,
-  };
-  if (input.tools) {
-    request.include = ["reasoning.encrypted_content"];
-    request.parallel_tool_calls = false;
-    request.tool_choice = "required";
-    request.tools = input.tools;
-  }
-  return await client.responses.create(request);
+    include: ["reasoning.encrypted_content"],
+    parallel_tool_calls: false,
+    tool_choice: "required",
+    tools: input.tools,
+  });
 }
 
-/** Creates an inactive revision only after the production scrape code reads it. */
-export async function suggestScrapeSourceRevision(input: {
-  scrapeSourceId: number;
-  externalSiteRunId: number;
-  executionToken: string;
-  createdById: number;
-  listPages: WebsitePage[];
-  detailPages: WebsitePage[];
-  loadPage: (url: URL) => Promise<WebsitePage>;
-}) {
+/** Saves a checked version without replacing the active version. */
+export async function suggestScrapeSourceRevision(
+  input: {
+    scrapeSourceId: number;
+    externalSiteRunId: number;
+    executionToken: string;
+    createdById?: number;
+    listPages: WebsitePage[];
+    detailPages: WebsitePage[];
+    failure?: WebsitePage & { issues: ScrapeIssue[] };
+    loadPage: (url: URL) => Promise<WebsitePage>;
+  },
+  requestModel: RequestScrapeSourceModel = requestAi,
+) {
   const source = await loadAiSource(input.scrapeSourceId);
   let previousRules: ExecutableScrapeRules | null = null;
   if (source.previousRulesVersion && source.previousRules) {
@@ -397,6 +408,7 @@ export async function suggestScrapeSourceRevision(input: {
     scrapeSourceId: input.scrapeSourceId,
     listPages: input.listPages,
     detailPages: input.detailPages,
+    failure: input.failure,
     previousSetup:
       source.previousListPageUrl &&
       source.previousRulesVersion &&
@@ -411,13 +423,11 @@ export async function suggestScrapeSourceRevision(input: {
         : undefined,
     request: async (request) => {
       await loadAiSource(input.scrapeSourceId);
-      return await requestAi({
-        model: config.SCRAPER_SETUP_MODEL,
-        instructions: request.instructions,
-        request: request.input,
-        tools: request.tools,
-        maxOutputTokens: 8_000,
-      });
+      await reserveScrapeSourceModelCall(
+        input.externalSiteRunId,
+        input.executionToken,
+      );
+      return await requestModel(request);
     },
     checkRules: async (submittedRules) => {
       const checkedPages = new Map<string, WebsitePage>();
@@ -489,5 +499,6 @@ export async function suggestScrapeSourceRevision(input: {
     createdById: input.createdById,
     aiModel: setup.model,
     aiInstructionsVersion: AI_INSTRUCTIONS_VERSION,
+    previewResult: createCheckedPreview(setup.checked.detailPages),
   });
 }

--- a/apps/server/src/scraper/runs.ts
+++ b/apps/server/src/scraper/runs.ts
@@ -2,6 +2,7 @@ import { db } from "@peated/server/db";
 import {
   externalSiteRuns,
   externalSites,
+  scrapeSourceRuns,
   type ExternalSiteRun,
 } from "@peated/server/db/schema";
 import type { ExternalSiteKey } from "@peated/server/types";
@@ -9,9 +10,21 @@ import * as Sentry from "@sentry/node";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
-import { resolveScrapeSourceRunRegistry } from "./configured/runtime";
-import { SCRAPE_SOURCE_PAUSED_ERROR } from "./configured/service";
+import {
+  createScrapeSourceRepairRun,
+  ScrapeSourceSuggestionCursorSchema,
+} from "./configured/runs";
+import {
+  resolveScrapeSourceRunRegistry,
+  ScrapeSourceParseError,
+} from "./configured/runtime";
+import {
+  activateScrapeSourceRevision,
+  SCRAPE_SOURCE_PAUSED_ERROR,
+  ScrapeSourceChangedError,
+} from "./configured/service";
 import { ScrapeSourceSetupError } from "./configured/setupError";
+import type { RequestScrapeSourceModel } from "./configured/suggestion";
 import { ScraperCoordinationError } from "./coordinator";
 import {
   findScraperSourceBySiteKey,
@@ -52,7 +65,8 @@ type ClaimedRun = {
 };
 
 export type ScraperRunExecutionResult =
-  | { status: "completed" | "duplicate" }
+  | { status: "completed"; nextRunId?: number }
+  | { status: "duplicate" }
   | { status: "waiting"; nextAttemptAt: Date };
 
 function safeRunError(error: Error) {
@@ -60,6 +74,7 @@ function safeRunError(error: Error) {
     return "The source is disabled.";
   }
   if (error instanceof ScrapeSourceSetupError) return error.adminMessage();
+  if (error instanceof ScrapeSourceParseError) return error.message;
   if (error instanceof z.ZodError) {
     return "The source returned data we could not use.";
   }
@@ -227,7 +242,7 @@ async function completeRun(claim: ClaimedRun, completedAt: Date) {
 }
 
 async function failRun(claim: ClaimedRun, error: Error, completedAt: Date) {
-  await db.transaction(async (tx) => {
+  return await db.transaction(async (tx) => {
     const [failed] = await tx
       .update(externalSiteRuns)
       .set({
@@ -248,12 +263,61 @@ async function failRun(claim: ClaimedRun, error: Error, completedAt: Date) {
         id: externalSiteRuns.id,
         externalSiteId: externalSiteRuns.externalSiteId,
       });
-    if (!failed) return;
+    if (!failed) return undefined;
+    const repair =
+      error instanceof ScrapeSourceParseError
+        ? await createScrapeSourceRepairRun(tx, {
+            failedRunId: failed.id,
+            pageUrl: error.pageUrl,
+            issues: error.issues,
+            now: completedAt,
+          })
+        : null;
     await tx
       .update(externalSites)
       .set({ lastRunAt: completedAt, lastRunId: failed.id })
       .where(eq(externalSites.id, failed.externalSiteId));
+    return repair?.id;
   });
+}
+
+async function activateRepair(runId: number, executionToken: string) {
+  const [row] = await db
+    .select({
+      run: externalSiteRuns,
+      sourceRun: scrapeSourceRuns,
+    })
+    .from(externalSiteRuns)
+    .innerJoin(
+      scrapeSourceRuns,
+      eq(scrapeSourceRuns.externalSiteRunId, externalSiteRuns.id),
+    )
+    .where(eq(externalSiteRuns.id, runId));
+  if (
+    !row ||
+    !["running", "succeeded"].includes(row.run.status) ||
+    row.run.requestedById !== null ||
+    row.sourceRun.purpose !== "suggest" ||
+    row.sourceRun.revisionId === null
+  ) {
+    return;
+  }
+  const cursor = ScrapeSourceSuggestionCursorSchema.safeParse(row.run.cursor);
+  if (!cursor.success || !cursor.data?.repair) return;
+
+  try {
+    await activateScrapeSourceRevision({
+      scrapeSourceId: row.sourceRun.scrapeSourceId,
+      revisionId: row.sourceRun.revisionId,
+      expectedActiveRevisionId: cursor.data.repair.revisionId,
+      currentRun:
+        row.run.status === "running"
+          ? { id: row.run.id, executionToken }
+          : undefined,
+    });
+  } catch (error) {
+    if (!(error instanceof ScrapeSourceChangedError)) throw error;
+  }
 }
 
 async function queueRunForLater(
@@ -303,11 +367,13 @@ export async function executeScraperRun(
     fetchImpl,
     clock = scraperSystemClock,
     executionToken = randomUUID(),
+    requestModel,
   }: {
     registry: ScraperRegistry;
     fetchImpl?: typeof fetch;
     clock?: ScraperHttpClock;
     executionToken?: string;
+    requestModel?: RequestScrapeSourceModel;
   },
 ): Promise<ScraperRunExecutionResult> {
   const { runId } = ScraperRunJobInputSchema.parse(input);
@@ -315,6 +381,7 @@ export async function executeScraperRun(
     runId,
     registry,
     executionToken,
+    requestModel,
   );
   const claimed = await claimScraperRun({
     runId,
@@ -322,7 +389,12 @@ export async function executeScraperRun(
     now: clock.now(),
     executionToken,
   });
-  if (!("run" in claimed)) return claimed;
+  if (!("run" in claimed)) {
+    if (claimed.status === "completed") {
+      await activateRepair(runId, executionToken);
+    }
+    return claimed;
+  }
 
   const stopExtendingRun = startExtendingRunTimeout({
     runId: claimed.run.id,
@@ -357,6 +429,7 @@ export async function executeScraperRun(
       .from(externalSiteRuns)
       .where(eq(externalSiteRuns.id, claimed.run.id));
     claimed.run.emittedItemCount = latest?.emittedItemCount ?? 0;
+    await activateRepair(claimed.run.id, claimed.executionToken);
     await completeRun(claimed, clock.now());
     return { status: "completed" };
   } catch (error) {
@@ -379,6 +452,15 @@ export async function executeScraperRun(
     if (error instanceof ScrapeSourceSetupError) {
       await failRun(claimed, error, clock.now());
       return { status: "completed" };
+    }
+    if (
+      error instanceof ScrapeSourceParseError &&
+      claimed.run.purpose === "collect"
+    ) {
+      const nextRunId = await failRun(claimed, error, clock.now());
+      return nextRunId === undefined
+        ? { status: "completed" }
+        : { status: "completed", nextRunId };
     }
     await failRun(
       claimed,

--- a/apps/server/src/worker/jobs/runScraper.test.ts
+++ b/apps/server/src/worker/jobs/runScraper.test.ts
@@ -35,6 +35,22 @@ test("does not enqueue terminal or duplicate deliveries", async () => {
   expect(services.enqueueRun).not.toHaveBeenCalled();
 });
 
+test("queues an automatic repair after a failed collection", async () => {
+  const services = createServices();
+  services.executeRun.mockResolvedValue({
+    status: "completed",
+    nextRunId: 84,
+  });
+
+  await runScraper({ runId: 42 }, services);
+
+  expect(services.enqueueRun).toHaveBeenCalledWith(84, {
+    jobId: "external-site-run-84",
+    removeOnComplete: true,
+    removeOnFail: true,
+  });
+});
+
 test("rejects queue payload fields other than run id", async () => {
   const services = createServices();
   await expect(

--- a/apps/server/src/worker/jobs/runScraper.ts
+++ b/apps/server/src/worker/jobs/runScraper.ts
@@ -29,6 +29,14 @@ export async function runScraper(
 ) {
   const { runId } = InputSchema.parse(input);
   const result = await services.executeRun({ runId });
+  if (result.status === "completed" && result.nextRunId !== undefined) {
+    await services.enqueueRun(result.nextRunId, {
+      jobId: `external-site-run-${result.nextRunId}`,
+      removeOnComplete: true,
+      removeOnFail: true,
+    });
+    return;
+  }
   if (result.status !== "waiting") return;
 
   const delay = Math.max(0, result.nextAttemptAt.getTime() - Date.now());


### PR DESCRIPTION
When saved crawler rules fail during collection, stop collection and give the setup agent one automatic repair attempt. The agent receives the failing page, parser errors, saved rules, and previous matches. Passing repairs activate automatically unless an admin paused the source or changed its active version.

Run history allows another automatic repair only after a complete successful collection. Time passing, a passing preview, and new rule versions do not reset that protection. Each setup or repair run gets at most three model calls total, including resumed jobs. Network failures do not trigger repair; failed repairs stay stopped for admin review.

Rule checks now validate every selected detail link instead of sampling three and save the passing preview with the revision. The v11 schema is unchanged, and no database migration or periodic repair timer is needed.

Integration tests use the real parser, database, run lifecycle, and activation path with mocked HTTP and model responses. They cover recovery, repeat failures, duplicate jobs, waits preserving the model limit, manual retries, and admin pauses. Live model evals were not run.

Refs #1210.
