### PR TITLE
fix(scraper): bypass classifier for trusted SMWS bottles

### DIFF
--- a/apps/server/src/lib/createStorePrices.ts
+++ b/apps/server/src/lib/createStorePrices.ts
@@ -6,7 +6,10 @@ import { db, type AnyTransaction } from "@peated/server/db";
 import {
   externalSites,
   storePriceHistories,
+  storePriceMatchAttempts,
+  storePriceMatchProposals,
   storePrices,
+  type Actor,
   type StorePrice,
 } from "@peated/server/db/schema";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
@@ -19,7 +22,11 @@ import {
 } from "@peated/server/lib/bottleReferences";
 import { ExternalSiteNotFoundError } from "@peated/server/lib/externalSites";
 import { normalizeGtin, type NormalizedGtin } from "@peated/server/lib/gtin";
-import { ActiveBottleSelectionError } from "@peated/server/lib/resolveActiveBottleIds";
+import { recordIncomingBottleDecisionInTransaction } from "@peated/server/lib/incomingBottleDecisionLog";
+import {
+  ActiveBottleSelectionError,
+  resolveActiveBottleIds,
+} from "@peated/server/lib/resolveActiveBottleIds";
 import { resolveStorePriceBottleMatchInTransaction } from "@peated/server/lib/storePriceBottleMatching";
 import {
   ExternalSiteKeySchema,
@@ -52,6 +59,113 @@ type StorePriceIdentity = {
   externalProductId?: string;
   externalSiteId: number;
   url: string;
+};
+
+type TrustedBottleMatch = {
+  bottleId: number;
+  candidate: null;
+  source: "trusted_source";
+  referenceMatch: null;
+};
+
+async function resolveTrustedBottleMatchInTransaction(
+  tx: AnyTransaction,
+  bottleId: number,
+): Promise<TrustedBottleMatch> {
+  await resolveActiveBottleIds(tx, [bottleId], { lock: "update" });
+  return {
+    bottleId,
+    candidate: null,
+    source: "trusted_source",
+    referenceMatch: null,
+  };
+}
+
+async function finalizeTrustedSourceAssignmentInTransaction({
+  tx,
+  actor,
+  bottleId,
+  createdBottle,
+  externalSiteId,
+  name,
+  priceId,
+  url,
+}: {
+  tx: AnyTransaction;
+  actor: Pick<Actor, "id" | "type" | "userId">;
+  bottleId: number;
+  createdBottle: boolean;
+  externalSiteId: number;
+  name: string;
+  priceId: number;
+  url: string;
+}) {
+  const [proposal] = await tx
+    .update(storePriceMatchProposals)
+    .set({
+      status: "approved",
+      currentBottleId: bottleId,
+      suggestedBottleId: bottleId,
+      error: null,
+      processingToken: null,
+      processingQueuedAt: null,
+      processingExpiresAt: null,
+      reviewedAt: sql`NOW()`,
+      reviewedById: null,
+      updatedAt: sql`NOW()`,
+    })
+    .where(
+      and(
+        eq(storePriceMatchProposals.priceId, priceId),
+        inArray(storePriceMatchProposals.status, ["pending_review", "errored"]),
+      ),
+    )
+    .returning({ id: storePriceMatchProposals.id });
+
+  if (proposal) {
+    await tx
+      .update(storePriceMatchAttempts)
+      .set({
+        finalStatus: "approved",
+        currentBottleId: bottleId,
+        suggestedBottleId: bottleId,
+        error: null,
+        reviewedAt: sql`NOW()`,
+        reviewedById: null,
+        updatedAt: sql`NOW()`,
+      })
+      .where(
+        and(
+          eq(storePriceMatchAttempts.proposalId, proposal.id),
+          isNull(storePriceMatchAttempts.finalStatus),
+        ),
+      );
+  }
+
+  await recordIncomingBottleDecisionInTransaction(tx, {
+    sourceKind: "store_price",
+    sourceId: priceId,
+    proposalId: proposal?.id ?? null,
+    externalSiteId,
+    name,
+    url,
+    decision: createdBottle ? "create_bottle" : "match_existing",
+    actor,
+    bottleId,
+    createdBottle,
+    rationale:
+      "Trusted Bottle source assigned the listing to the Bottle it supplied.",
+    metadata: {
+      matchingBasis: "source_bottle",
+      resolutionSource: "trusted_scraper",
+    },
+  });
+}
+
+type TrustedBottleSource = {
+  actor: Pick<Actor, "id" | "type" | "userId">;
+  bottleId: number;
+  createdBottle: boolean;
 };
 
 function getSourceFingerprint({
@@ -353,9 +467,10 @@ async function persistStorePriceInTransaction({
 }
 
 /** Persists one scraper batch with attribution chosen by the owning boundary. */
-export async function createStorePrices(
+async function createStorePricesInternal(
   rawInput: CreateStorePricesInput,
   actorId: number,
+  trustedBottleSource?: TrustedBottleSource,
 ) {
   const input = CreateStorePricesInputSchema.parse(rawInput);
   const site = await db.query.externalSites.findFirst({
@@ -382,15 +497,17 @@ export async function createStorePrices(
             const referenceKey = normalizeBottleReferenceKey(sp.name);
             let bottleMatch;
             try {
-              bottleMatch = await resolveStorePriceBottleMatchInTransaction(
-                tx,
-                {
-                  name: sp.name,
-                  normalizedBarcode,
-                  sourceBottleIdentity: sp.sourceBottleIdentity ?? null,
-                  volume: sp.volume,
-                },
-              );
+              bottleMatch = trustedBottleSource
+                ? await resolveTrustedBottleMatchInTransaction(
+                    tx,
+                    trustedBottleSource.bottleId,
+                  )
+                : await resolveStorePriceBottleMatchInTransaction(tx, {
+                    name: sp.name,
+                    normalizedBarcode,
+                    sourceBottleIdentity: sp.sourceBottleIdentity ?? null,
+                    volume: sp.volume,
+                  });
             } catch (error) {
               if (!(error instanceof ActiveBottleSelectionError)) {
                 throw error;
@@ -454,6 +571,28 @@ export async function createStorePrices(
               })
               .onConflictDoNothing();
 
+            const directMatchSource = persisted.sourceIdentityReused
+              ? "source"
+              : hasDirectMatch
+                ? bottleMatch.source
+                : null;
+            if (
+              trustedBottleSource &&
+              hasDirectMatch &&
+              directMatchSource === "trusted_source"
+            ) {
+              await finalizeTrustedSourceAssignmentInTransaction({
+                tx,
+                actor: trustedBottleSource.actor,
+                bottleId: trustedBottleSource.bottleId,
+                createdBottle: trustedBottleSource.createdBottle,
+                externalSiteId: site.id,
+                name: sp.name,
+                priceId,
+                url: sp.url,
+              });
+            }
+
             return {
               price: {
                 id: priceId,
@@ -461,11 +600,7 @@ export async function createStorePrices(
                 imageUrl: persisted.price.imageUrl,
                 identityChanged: persisted.identityChanged,
                 hasDirectMatch,
-                directMatchSource: persisted.sourceIdentityReused
-                  ? "source"
-                  : hasDirectMatch
-                    ? bottleMatch.source
-                    : null,
+                directMatchSource,
               },
               referenceAssignment,
             };
@@ -486,7 +621,10 @@ export async function createStorePrices(
         }
 
         // The old match was cleared. Do not reuse its completed job.
-        if (price.identityChanged) {
+        if (
+          price.identityChanged &&
+          price.directMatchSource !== "trusted_source"
+        ) {
           await pushJob("ResolveStorePriceBottle", {
             priceId: price.id,
             force: true,
@@ -510,8 +648,35 @@ export async function createStorePrices(
   return { newItemCount, existingItemCount };
 }
 
+export async function createStorePrices(
+  rawInput: CreateStorePricesInput,
+  actorId: number,
+) {
+  return await createStorePricesInternal(rawInput, actorId);
+}
+
 /** Trusted worker capability; callers cannot select an arbitrary actor. */
 export async function createStorePricesAsPeated(input: CreateStorePricesInput) {
   const actor = await getPeatedSystemActor();
-  return await createStorePrices(input, actor.id);
+  return await createStorePricesInternal(input, actor.id);
+}
+
+/** Trusted Bottle-source capability for one listing emitted with its Bottle. */
+export async function createStorePriceForBottleAsPeated({
+  bottleId,
+  createdBottle,
+  price,
+  site,
+}: {
+  bottleId: number;
+  createdBottle: boolean;
+  price: z.input<typeof StorePriceInputSchema>;
+  site: z.input<typeof ExternalSiteKeySchema>;
+}) {
+  const actor = await getPeatedSystemActor();
+  return await createStorePricesInternal({ site, prices: [price] }, actor.id, {
+    actor,
+    bottleId,
+    createdBottle,
+  });
 }

--- a/apps/server/src/lib/flatBottleInput.ts
+++ b/apps/server/src/lib/flatBottleInput.ts
@@ -1,8 +1,10 @@
+import { BottleExtractedDetailsSchema } from "@peated/bottle-classifier/contract";
 import { BottleCreateInputSchema } from "@peated/server/lib/bottleSchemas";
 import type { BottleInputSchema } from "@peated/server/schemas";
-import type { z } from "zod";
+import { z } from "zod";
 
 type FlatBottleInput = z.input<typeof BottleInputSchema>;
+const NamedChoiceSchema = z.object({ name: z.string() });
 
 /**
  * Translates the retained flat Bottle input into the strict Bottle create
@@ -33,5 +35,37 @@ export function buildBottleCreateInput(input: FlatBottleInput) {
     description: input.description,
     descriptionSrc: input.descriptionSrc,
     tastingNotes: input.tastingNotes,
+  });
+}
+
+function getChoiceName(
+  choice: number | { name: string } | null | undefined,
+): string | null {
+  return NamedChoiceSchema.safeParse(choice).data?.name ?? null;
+}
+
+/** Keeps trusted scraper Bottle facts with the listing that supplied them. */
+export function buildBottleSourceIdentity(input: FlatBottleInput) {
+  return BottleExtractedDetailsSchema.parse({
+    brand: getChoiceName(input.brand),
+    bottler: getChoiceName(input.bottler),
+    expression: input.name,
+    series: getChoiceName(input.series),
+    distillery: (input.distillers ?? [])
+      .map(getChoiceName)
+      .filter((name): name is string => name !== null),
+    category: input.category,
+    stated_age: input.statedAge,
+    abv: input.abv,
+    release_year: input.releaseYear,
+    release_month: input.releaseMonth,
+    release_day: input.releaseDay,
+    vintage_year: input.vintageYear,
+    cask_strength: input.caskStrength,
+    single_cask: input.singleCask,
+    maturation: input.maturation,
+    cask_number: input.caskNumber,
+    outturn: input.outturn,
+    edition: input.edition,
   });
 }

--- a/apps/server/src/scraper/legacy/scraper.test.ts
+++ b/apps/server/src/scraper/legacy/scraper.test.ts
@@ -3,10 +3,15 @@ import {
   bottleReferences,
   bottles,
   entities,
+  incomingBottleDecisionLogs,
+  storePriceMatchAttempts,
+  storePriceMatchProposals,
   storePrices,
 } from "@peated/server/db/schema";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
+import { createStorePricesAsPeated } from "@peated/server/lib/createStorePrices";
 import waitError from "@peated/server/lib/test/waitError";
+import * as workerClient from "@peated/server/lib/test/workerDispatch";
 import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import scrapePrices, {
@@ -67,14 +72,40 @@ describe("handleBottle", () => {
       edition: bottleInput.edition,
       statedAge: bottleInput.statedAge,
     });
-    expect(
-      await db.query.storePrices.findFirst({
-        where: and(
-          eq(storePrices.externalSiteId, site.id),
-          eq(storePrices.price, priceInput.price),
-        ),
+    const price = await db.query.storePrices.findFirst({
+      where: and(
+        eq(storePrices.externalSiteId, site.id),
+        eq(storePrices.price, priceInput.price),
+      ),
+    });
+    expect(price).toMatchObject({
+      bottleId: bottle!.id,
+      price: priceInput.price,
+      sourceBottleIdentity: expect.objectContaining({
+        expression: bottleInput.name,
+        edition: bottleInput.edition,
       }),
-    ).toMatchObject({ price: priceInput.price });
+    });
+    expect(workerClient.pushUniqueJob).not.toHaveBeenCalledWith(
+      "ResolveStorePriceBottle",
+      expect.anything(),
+    );
+    expect(
+      await db.query.incomingBottleDecisionLogs.findFirst({
+        where: eq(incomingBottleDecisionLogs.sourceId, price!.id),
+      }),
+    ).toMatchObject({
+      sourceKind: "store_price",
+      sourceId: price!.id,
+      decision: "create_bottle",
+      actorId: systemActor.id,
+      bottleId: bottle!.id,
+      createdBottle: true,
+      metadata: {
+        matchingBasis: "source_bottle",
+        resolutionSource: "trusted_scraper",
+      },
+    });
   });
 
   it("updates the canonical Bottle when repeated ingestion conflicts", async () => {
@@ -197,7 +228,84 @@ describe("handleBottle", () => {
           eq(storePrices.price, priceInput.price),
         ),
       }),
-    ).toMatchObject({ price: priceInput.price });
+    ).toMatchObject({ bottleId: null, price: priceInput.price });
+    expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
+      "ResolveStorePriceBottle",
+      expect.anything(),
+    );
+  });
+
+  it("closes an active classifier proposal after the trusted source assigns its Bottle", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({ type: "smws" });
+    await createStorePricesAsPeated({ site: "smws", prices: [priceInput] });
+    const unresolvedPrice = await db.query.storePrices.findFirst({
+      where: eq(storePrices.externalSiteId, site.id),
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: unresolvedPrice!.id,
+        status: "errored",
+        proposalType: "no_match",
+        error: "Classifier unavailable",
+        processingToken: "stale-classifier-run",
+        processingQueuedAt: new Date(),
+        processingExpiresAt: new Date(Date.now() + 10 * 60_000),
+      })
+      .returning();
+    const [attempt] = await db
+      .insert(storePriceMatchAttempts)
+      .values({
+        priceId: unresolvedPrice!.id,
+        proposalId: proposal!.id,
+        proposalType: "no_match",
+        initialStatus: "errored",
+        error: "Classifier unavailable",
+      })
+      .returning();
+    vi.mocked(workerClient.pushJob).mockClear();
+    vi.mocked(workerClient.pushUniqueJob).mockClear();
+
+    await handleBottle(bottleInput, priceInput);
+
+    const [resolvedPrice, resolvedProposal, resolvedAttempt] =
+      await Promise.all([
+        db.query.storePrices.findFirst({
+          where: eq(storePrices.id, unresolvedPrice!.id),
+        }),
+        db.query.storePriceMatchProposals.findFirst({
+          where: eq(storePriceMatchProposals.id, proposal!.id),
+        }),
+        db.query.storePriceMatchAttempts.findFirst({
+          where: eq(storePriceMatchAttempts.id, attempt!.id),
+        }),
+      ]);
+    expect(resolvedPrice?.bottleId).not.toBeNull();
+    expect(resolvedProposal).toMatchObject({
+      status: "approved",
+      currentBottleId: resolvedPrice!.bottleId,
+      suggestedBottleId: resolvedPrice!.bottleId,
+      error: null,
+      processingToken: null,
+      processingQueuedAt: null,
+      processingExpiresAt: null,
+    });
+    expect(resolvedAttempt).toMatchObject({
+      finalStatus: "approved",
+      currentBottleId: resolvedPrice!.bottleId,
+      suggestedBottleId: resolvedPrice!.bottleId,
+      error: null,
+    });
+    expect(workerClient.pushJob).not.toHaveBeenCalledWith(
+      "ResolveStorePriceBottle",
+      expect.anything(),
+    );
+    expect(workerClient.pushUniqueJob).not.toHaveBeenCalledWith(
+      "ResolveStorePriceBottle",
+      expect.anything(),
+    );
   });
 
   it("rejects invalid flat Bottle input before persistence", async () => {

--- a/apps/server/src/scraper/legacy/scraper.ts
+++ b/apps/server/src/scraper/legacy/scraper.ts
@@ -9,8 +9,14 @@ import {
   BottleAlreadyExistsError,
   createBottleAsPeated,
 } from "@peated/server/lib/createBottle";
-import { createStorePricesAsPeated } from "@peated/server/lib/createStorePrices";
-import { buildBottleCreateInput } from "@peated/server/lib/flatBottleInput";
+import {
+  createStorePriceForBottleAsPeated,
+  createStorePricesAsPeated,
+} from "@peated/server/lib/createStorePrices";
+import {
+  buildBottleCreateInput,
+  buildBottleSourceIdentity,
+} from "@peated/server/lib/flatBottleInput";
 import { formatBottleName } from "@peated/server/lib/format";
 import { logError, logInfo, logWarn } from "@peated/server/lib/log";
 import {
@@ -220,7 +226,21 @@ export async function persistBottleObservation(
   }
 
   if (price) {
-    await createStorePricesAsPeated({ site: "smws", prices: [price] });
+    const sourcePrice = {
+      ...price,
+      sourceBottleIdentity:
+        price.sourceBottleIdentity ?? buildBottleSourceIdentity(bottle),
+    };
+    if (resultBottle) {
+      await createStorePriceForBottleAsPeated({
+        bottleId: resultBottle.id,
+        createdBottle: isNew,
+        site: "smws",
+        price: sourcePrice,
+      });
+    } else {
+      await createStorePricesAsPeated({ site: "smws", prices: [sourcePrice] });
+    }
   }
 
   return {

--- a/docs/architecture/store-price-matching.md
+++ b/docs/architecture/store-price-matching.md
@@ -35,6 +35,12 @@ different store or product ID never inherits the assignment.
 Price ingestion builds the Bottle Reference key and reuses an assigned exact
 reference when one exists. Otherwise it queues `ResolveStorePriceBottle`.
 
+A trusted Bottle source may emit one parsed Bottle and its retailer listing
+together. After the source successfully creates or resolves that exact Bottle,
+price ingestion assigns the listing to the returned Bottle ID and records the
+source decision without running the classifier. If Bottle resolution is
+ambiguous or conflicts, the listing stays unresolved and uses the normal queue.
+
 A full run:
 
 1. Extracts Bottle facts from the title or image.
@@ -52,8 +58,10 @@ catalog correction stays `no_match`; a separate Bottle audit owns catalog
 changes. Deterministic code can reject an unsafe result but cannot promote a
 semantic result that the classifier did not make.
 
-SMWS parsing supplies an exact code as an identity anchor. The classifier still
-makes the Bottle decision.
+Generic SMWS reference parsing supplies an exact code as an identity anchor and
+still uses the classifier. The SMWS catalog importer instead uses the trusted
+Bottle-source path above because it already created or resolved the Bottle from
+the same structured source record.
 
 ## Proposal And Review
 


### PR DESCRIPTION
SMWS catalog ingestion now assigns a retailer listing directly to the active Bottle created or resolved from the same structured source record. The assignment and audit decision commit together, and any pending or errored classifier proposal—including an active retry lease—is finalized as approved so the listing no longer waits on model work.

The public price-ingestion contract remains unchanged and cannot select arbitrary Bottle IDs. If the catalog import encounters an ambiguous Bottle update or duplicate conflict, it keeps the listing unresolved and falls back to the existing classifier review queue.
