### PR TITLE
fix(reviews): refresh summaries after reference assignment

### DIFF
--- a/apps/server/src/lib/bottleReferences.test.ts
+++ b/apps/server/src/lib/bottleReferences.test.ts
@@ -684,6 +684,11 @@ describe("finalizeBottleReferenceAssignment", () => {
       "IndexBottleSearchVectors",
       { bottleId: bottle.id },
     );
+    expect(workerClient.pushJob).not.toHaveBeenCalledWith(
+      "UpdateBottleStats",
+      expect.anything(),
+      expect.anything(),
+    );
   });
 
   test("treats queue failures as nonfatal post-commit effects", async ({

--- a/apps/server/src/lib/bottleReferences.ts
+++ b/apps/server/src/lib/bottleReferences.ts
@@ -17,6 +17,7 @@ import {
   storePrices,
 } from "@peated/server/db/schema";
 import { reconcileBottleSeriesRepresentativesForBottles } from "@peated/server/lib/bottleSeriesRepresentatives";
+import { dispatchBottleStatsRecomputes } from "@peated/server/lib/dispatchBottleStatsRecompute";
 import {
   logError,
   logInfo,
@@ -204,6 +205,7 @@ export type BottleReferenceAssignmentResult = {
   isNew: boolean;
   bottleImageCandidate: BottleImageCandidate | null;
   bottleId: number;
+  changedReviewBottleIds: number[];
 };
 
 type BottleReferenceAssignmentValues = {
@@ -581,7 +583,7 @@ async function syncBottleReferenceConsumersInTransaction(
     eq(externalReviews.bottleId, bottleId),
     expectedReview ? eq(externalReviews.id, expectedReview.id) : undefined,
   );
-  await tx
+  const changedReviews = await tx
     .update(externalReviews)
     .set({ bottleId })
     .where(
@@ -603,11 +605,22 @@ async function syncBottleReferenceConsumersInTransaction(
             )
           : undefined,
         reviewIdentity,
+        sql`${externalReviews.bottleId} IS DISTINCT FROM ${bottleId}`,
       ),
-    );
+    )
+    .returning({ id: externalReviews.id });
 
   const priceWithImage = matchingPrices.find((price) => !!price.imageUrl);
   return {
+    changedReviewBottleIds: changedReviews.length
+      ? Array.from(
+          new Set(
+            [expectedReview?.bottleId, bottleId].filter(
+              (value): value is number => value !== null && value !== undefined,
+            ),
+          ),
+        )
+      : [],
     bottleImageCandidate: priceWithImage?.imageUrl
       ? {
           bottleId,
@@ -644,7 +657,7 @@ export async function assignBottleReferenceInTransaction(
       [name, ...backfillNames].map((value) => value.trim().toLowerCase()),
     ),
   ).filter(Boolean);
-  const { bottleImageCandidate } =
+  const { bottleImageCandidate, changedReviewBottleIds } =
     await syncBottleReferenceConsumersInTransaction(tx, {
       bottleId,
       externalSiteId,
@@ -684,6 +697,7 @@ export async function assignBottleReferenceInTransaction(
       ? { ...bottleImageCandidate, createdByActorId: assignedByActorId }
       : null,
     bottleId,
+    changedReviewBottleIds,
   };
 }
 
@@ -691,7 +705,7 @@ export async function assignBottleReferenceInTransaction(
 export async function syncBottleReferenceConsumersForReferenceChange(
   name: string,
 ) {
-  await db.transaction(async (tx) => {
+  const changedReviewBottleIds = await db.transaction(async (tx) => {
     const [reference] = await tx
       .select({
         name: bottleReferences.name,
@@ -706,7 +720,7 @@ export async function syncBottleReferenceConsumersForReferenceChange(
     if (!reference) {
       throw new Error(`Unknown bottle reference: ${name}`);
     }
-    if (reference.ignored || reference.bottleId === null) return;
+    if (reference.ignored || reference.bottleId === null) return [];
 
     try {
       await lockActiveBottleInTransaction(tx, reference.bottleId);
@@ -716,14 +730,15 @@ export async function syncBottleReferenceConsumersForReferenceChange(
         error instanceof BottleReferenceBottleRetiredError ||
         error instanceof BottleReferenceBottleInactiveError
       ) {
-        return;
+        return [];
       }
       throw error;
     }
-    await syncBottleReferenceConsumersInTransaction(tx, {
-      bottleId: reference.bottleId,
-      lookupNames: [reference.name.toLowerCase()],
-    });
+    const { changedReviewBottleIds } =
+      await syncBottleReferenceConsumersInTransaction(tx, {
+        bottleId: reference.bottleId,
+        lookupNames: [reference.name.toLowerCase()],
+      });
 
     const [unchangedReference] = await tx
       .select({ name: bottleReferences.name })
@@ -742,7 +757,15 @@ export async function syncBottleReferenceConsumersForReferenceChange(
     if (!unchangedReference) {
       throw new BottleReferenceIdentityChangedError(reference.name);
     }
+
+    return changedReviewBottleIds;
   });
+
+  await dispatchBottleStatsRecomputes(
+    "externalReview",
+    `bottleReference:${name}`,
+    changedReviewBottleIds,
+  );
 }
 
 function recordUnresolvedBottleImageCandidate(
@@ -763,9 +786,8 @@ function recordUnresolvedBottleImageCandidate(
 }
 
 /**
- * Runs after commit, fills only missing Bottle images (following a merged
- * source through its tombstone), and logs image/index/notification failures as
- * nonfatal side effects.
+ * Runs post-commit work for one reference assignment. This boundary owns Bottle
+ * summary refreshes for critic reviews moved by the assignment.
  */
 export async function finalizeBottleReferenceAssignment(
   {
@@ -773,6 +795,7 @@ export async function finalizeBottleReferenceAssignment(
     referenceChanged,
     bottleImageCandidate,
     bottleId,
+    changedReviewBottleIds,
   }: BottleReferenceAssignmentResult,
   contexts?: SentryLogContexts,
 ) {
@@ -791,6 +814,12 @@ export async function finalizeBottleReferenceAssignment(
   } catch (err) {
     logError(err, contexts);
   }
+
+  await dispatchBottleStatsRecomputes(
+    "externalReview",
+    `bottleReference:${reference.name}`,
+    changedReviewBottleIds,
+  );
 }
 
 /** Fills only a missing Bottle image and respects rejected image URLs. */
@@ -972,6 +1001,7 @@ export async function correctBottleReference(
         },
         previousBottleId: reference.bottleId,
         changed: false,
+        changedReviewBottleIds: [],
       };
     }
 
@@ -1015,7 +1045,7 @@ export async function correctBottleReference(
             : priorPriceIdentity,
         ),
       );
-    await tx
+    const changedReviews = await tx
       .update(externalReviews)
       .set({ bottleId })
       .where(
@@ -1024,8 +1054,10 @@ export async function correctBottleReference(
           bottleId === null && previousBottleId !== null
             ? eq(externalReviews.bottleId, previousBottleId)
             : priorReviewIdentity,
+          sql`${externalReviews.bottleId} IS DISTINCT FROM ${bottleId}`,
         ),
-      );
+      )
+      .returning({ id: externalReviews.id });
 
     const [updatedReference] = await tx
       .update(bottleReferences)
@@ -1059,6 +1091,11 @@ export async function correctBottleReference(
       },
       previousBottleId,
       changed: true,
+      changedReviewBottleIds: changedReviews.length
+        ? [previousBottleId, bottleId].filter(
+            (value): value is number => value !== null,
+          )
+        : [],
     };
   });
 
@@ -1082,6 +1119,12 @@ export async function correctBottleReference(
         logError(err, contexts);
       }
     }
+
+    await dispatchBottleStatsRecomputes(
+      "externalReview",
+      `bottleReference:${result.reference.id}`,
+      result.changedReviewBottleIds,
+    );
   }
 
   return result.reference;

--- a/apps/server/src/orpc/routes/bottleReferences/update.test.ts
+++ b/apps/server/src/orpc/routes/bottleReferences/update.test.ts
@@ -142,6 +142,17 @@ describe("PATCH /bottle-references/:reference", () => {
       "IndexBottleSearchVectors",
       { bottleId: target.id },
     );
+    for (const bottle of [source, target]) {
+      expect(workerClient.pushJob).toHaveBeenCalledWith(
+        "UpdateBottleStats",
+        { bottleId: bottle.id },
+        {
+          delay: 5000,
+          removeOnComplete: true,
+          removeOnFail: false,
+        },
+      );
+    }
   });
 
   test("unassigns the reference and exact consumers using the old identity", async ({

--- a/apps/server/src/orpc/routes/bottleReferences/upsert.test.ts
+++ b/apps/server/src/orpc/routes/bottleReferences/upsert.test.ts
@@ -66,6 +66,15 @@ describe("PUT /bottle-references", () => {
         where: eq(externalReviews.id, review.id),
       }),
     ).resolves.toMatchObject({ bottleId: bottle.id });
+    expect(workerClient.pushJob).toHaveBeenCalledWith(
+      "UpdateBottleStats",
+      { bottleId: bottle.id },
+      {
+        delay: 5000,
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
   });
 
   test("assigns an existing unresolved reference and reindexes it", async ({

--- a/apps/server/src/worker/jobs/createMissingBottles.test.ts
+++ b/apps/server/src/worker/jobs/createMissingBottles.test.ts
@@ -193,6 +193,15 @@ describe("createMissingBottles", () => {
         bottleId: updatedReview?.bottleId,
       },
     );
+    expect(workerClient.pushJob).toHaveBeenCalledWith(
+      "UpdateBottleStats",
+      { bottleId },
+      {
+        delay: 5000,
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
   });
 
   test("audits safe canonical create reuse as an existing Bottle match", async ({

--- a/apps/server/src/worker/jobs/onBottleReferenceChange.test.ts
+++ b/apps/server/src/worker/jobs/onBottleReferenceChange.test.ts
@@ -4,6 +4,7 @@ import {
   externalReviews,
   storePrices,
 } from "@peated/server/db/schema";
+import * as workerClient from "@peated/server/lib/test/workerDispatch";
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { JobPayload } from "../types";
@@ -78,6 +79,15 @@ describe("onBottleReferenceChange", () => {
     ).toMatchObject({ bottleId: otherBottle.id });
     expect(runReferenceIndex).toHaveBeenCalledTimes(2);
     expect(runReferenceIndex).toHaveBeenLastCalledWith(reference.name);
+    expect(workerClient.pushJob).toHaveBeenCalledWith(
+      "UpdateBottleStats",
+      { bottleId: bottle.id },
+      {
+        delay: 5000,
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
   });
 
   test("does not propagate ignored or unbound aliases", async ({


### PR DESCRIPTION
Bottle Reference assignments now refresh saved Bottle and BottleGroup review and tasting summaries whenever they move critic reviews. This keeps cached counts, scores, and flavor summaries aligned with the live review feed for automated matching, reference replay, and moderator corrections. Price-only and reference-only updates do not queue unnecessary summary work.

The regression came from the unified public review-and-tasting summaries: direct review mutations queued `UpdateBottleStats`, but the older shared Bottle Reference path only refreshed search indexes. Review this from `bottleReferences.ts`, where changed critic-review Bottle IDs are captured inside the transaction and dispatched after commit.
