### PR TITLE
fix(server): repoint parent Bottle references during merges

### DIFF
--- a/apps/server/src/lib/mergeBottles.test.ts
+++ b/apps/server/src/lib/mergeBottles.test.ts
@@ -159,6 +159,7 @@ describe("exact Bottle merges", () => {
         proposalType: "match_existing",
         currentBottleId: source.id,
         suggestedBottleId: source.id,
+        legacyParentBottleId: source.id,
       })
       .returning();
     const [attempt] = await db
@@ -170,6 +171,7 @@ describe("exact Bottle merges", () => {
         initialStatus: "pending_review",
         currentBottleId: source.id,
         suggestedBottleId: source.id,
+        legacyParentBottleId: source.id,
       })
       .returning();
     const [decisionLog] = await db
@@ -297,6 +299,7 @@ describe("exact Bottle merges", () => {
     ).toMatchObject({
       currentBottleId: destination.id,
       suggestedBottleId: destination.id,
+      legacyParentBottleId: destination.id,
     });
     expect(
       await db.query.storePriceMatchAttempts.findFirst({
@@ -305,6 +308,7 @@ describe("exact Bottle merges", () => {
     ).toMatchObject({
       currentBottleId: destination.id,
       suggestedBottleId: destination.id,
+      legacyParentBottleId: destination.id,
     });
 
     expect(

--- a/apps/server/src/lib/mergeBottles.ts
+++ b/apps/server/src/lib/mergeBottles.ts
@@ -424,12 +424,14 @@ async function repointBottleConsumers(
       .set({
         currentBottleId: sql`CASE WHEN ${table.currentBottleId} = ${sourceBottleId} THEN ${destinationBottleId} ELSE ${table.currentBottleId} END`,
         suggestedBottleId: sql`CASE WHEN ${table.suggestedBottleId} = ${sourceBottleId} THEN ${destinationBottleId} ELSE ${table.suggestedBottleId} END`,
+        legacyParentBottleId: sql`CASE WHEN ${table.legacyParentBottleId} = ${sourceBottleId} THEN ${destinationBottleId} ELSE ${table.legacyParentBottleId} END`,
         updatedAt: new Date(),
       })
       .where(
         or(
           eq(table.currentBottleId, sourceBottleId),
           eq(table.suggestedBottleId, sourceBottleId),
+          eq(table.legacyParentBottleId, sourceBottleId),
         ),
       )
       .returning({ id: table.id });
@@ -575,6 +577,7 @@ export async function lockBottleMergeDependencies(
       or(
         inArray(storePriceMatchProposals.currentBottleId, bottleIds),
         inArray(storePriceMatchProposals.suggestedBottleId, bottleIds),
+        inArray(storePriceMatchProposals.legacyParentBottleId, bottleIds),
       ),
     )
     .orderBy(asc(storePriceMatchProposals.id))
@@ -586,6 +589,7 @@ export async function lockBottleMergeDependencies(
       or(
         inArray(storePriceMatchAttempts.currentBottleId, bottleIds),
         inArray(storePriceMatchAttempts.suggestedBottleId, bottleIds),
+        inArray(storePriceMatchAttempts.legacyParentBottleId, bottleIds),
       ),
     )
     .orderBy(asc(storePriceMatchAttempts.id))


### PR DESCRIPTION
Bottle merges now repoint retained parent Bottle references on store-price match proposals and attempts before deleting the source Bottle. This prevents merges from failing on the `store_price_match_proposal_parent_bottle_id_bottle_id_fk` constraint and preserves the legacy relationship on the destination Bottle.

The dependency lock now includes rows that reference either Bottle through the retained parent field, and the existing merge integration test covers both proposal and attempt references.

Fixes https://peated.sentry.io/issues/7724927248/
