### PR TITLE
fix(scraper): allow admins to rebuild setup

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/suggest.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/suggest.test.ts
@@ -1,8 +1,16 @@
+import { db } from "@peated/server/db";
+import {
+  externalSiteRuns,
+  scrapeSourceRevisions,
+  scrapeSources,
+} from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { pushJob } from "@peated/server/lib/test/workerDispatch";
 import { routerClient } from "@peated/server/orpc/router";
+import { activateScrapeSourceRevision } from "@peated/server/scraper/configured/service";
+import { eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
-import { createTestSource } from "./testUtils";
+import { createTestRevision, createTestSource } from "./testUtils";
 
 describe("POST /admin/scrape-sources/:id/suggest", () => {
   test("requires an administrator", async ({ defaults }) => {
@@ -42,6 +50,78 @@ describe("POST /admin/scrape-sources/:id/suggest", () => {
       status: "queued",
       trigger: "manual",
     });
+    expect(pushJob).toHaveBeenCalledOnce();
+  });
+
+  test.for(["pending", "passed"] as const)(
+    "rebuilds a %s inactive proposal without changing active rules",
+    async (previewStatus, { fixtures }) => {
+      const admin = await fixtures.User({ admin: true });
+      const { source } = await createTestSource(admin.id);
+      const active = await createTestRevision(source.id, admin.id);
+      await db
+        .update(scrapeSourceRevisions)
+        .set({ previewStatus: "passed" })
+        .where(eq(scrapeSourceRevisions.id, active.id));
+      await activateScrapeSourceRevision({
+        scrapeSourceId: source.id,
+        revisionId: active.id,
+      });
+      await db
+        .update(scrapeSourceRevisions)
+        .set({ rulesVersion: 10 })
+        .where(eq(scrapeSourceRevisions.id, active.id));
+      const proposal = await createTestRevision(source.id, admin.id);
+      await db
+        .update(scrapeSourceRevisions)
+        .set({ previewStatus })
+        .where(eq(scrapeSourceRevisions.id, proposal.id));
+      const before = await db.select().from(scrapeSourceRevisions);
+      const sourcesBefore = await db.select().from(scrapeSources);
+
+      const run = await routerClient.externalSites.scrapeSources.suggest(
+        { id: source.id },
+        { context: { user: admin } },
+      );
+
+      expect(run).toMatchObject({
+        status: "queued",
+        purpose: "suggest",
+        requestedById: admin.id,
+      });
+      expect(await db.select().from(scrapeSourceRevisions)).toEqual(before);
+      expect(await db.select().from(scrapeSources)).toEqual(sourcesBefore);
+      expect(pushJob).toHaveBeenCalledOnce();
+    },
+  );
+
+  test("concurrent rebuild requests queue only one run", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const { source } = await createTestSource(admin.id);
+    await createTestRevision(source.id, admin.id);
+
+    const results = await Promise.allSettled([
+      routerClient.externalSites.scrapeSources.suggest(
+        { id: source.id },
+        { context: { user: admin } },
+      ),
+      routerClient.externalSites.scrapeSources.suggest(
+        { id: source.id },
+        { context: { user: admin } },
+      ),
+    ]);
+
+    expect(
+      results.filter((result) => result.status === "fulfilled"),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.status === "rejected"),
+    ).toHaveLength(1);
+    expect(await db.select().from(externalSiteRuns)).toMatchObject([
+      { status: "queued", purpose: "suggest" },
+    ]);
     expect(pushJob).toHaveBeenCalledOnce();
   });
 });

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -149,6 +149,8 @@ The tool returns extracted examples, visited pages, and any errors. The agent
 inspects successful results too: valid fields do not guarantee the right content.
 `finish` saves exactly the last passing rules and their test results. An admin
 turns on versions requested through setup; no separate preview is required.
+An admin can rebuild an inactive proposal, whether or not it passed testing.
+The active rules stay in place until the replacement is tested and activated.
 
 Setup keeps old rules and previous matches as context even when their saved
 format cannot be decoded. Only executable old rules can enforce the same list

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -149,7 +149,8 @@ The tool returns extracted examples, visited pages, and any errors. The agent
 inspects successful results too: valid fields do not guarantee the right content.
 `finish` saves exactly the last passing rules and their test results. An admin
 turns on versions requested through setup; no separate preview is required.
-An admin can rebuild an inactive proposal, whether or not it passed testing.
+An admin can request a fresh setup regardless of the saved rules' version or
+test status.
 The active rules stay in place until the replacement is tested and activated.
 
 Setup keeps old rules and previous matches as context even when their saved

--- a/apps/server/src/scraper/configured/runs.ts
+++ b/apps/server/src/scraper/configured/runs.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { ScraperRunTakenOverError } from "../session";
 import { loadExecutableScrapeRules } from "./compatibility";
 import { ScrapeIssueSchema, type ScrapeIssue } from "./preview";
-import { SCRAPE_RULES_VERSION, SCRAPE_SOURCE_MAX_LIST_PAGES } from "./rules";
+import { SCRAPE_SOURCE_MAX_LIST_PAGES } from "./rules";
 import {
   ScrapeSourceNotFoundError,
   ScrapeSourceValidationError,
@@ -195,26 +195,6 @@ export async function createScrapeSourceSuggestionRun(input: {
       .where(eq(scrapeSources.id, input.scrapeSourceId))
       .for("update");
     if (!source) throw new ScrapeSourceNotFoundError();
-    const [latestRevision] = await tx
-      .select({
-        active: scrapeSourceRevisions.active,
-        previewStatus: scrapeSourceRevisions.previewStatus,
-        rulesVersion: scrapeSourceRevisions.rulesVersion,
-      })
-      .from(scrapeSourceRevisions)
-      .where(eq(scrapeSourceRevisions.scrapeSourceId, source.id))
-      .orderBy(desc(scrapeSourceRevisions.revision))
-      .limit(1);
-    // Scraper setup protects active rules, not proposals awaiting activation.
-    if (
-      latestRevision?.active &&
-      latestRevision.rulesVersion === SCRAPE_RULES_VERSION &&
-      latestRevision.previewStatus !== "failed"
-    ) {
-      throw new ScrapeSourceValidationError(
-        "The active rules already use the current format and passed testing.",
-      );
-    }
     const [run] = await tx
       .insert(externalSiteRuns)
       .values({

--- a/apps/server/src/scraper/configured/runs.ts
+++ b/apps/server/src/scraper/configured/runs.ts
@@ -197,6 +197,7 @@ export async function createScrapeSourceSuggestionRun(input: {
     if (!source) throw new ScrapeSourceNotFoundError();
     const [latestRevision] = await tx
       .select({
+        active: scrapeSourceRevisions.active,
         previewStatus: scrapeSourceRevisions.previewStatus,
         rulesVersion: scrapeSourceRevisions.rulesVersion,
       })
@@ -204,13 +205,14 @@ export async function createScrapeSourceSuggestionRun(input: {
       .where(eq(scrapeSourceRevisions.scrapeSourceId, source.id))
       .orderBy(desc(scrapeSourceRevisions.revision))
       .limit(1);
+    // Scraper setup protects active rules, not proposals awaiting activation.
     if (
-      latestRevision &&
+      latestRevision?.active &&
       latestRevision.rulesVersion === SCRAPE_RULES_VERSION &&
       latestRevision.previewStatus !== "failed"
     ) {
       throw new ScrapeSourceValidationError(
-        "AI suggestions are available only when the saved rules need updating or the latest preview fails.",
+        "The active rules already use the current format and passed testing.",
       );
     }
     const [run] = await tx

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -202,63 +202,42 @@ test("keeps immutable revisions and only activates a passing revision", async ()
   expect(updated.source.listUrl).toBe("https://versioned.example/new-archive");
 });
 
-test("allows AI to update a healthy old rule format", async () => {
-  const user = await createUser();
-  const { source } = await createSiteWithScrapeSource({
-    name: "Old Rules",
-    kind: "review",
-    websiteUrl: "https://old-rules.example/",
-    createdById: user.id,
-  });
-  const revision = await createScrapeSourceRevision({
-    scrapeSourceId: source.id,
-    rules,
-    author: "person",
-    createdById: user.id,
-  });
-  await markPreviewPassed(revision.id);
-  await db
-    .update(scrapeSourceRevisions)
-    .set({ rulesVersion: 10 })
-    .where(eq(scrapeSourceRevisions.id, revision.id));
-
-  await expect(
-    createScrapeSourceSuggestionRun({
+test.each([10, 11])(
+  "manual setup leaves active v%i rules unchanged",
+  async (rulesVersion) => {
+    const user = await createUser();
+    const { source } = await createSiteWithScrapeSource({
+      name: "Existing Rules",
+      kind: "review",
+      websiteUrl: "https://existing-rules.example/",
+      createdById: user.id,
+    });
+    const revision = await createScrapeSourceRevision({
       scrapeSourceId: source.id,
-      requestedById: user.id,
-    }),
-  ).resolves.toMatchObject({ purpose: "suggest", status: "queued" });
-});
-
-test("does not replace a healthy current rule format", async () => {
-  const user = await createUser();
-  const { source } = await createSiteWithScrapeSource({
-    name: "Current Rules",
-    kind: "review",
-    websiteUrl: "https://current-rules.example/",
-    createdById: user.id,
-  });
-  const revision = await createScrapeSourceRevision({
-    scrapeSourceId: source.id,
-    rules,
-    author: "person",
-    createdById: user.id,
-  });
-  await markPreviewPassed(revision.id);
-  await activateScrapeSourceRevision({
-    scrapeSourceId: source.id,
-    revisionId: revision.id,
-  });
-
-  await expect(
-    createScrapeSourceSuggestionRun({
+      rules,
+      author: "person",
+      createdById: user.id,
+    });
+    await markPreviewPassed(revision.id);
+    await activateScrapeSourceRevision({
       scrapeSourceId: source.id,
-      requestedById: user.id,
-    }),
-  ).rejects.toThrow(
-    "The active rules already use the current format and passed testing.",
-  );
-});
+      revisionId: revision.id,
+    });
+    await db
+      .update(scrapeSourceRevisions)
+      .set({ rulesVersion })
+      .where(eq(scrapeSourceRevisions.id, revision.id));
+    const before = await db.select().from(scrapeSourceRevisions);
+
+    await expect(
+      createScrapeSourceSuggestionRun({
+        scrapeSourceId: source.id,
+        requestedById: user.id,
+      }),
+    ).resolves.toMatchObject({ purpose: "suggest", status: "queued" });
+    expect(await db.select().from(scrapeSourceRevisions)).toEqual(before);
+  },
+);
 
 test("an old worker cannot overwrite a preview after another worker takes over", async () => {
   const user = await createUser();

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -245,6 +245,10 @@ test("does not replace a healthy current rule format", async () => {
     createdById: user.id,
   });
   await markPreviewPassed(revision.id);
+  await activateScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    revisionId: revision.id,
+  });
 
   await expect(
     createScrapeSourceSuggestionRun({
@@ -252,7 +256,7 @@ test("does not replace a healthy current rule format", async () => {
       requestedById: user.id,
     }),
   ).rejects.toThrow(
-    "AI suggestions are available only when the saved rules need updating or the latest preview fails.",
+    "The active rules already use the current format and passed testing.",
   );
 });
 

--- a/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
+++ b/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
@@ -28,7 +28,6 @@ import {
   getSetupAfterLatestVersion,
   getSetupDescription,
   getSetupSteps,
-  needsScrapeRulesUpdate,
 } from "./scraperParsingStatus";
 import { ScraperPreviewResult } from "./scraperPreviewResult.stylex";
 
@@ -106,7 +105,6 @@ export function ScraperParsingEditor({
     (revision) => revision.id === source.activeRevisionId,
   );
   const setup = getSetupAfterLatestVersion(source);
-  const needsRulesUpdate = needsScrapeRulesUpdate(source);
   const canSuggest = canSuggestScrapeRules(source);
   const setupSteps = getSetupSteps(source);
   const setupDescription = getSetupDescription(source);
@@ -187,15 +185,7 @@ export function ScraperParsingEditor({
                 })
               }
             >
-              {needsRulesUpdate
-                ? "Update parsing rules"
-                : latest
-                  ? latest.previewStatus === "failed"
-                    ? "Ask AI to repair"
-                    : "Rebuild setup"
-                  : setup
-                    ? "Retry AI setup"
-                    : "Start AI setup"}
+              {latest ? "Rebuild setup" : "Start AI setup"}
             </AdminButton>
           ) : undefined
         }

--- a/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
+++ b/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
@@ -24,6 +24,7 @@ import {
 } from "./adminForm.stylex";
 import { AdminEmptyActivity } from "./adminUtility.stylex";
 import {
+  canSuggestScrapeRules,
   getSetupAfterLatestVersion,
   getSetupDescription,
   getSetupSteps,
@@ -106,9 +107,7 @@ export function ScraperParsingEditor({
   );
   const setup = getSetupAfterLatestVersion(source);
   const needsRulesUpdate = needsScrapeRulesUpdate(source);
-  const canSuggest =
-    (!setup || setup.status === "failed") &&
-    (!latest || latest.previewStatus === "failed" || needsRulesUpdate);
+  const canSuggest = canSuggestScrapeRules(source);
   const setupSteps = getSetupSteps(source);
   const setupDescription = getSetupDescription(source);
   const previewRevisionId =
@@ -191,7 +190,9 @@ export function ScraperParsingEditor({
               {needsRulesUpdate
                 ? "Update parsing rules"
                 : latest
-                  ? "Ask AI to repair"
+                  ? latest.previewStatus === "failed"
+                    ? "Ask AI to repair"
+                    : "Rebuild setup"
                   : setup
                     ? "Retry AI setup"
                     : "Start AI setup"}

--- a/apps/web/src/components/admin/scraperParsingStatus.test.ts
+++ b/apps/web/src/components/admin/scraperParsingStatus.test.ts
@@ -17,50 +17,26 @@ const failedSetup = {
 };
 
 describe("canSuggestScrapeRules", () => {
-  const revision = {
-    id: 2,
-    createdAt: "2026-09-01T12:00:00Z",
-    rulesVersion: SCRAPE_RULES_VERSION,
-    previewStatus: "passed" as const,
-  };
-  const source = { setup: null, activeRevisionId: 1, revisions: [revision] };
-
-  it.each(["pending", "passed"] as const)(
-    "allows rebuilding a %s inactive proposal",
-    (previewStatus) => {
-      expect(
-        canSuggestScrapeRules({
-          ...source,
-          revisions: [{ ...revision, previewStatus }],
-        }),
-      ).toBe(true);
-    },
-  );
-
   it.each(["queued", "running"] as const)(
-    "blocks rebuilding while setup is %s, even if a newer proposal exists",
+    "blocks rebuilding while setup is %s",
     (status) => {
-      expect(
-        canSuggestScrapeRules({ ...source, setup: { ...failedSetup, status } }),
-      ).toBe(false);
+      expect(canSuggestScrapeRules({ setup: { ...failedSetup, status } })).toBe(
+        false,
+      );
     },
   );
 
-  it("protects healthy active current rules but allows failed or older rules", () => {
-    const active = { ...source, activeRevisionId: revision.id };
-    expect(canSuggestScrapeRules(active)).toBe(false);
-    expect(
-      canSuggestScrapeRules({
-        ...active,
-        revisions: [{ ...revision, previewStatus: "failed" }],
-      }),
-    ).toBe(true);
-    expect(
-      canSuggestScrapeRules({
-        ...active,
-        revisions: [{ ...revision, rulesVersion: SCRAPE_RULES_VERSION - 1 }],
-      }),
-    ).toBe(true);
+  it.each(["failed", "succeeded"] as const)(
+    "allows another setup after it %s",
+    (status) => {
+      expect(canSuggestScrapeRules({ setup: { ...failedSetup, status } })).toBe(
+        true,
+      );
+    },
+  );
+
+  it("allows the first setup", () => {
+    expect(canSuggestScrapeRules({ setup: null })).toBe(true);
   });
 });
 

--- a/apps/web/src/components/admin/scraperParsingStatus.test.ts
+++ b/apps/web/src/components/admin/scraperParsingStatus.test.ts
@@ -1,6 +1,7 @@
 import { SCRAPE_RULES_VERSION } from "@peated/server/schemas";
 import { describe, expect, it } from "vitest";
 import {
+  canSuggestScrapeRules,
   getSetupAfterLatestVersion,
   getSetupDescription,
   getSetupSteps,
@@ -14,6 +15,54 @@ const failedSetup = {
   createdAt: "2026-08-29T23:19:00.000Z",
   completedAt: "2026-08-29T23:20:00.000Z",
 };
+
+describe("canSuggestScrapeRules", () => {
+  const revision = {
+    id: 2,
+    createdAt: "2026-09-01T12:00:00Z",
+    rulesVersion: SCRAPE_RULES_VERSION,
+    previewStatus: "passed" as const,
+  };
+  const source = { setup: null, activeRevisionId: 1, revisions: [revision] };
+
+  it.each(["pending", "passed"] as const)(
+    "allows rebuilding a %s inactive proposal",
+    (previewStatus) => {
+      expect(
+        canSuggestScrapeRules({
+          ...source,
+          revisions: [{ ...revision, previewStatus }],
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it.each(["queued", "running"] as const)(
+    "blocks rebuilding while setup is %s, even if a newer proposal exists",
+    (status) => {
+      expect(
+        canSuggestScrapeRules({ ...source, setup: { ...failedSetup, status } }),
+      ).toBe(false);
+    },
+  );
+
+  it("protects healthy active current rules but allows failed or older rules", () => {
+    const active = { ...source, activeRevisionId: revision.id };
+    expect(canSuggestScrapeRules(active)).toBe(false);
+    expect(
+      canSuggestScrapeRules({
+        ...active,
+        revisions: [{ ...revision, previewStatus: "failed" }],
+      }),
+    ).toBe(true);
+    expect(
+      canSuggestScrapeRules({
+        ...active,
+        revisions: [{ ...revision, rulesVersion: SCRAPE_RULES_VERSION - 1 }],
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("getSetupAfterLatestVersion", () => {
   it("ignores a failed setup when a newer version exists", () => {

--- a/apps/web/src/components/admin/scraperParsingStatus.ts
+++ b/apps/web/src/components/admin/scraperParsingStatus.ts
@@ -32,17 +32,8 @@ export function needsScrapeRulesUpdate(source: {
   return Boolean(latest && latest.rulesVersion < SCRAPE_RULES_VERSION);
 }
 
-export function canSuggestScrapeRules(source: Omit<SetupSource, "enabled">) {
-  if (source.setup?.status === "queued" || source.setup?.status === "running") {
-    return false;
-  }
-  const latest = source.revisions[0];
-  return (
-    !latest ||
-    latest.id !== source.activeRevisionId ||
-    latest.previewStatus === "failed" ||
-    needsScrapeRulesUpdate(source)
-  );
+export function canSuggestScrapeRules({ setup }: Pick<Source, "setup">) {
+  return setup?.status !== "queued" && setup?.status !== "running";
 }
 
 export function getSetupSteps(source: SetupSource) {

--- a/apps/web/src/components/admin/scraperParsingStatus.ts
+++ b/apps/web/src/components/admin/scraperParsingStatus.ts
@@ -32,6 +32,19 @@ export function needsScrapeRulesUpdate(source: {
   return Boolean(latest && latest.rulesVersion < SCRAPE_RULES_VERSION);
 }
 
+export function canSuggestScrapeRules(source: Omit<SetupSource, "enabled">) {
+  if (source.setup?.status === "queued" || source.setup?.status === "running") {
+    return false;
+  }
+  const latest = source.revisions[0];
+  return (
+    !latest ||
+    latest.id !== source.activeRevisionId ||
+    latest.previewStatus === "failed" ||
+    needsScrapeRulesUpdate(source)
+  );
+}
+
 export function getSetupSteps(source: SetupSource) {
   const latest = source.revisions[0];
   const setupStatus = getSetupAfterLatestVersion(source)?.status;


### PR DESCRIPTION
Admins can request a fresh scraper setup regardless of the saved rules’ version or test status. Previously, current-format rules blocked another setup run, even when they were an unfinished proposal. Admin now has two actions for this flow: “Start AI setup” and “Rebuild setup,” unavailable while setup is queued or running.

A manual rebuild only creates a proposal. Active rules and revision history stay unchanged until the replacement is tested and explicitly activated, so the extra version/status eligibility check and database lookup are unnecessary. Admin permissions, one-run-at-a-time enforcement, cost limits, and one-shot automatic repair remain unchanged. No migration is needed.

Regression coverage uses the real API and database to check rebuilding inactive proposals, preserving healthy active rules, and concurrent requests creating only one queued run. Browser QA was not run.

Refs #1210.
