### PR TITLE
fix(scraper): separate setup samples from collection limits

### DIFF
--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -144,7 +144,10 @@ Adding a source starts AI setup. The server reads the main page, up to four
 likely list pages on the same website, and any optional example review or
 product pages. The agent can use `read_page` to inspect more pages on the same
 website. It submits v11 rules to `test_rules`, which runs the collection crawler
-without importing anything, including the same pagination and item limits.
+without importing anything. Ordinary setup tests sample at most 20 detail pages;
+repair tests use the full collection limit so they can reach the failing page.
+Code preserves the active rules' collection limit, or uses 99 for new or unreadable
+rules. The agent cannot change that limit to make a test cheaper or easier to pass.
 The tool returns extracted examples, visited pages, and any errors. The agent
 inspects successful results too: valid fields do not guarantee the right content.
 `finish` saves exactly the last passing rules and their test results. An admin

--- a/apps/server/src/scraper/configured/repair.test.ts
+++ b/apps/server/src/scraper/configured/repair.test.ts
@@ -81,7 +81,7 @@ async function runToCompletion(input: {
   executionToken: string;
 }) {
   const registry = createScraperRegistry({ targets: [], sources: [] });
-  for (let attempt = 1; attempt <= 20; attempt += 1) {
+  for (let attempt = 1; attempt <= 100; attempt += 1) {
     const result = await executeScraperRun(
       { runId: input.runId },
       {
@@ -98,10 +98,10 @@ async function runToCompletion(input: {
     }
     input.clock.advanceTo(result.nextAttemptAt);
   }
-  throw new Error("The test run did not finish within 20 attempts.");
+  throw new Error("The test run did not finish within 100 attempts.");
 }
 
-async function setupSource() {
+async function setupSource(limit: number = oldRules.list.limit) {
   const [user] = await db
     .insert(users)
     .values({
@@ -121,7 +121,7 @@ async function setupSource() {
     scrapeSourceId: created.source.id,
     author: "person",
     createdById: user.id,
-    rules: oldRules,
+    rules: { ...oldRules, list: { ...oldRules.list, limit } },
   });
   await db
     .update(scrapeSourceRevisions)
@@ -558,6 +558,91 @@ test("failed repair stops after three model calls and allows an explicit manual 
   ).toMatchObject([{ active: false, previewStatus: "passed" }]);
 });
 
+test("a sampled setup preserves the collection cap and collects beyond its sample", async () => {
+  const { source, site, user, revision } = await setupSource(99);
+  const rules = { ...oldRules, list: { ...oldRules.list, limit: 99 } };
+  const fetchImpl: typeof fetch = async (input) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.pathname === "/archive") {
+      return new Response(
+        Array.from(
+          { length: 25 },
+          (_, i) => `<a class="review" href="/reviews/${i}">Malt ${i}</a>`,
+        ).join(""),
+      );
+    }
+    if (url.pathname.startsWith("/reviews/")) {
+      return new Response(
+        `<h1>Malt ${url.pathname.split("/").at(-1)}</h1><time datetime="2026-09-08"></time><article class="review"><h3>Coastal Malt</h3><div class="body">Soft smoke.</div></article>`,
+      );
+    }
+    throw new Error(`Unexpected URL: ${url.toString()}`);
+  };
+  const run = await createScrapeSourceSuggestionRun({
+    scrapeSourceId: source.id,
+    requestedById: user.id,
+  });
+  requestModel
+    .mockResolvedValueOnce(
+      ruleResponse({ ...rules, list: { ...rules.list, limit: 20 } }),
+    )
+    .mockImplementation(acceptTestedRules(rules));
+  await runToCompletion({
+    runId: run.id,
+    fetchImpl,
+    clock: testClock(),
+    executionToken: "sampled-setup",
+  });
+  const revisions = await db
+    .select()
+    .from(scrapeSourceRevisions)
+    .where(eq(scrapeSourceRevisions.scrapeSourceId, source.id));
+  const suggested = revisions.find((candidate) => candidate.author === "ai");
+  expect(suggested).toMatchObject({
+    active: false,
+    rulesVersion: 11,
+    rules,
+    previewStatus: "passed",
+  });
+  expect(suggested!.previewResult!.pages).toHaveLength(20);
+  expect(
+    await db
+      .select()
+      .from(externalSiteRuns)
+      .where(eq(externalSiteRuns.id, run.id)),
+  ).toMatchObject([{ status: "succeeded", requestCount: 21 }]);
+  expect(
+    revisions.find((candidate) => candidate.id === revision.id),
+  ).toMatchObject({
+    active: true,
+  });
+
+  await activateScrapeSourceRevision({
+    scrapeSourceId: source.id,
+    revisionId: suggested!.id,
+  });
+  const collection = await createPinnedScrapeSourceRun(db, {
+    externalSiteId: site.id,
+    trigger: "manual",
+    purpose: "collect",
+    requestedById: user.id,
+  });
+  await runToCompletion({
+    runId: collection.run.id,
+    fetchImpl,
+    clock: testClock(),
+    executionToken: "full-collection",
+  });
+  expect(
+    await db
+      .select()
+      .from(externalSiteRuns)
+      .where(eq(externalSiteRuns.id, collection.run.id)),
+  ).toMatchObject([{ status: "succeeded", emittedItemCount: 25 }]);
+  // Scraper setup owns the model budget; collection must not invoke it.
+  expect(requestModel).toHaveBeenCalledTimes(3);
+});
+
 test.each([
   {
     rulesVersion: 11,
@@ -576,7 +661,11 @@ test.each([
       scrapeSourceId: source.id,
       requestedById: user.id,
     });
-    requestModel.mockImplementation(acceptTestedRules(repairedRules));
+    const replacement = {
+      ...repairedRules,
+      list: { ...repairedRules.list, limit: 99 },
+    };
+    requestModel.mockImplementation(acceptTestedRules(replacement));
     await expect(
       runToCompletion({
         runId: run.id,
@@ -606,7 +695,7 @@ test.each([
         expect.objectContaining({
           rulesVersion: 11,
           active: false,
-          rules: repairedRules,
+          rules: replacement,
           previewStatus: "passed",
         }),
       ]),

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -764,7 +764,7 @@ export const ScrapeRulesV8Schema = z.discriminatedUnion("kind", [
   ScrapeCatalogRulesV9Schema,
 ]);
 
-const ScrapeListSchema = z
+export const ScrapeListSchema = z
   .object({
     links: ScrapeSelectorSchema.describe("Links to article or product pages."),
     nextPage: ScrapeSelectorSchema.nullable().describe(

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -228,6 +228,7 @@ function runAgentWithPages(
     conversationId: "scrape_source:1",
     externalSiteRunId: 10,
     kind: rules.kind,
+    collectionLimit: rules.list.limit,
     scrapeSourceId: 1,
     listPages: [listPage],
     detailPages: [],

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -21,6 +21,7 @@ import {
   SCRAPE_SOURCE_MAX_ITEMS,
   SCRAPE_SOURCE_MAX_LIST_PAGES,
   ScrapeCatalogRulesSchema,
+  ScrapeListSchema,
   ScrapePriceRulesSchema,
   ScrapeReviewRulesSchema,
   ScrapeRulesSchema,
@@ -32,9 +33,10 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v27";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v28";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_EXAMPLE_PAGES = 3;
+export const MAX_RULE_TEST_ITEMS = 20;
 const MAX_RULE_TESTS = 3;
 export const MAX_SETUP_MODEL_CALLS = 8;
 const MAX_PAGE_READS = 4;
@@ -61,7 +63,13 @@ export function setupRequestLimit(samplePageCount: number) {
   );
 }
 
-function ruleTestSchema(kind: ScrapeRules["kind"]) {
+function ruleTestSchema(kind: ScrapeRules["kind"], collectionLimit: number) {
+  const rulesSchema =
+    kind === "review"
+      ? ScrapeReviewRulesSchema
+      : kind === "catalog"
+        ? ScrapeCatalogRulesSchema
+        : ScrapePriceRulesSchema;
   return z
     .object({
       listPageUrl: z
@@ -70,12 +78,15 @@ function ruleTestSchema(kind: ScrapeRules["kind"]) {
         .min(1)
         .max(2_000)
         .describe("The exact URL of a collection page you inspected."),
-      rules:
-        kind === "review"
-          ? ScrapeReviewRulesSchema
-          : kind === "catalog"
-            ? ScrapeCatalogRulesSchema
-            : ScrapePriceRulesSchema,
+      rules: rulesSchema.extend({
+        list: ScrapeListSchema.extend({
+          limit: z
+            .literal(collectionLimit)
+            .describe(
+              "The server-owned collection limit. Keep this value; test sampling is separate.",
+            ),
+        }),
+      }),
     })
     .strict();
 }
@@ -251,6 +262,7 @@ type ScrapeSourceSetupAgentInput = {
   conversationId: string;
   externalSiteRunId: number;
   kind: ScrapeRules["kind"];
+  collectionLimit: number;
   scrapeSourceId: number;
   listPages: WebsitePage[];
   detailPages: WebsitePage[];
@@ -389,7 +401,7 @@ async function runSetupTurns(
               );
             }
             const submitted = parseToolArguments(
-              ruleTestSchema(input.kind),
+              ruleTestSchema(input.kind, input.collectionLimit),
               call.arguments,
             );
             const tested = await input.testRules(
@@ -443,9 +455,8 @@ export async function runScrapeSourceSetupAgent(
   const tools: Tool[] = [
     zodResponsesFunction({
       name: "test_rules",
-      description:
-        "Run the collection crawler without importing data. Returns extracted examples, visited pages, and errors. Inspect the results before finishing; passing means the parser worked, not that the selected content is correct.",
-      parameters: ruleTestSchema(input.kind),
+      description: `Run the collection crawler without importing data. Ordinary setup tests sample at most ${MAX_RULE_TEST_ITEMS} detail pages; repairs test the full collection limit. Sampling never changes the saved collection limit. Returns extracted examples, visited pages, and errors. Inspect the results before finishing; passing means the parser worked, not that the selected content is correct.`,
+      parameters: ruleTestSchema(input.kind, input.collectionLimit),
     }),
     zodResponsesFunction({
       name: "read_page",

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -782,6 +782,7 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         aiInstructionsVersion: AI_INSTRUCTIONS_VERSION,
         listUrl: BRUICHLADDICH_LIST_URL,
         rulesVersion: 11,
+        rules: { list: { limit: 99 } },
       });
 
       const rules = loadExecutableScrapeRules(

--- a/apps/server/src/scraper/configured/suggestion.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.test.ts
@@ -155,6 +155,38 @@ test("does not pass a repair by excluding the failing page", async () => {
   });
 });
 
+test("repair tests reach failures beyond the ordinary setup sample", async () => {
+  const pages = Object.fromEntries(
+    Array.from({ length: 21 }, (_, i) => [`/review-${i}`, article]),
+  );
+  pages["/reviews"] = Array.from(
+    { length: 21 },
+    (_, i) => `<a class="review" href="/review-${i}">Review ${i}</a>`,
+  ).join("");
+  pages["/review-20"] = "<main>Broken review</main>";
+  const options = {
+    rules: { ...reviewRules, list: { ...reviewRules.list, limit: 99 } },
+  };
+  expect(await testPages(pages, options)).toMatchObject({ status: "passed" });
+  expect(
+    await testPages(pages, {
+      ...options,
+      failureUrl: "https://example.test/review-20",
+    }),
+  ).toMatchObject({ status: "failed" });
+  pages["/review-20"] = article;
+  const repaired = await testPages(pages, {
+    ...options,
+    failureUrl: "https://example.test/review-20",
+  });
+  expect(repaired).toMatchObject({
+    status: "passed",
+    visitedPages: expect.arrayContaining(["https://example.test/review-20"]),
+  });
+  if (repaired.status !== "passed") throw new Error(repaired.feedback.message);
+  expect(repaired.preview.pages).toHaveLength(21);
+});
+
 test("rejects pagination loops through the same crawler used for collection", async () => {
   const result = await testPages(
     {

--- a/apps/server/src/scraper/configured/suggestion.ts
+++ b/apps/server/src/scraper/configured/suggestion.ts
@@ -17,7 +17,11 @@ import {
 } from "./crawl";
 import { inspectSyndicationFeed } from "./discovery";
 import type { ScrapeIssue, ScrapeSourcePreviewResult } from "./preview";
-import { SCRAPE_RULES_VERSION, type ScrapeRules } from "./rules";
+import {
+  SCRAPE_RULES_VERSION,
+  SCRAPE_SOURCE_MAX_ITEMS,
+  type ScrapeRules,
+} from "./rules";
 import {
   reserveScrapeSourceModelCall,
   saveScrapeSourceSetupState,
@@ -25,6 +29,7 @@ import {
 import { saveScrapeSourceSuggestion } from "./service";
 import {
   AI_INSTRUCTIONS_VERSION,
+  MAX_RULE_TEST_ITEMS,
   runScrapeSourceSetupAgent,
   type RuleTestResult,
   type SetupAgentModelRequest,
@@ -110,7 +115,8 @@ export async function testScrapeRules(input: {
     const adapter = createScrapeSourceAdapter({
       targetKey: "rule-test",
       listUrl: input.listPageUrl,
-      rules,
+      // Setup samples detail pages; repairs must still exercise the failing page.
+      rules: input.failureUrl ? rules : rules.withLimit(MAX_RULE_TEST_ITEMS),
       purpose: "preview",
       recordPreview: async (result) => {
         preview = result.result;
@@ -301,6 +307,7 @@ export async function suggestScrapeSourceRevision(
     conversationId: `scrape_source:${input.scrapeSourceId}`,
     externalSiteRunId: input.externalSiteRunId,
     kind: source.kind,
+    collectionLimit: previousRules?.limit ?? SCRAPE_SOURCE_MAX_ITEMS,
     scrapeSourceId: input.scrapeSourceId,
     listPages: input.listPages,
     detailPages: input.detailPages,


### PR DESCRIPTION
Scraper setup now tests a sample of at most 20 detail pages without lowering the saved collection limit. Code preserves the active rules' limit, or uses 99 for new or unreadable rules. The agent cannot shrink that limit to fit the current sample and silently miss later products or reviews.

Automatic repairs still test the full collection scope and must reach the failing page. The v11 saved format, activation rules, and model-call limits stay unchanged; no migration or production revision edits are included.

Integration coverage rejects a smaller proposed cap, saves a 20-page preview, and then collects all 25 fixture items without another model call. A separate regression checks a broken page beyond the sample, and the existing live migration check now requires the original collection limit.

Refs #1210.
