### PR TITLE
fix(scraper): restore SMWSA bottle ingestion

### DIFF
--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
@@ -339,6 +339,18 @@ test("enriches archive cards from the batch storefront API", async ({
                         value: "2020-10-02 08:00:00",
                       },
                     },
+                    {
+                      node: {
+                        name: "Initial Cask",
+                        value: "1st fill ex-bourbon barrel",
+                      },
+                    },
+                    {
+                      node: {
+                        name: "Cask Type",
+                        value: "2nd fill oloroso hogshead",
+                      },
+                    },
                     { node: { name: "Outturn", value: "607" } },
                     {
                       node: {
@@ -380,6 +392,8 @@ test("enriches archive cards from the batch storefront API", async ({
         caskNumber: "1.243",
         description: "A bright & sunny Society description.",
         flavorProfile: "sweet_fruit_mellow",
+        maturation:
+          "Initial cask: 1st fill ex-bourbon barrel; final cask: 2nd fill oloroso hogshead",
         outturn: 607,
         releaseMonth: 10,
         releaseDay: 2,
@@ -541,6 +555,36 @@ test("continues when optional fields are absent and recovers code from SKU", asy
   expect(items[2][0]).not.toHaveProperty("releaseYear");
   expect(items[2][0]).not.toHaveProperty("releaseMonth");
   expect(items[2][0]).not.toHaveProperty("releaseDay");
+});
+
+test("keeps the initial and final casks from the live feed", async ({
+  axiosMock,
+}) => {
+  const url = "https://smws.com/all-whisky?filter-page=1&per-page=128";
+  const payload = z
+    .object({
+      items: z.array(z.record(z.string(), z.unknown())),
+    })
+    .passthrough()
+    .parse(JSON.parse(await loadFixture("smws", "bottle-list.json")));
+  payload.items = [
+    {
+      ...payload.items[0],
+      initial_cask: "1st fill ex-bourbon barrel",
+      cask_type: "2nd fill oloroso hogshead",
+    },
+  ];
+  axiosMock.onGet(url).reply(200, payload);
+
+  const items: any[] = [];
+  await scrapeBottles(url, async (...item) => {
+    items.push(item);
+  });
+
+  expect(items[0]?.[0]).toMatchObject({
+    maturation:
+      "Initial cask: 1st fill ex-bourbon barrel; final cask: 2nd fill oloroso hogshead",
+  });
 });
 
 test("omits the release date when it conflicts with age and vintage", async ({

--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWS.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWS.ts
@@ -249,6 +249,17 @@ function isSingleCask(
   );
 }
 
+function formatMaturation(
+  initialCask: string | null | undefined,
+  finalCask: string | null | undefined,
+): string | null {
+  const initial = initialCask?.trim() || null;
+  const final = finalCask?.trim() || null;
+  if (!initial || initial === final) return final ?? initial;
+  if (!final) return initial;
+  return `Initial cask: ${initial}; final cask: ${final}`;
+}
+
 type ArchiveBottle = {
   bottle: z.input<typeof BottleInputSchema>;
   imageUrl: string | null;
@@ -495,8 +506,10 @@ function mergeArchiveDetails(
       releaseYear: release?.releaseYear ?? null,
       releaseMonth: release?.releaseMonth ?? null,
       releaseDay: release?.releaseDay ?? null,
-      maturation:
-        archived.bottle.maturation ?? customFields.get("cask type") ?? null,
+      maturation: formatMaturation(
+        customFields.get("initial cask"),
+        archived.bottle.maturation ?? customFields.get("cask type"),
+      ),
       outturn: parsePositiveInteger(
         customFields.get("outturn") ??
           customFields.get("bottles produced") ??
@@ -633,6 +646,7 @@ const SMWSPayloadSchema = z.object({
       abv: z.union([z.string(), z.number()]).nullish(),
       cask_no: z.string().nullish(),
       cask_type: z.string().nullish(),
+      initial_cask: z.string().nullish(),
       region: z.string().nullish(),
       spirit_type: z.string().nullish(),
       distilleddate: z.string().nullish(),
@@ -708,6 +722,7 @@ export async function scrapeBottles(
           });
         }
 
+        const maturation = formatMaturation(item.initial_cask, item.cask_type);
         const bottle: z.input<typeof BottleInputSchema> = {
           name,
           vintageYear,
@@ -721,13 +736,9 @@ export async function scrapeBottles(
             name: "The Scotch Malt Whisky Society",
           },
           distillers: distiller ? [{ name: distiller }] : [],
-          maturation: item.cask_type?.trim() || null,
+          maturation,
           caskNumber,
-          singleCask: isSingleCask(
-            caskNumber,
-            category,
-            item.cask_type?.trim() || null,
-          ),
+          singleCask: isSingleCask(caskNumber, category, maturation),
           description: item.list_description?.trim() || null,
         };
         if (edition) bottle.edition = edition;

--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWSA.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWSA.test.ts
@@ -81,3 +81,55 @@ test("bottle list", async ({ axiosMock }) => {
     ]
   `);
 });
+
+test("parses the current product-card markup", async ({ axiosMock }) => {
+  const url = "https://newmake.smwsa.com/collections/all-products";
+  axiosMock.onGet(url).reply(
+    200,
+    `
+      <div data-product-tile>
+        <a href="/products/cask-no-41-176"
+          data-ecommerce-action="select-product"
+          data-product-name="Baristaliscious"
+          data-product-price="185.00"
+          data-product-product-id="7609520586823"
+          data-product-image="https://images.example/41.176.png">
+          <img src="https://images.example/41.176.png">
+        </a>
+        <div>
+          <h3>Cask No. 41.176</h3>
+          <h1>Baristaliscious</h1>
+          <ul>
+            <li><div>Age:</div><div>Vintage 1989</div></li>
+            <li><div>Region:</div><div>Speyside</div></li>
+            <li><div>Cask:</div><div>First-fill Chinkapin oak barrel</div></li>
+            <li><div>ABV:</div><div>58.8%</div></li>
+          </ul>
+        </div>
+      </div>
+    `,
+  );
+
+  const items: any[] = [];
+  await scrapeBottles(url, async (...item) => {
+    items.push(item);
+  });
+
+  expect(items).toEqual([
+    [
+      expect.objectContaining({
+        name: "41.176 Baristaliscious",
+        vintageYear: 1989,
+        statedAge: null,
+        abv: 58.8,
+        maturation: "First-fill Chinkapin oak barrel",
+      }),
+      expect.objectContaining({
+        externalProductId: "7609520586823",
+        price: 18_500,
+        url: "https://newmake.smwsa.com/products/cask-no-41-176",
+      }),
+      "https://images.example/41.176.png",
+    ],
+  ]);
+});

--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWSA.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWSA.ts
@@ -12,10 +12,30 @@ import { logScrapeWarning } from "./scrapeLogging";
 
 const SITE = "smwsa";
 
+function parseAbv(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const abv = Number.parseFloat(value.replace("%", "").trim());
+  return Number.isFinite(abv) && abv >= 0 && abv <= 100 ? abv : null;
+}
+
+function parseAge(value: string | null | undefined) {
+  const normalized = value?.trim() ?? "";
+  const vintageMatch = /^Vintage\s+(?<year>\d{4})$/iu.exec(normalized);
+  if (vintageMatch?.groups) {
+    return { statedAge: null, vintageYear: Number(vintageMatch.groups.year) };
+  }
+  const ageMatch = /^(?<age>\d+)\s+years?$/iu.exec(normalized);
+  return {
+    statedAge: ageMatch?.groups ? Number(ageMatch.groups.age) : null,
+    vintageYear: null,
+  };
+}
+
 export default async function scrapeSMWSA() {
   return scrapeBottles(
     `https://newmake.smwsa.com/collections/all-products`,
-    handleBottle,
+    async (bottle, price, imageUrl) =>
+      await handleBottle(bottle, price, imageUrl, { site: SITE }),
   );
 }
 
@@ -26,68 +46,83 @@ export async function scrapeBottles(
     price?: z.input<typeof StorePriceInputSchema> | null,
     imageUrl?: string | null,
   ) => Promise<void>,
+  request: (url: string) => Promise<string> = getUrl,
 ) {
-  const data = await getUrl(url);
+  const data = await request(url);
   const $ = cheerio(data);
   let itemCount = 0;
 
-  for (const el of $(".product-collection-module__grid-item")) {
-    const itemType = $(".product-collection-module__type", el)
-      .first()
-      .text()
-      .trim();
+  for (const el of $(
+    ".product-collection-module__grid-item, [data-product-tile]",
+  )) {
+    const card = $(el);
+    const productLink = card
+      .find('[data-ecommerce-action="select-product"]')
+      .first();
+    const itemType =
+      $(".product-collection-module__type", el).first().text().trim() ||
+      card.find("h3").first().text().trim();
     if (!itemType || !itemType.startsWith("Cask No.")) {
       continue;
     }
 
-    const caskName = $(".product-collection-module__title", el)
-      .first()
-      .text()
-      .trim();
+    const caskName =
+      $(".product-collection-module__title", el).first().text().trim() ||
+      productLink.attr("data-product-name")?.trim() ||
+      card.find("h1").first().text().trim();
 
     const specList: [string, string][] = [];
-    $(".product-collection-module__specs-list li", el).each((_, specEl) => {
-      const name = $(
-        ".product-collection-module__specs-item-col--title",
-        specEl,
-      )
-        .first()
-        .text()
-        .trim();
-      const value = $(
-        ".product-collection-module__specs-item-col--desc",
-        specEl,
-      )
-        .first()
-        .text()
-        .trim();
+    const legacySpecs = $(".product-collection-module__specs-list li", el);
+    const specs = legacySpecs.length
+      ? legacySpecs
+      : card.find("ul").first().find("li");
+    specs.each((_, specEl) => {
+      const columns = $(specEl).children("div");
+      const name =
+        $(".product-collection-module__specs-item-col--title", specEl)
+          .first()
+          .text()
+          .trim() || columns.first().text().trim();
+      const value =
+        $(".product-collection-module__specs-item-col--desc", specEl)
+          .first()
+          .text()
+          .trim() || columns.eq(1).text().trim();
       specList.push([name, value]);
     });
 
-    const rawPrice = $(".product-collection-module__price", el)
-      .first()
-      .text()
-      .trim();
+    const rawPrice =
+      $(".product-collection-module__price", el).first().text().trim() ||
+      productLink.attr("data-product-price")?.trim();
+    const parsedPrice = rawPrice
+      ? Number(rawPrice.replace(/^\$/u, "").replaceAll(",", ""))
+      : Number.NaN;
     const price =
-      rawPrice && rawPrice.startsWith("$")
-        ? Math.floor(Number(rawPrice.substring(1)) * 100)
+      Number.isFinite(parsedPrice) && parsedPrice > 0
+        ? Math.round(parsedPrice * 100)
         : null;
 
-    const url = $("a.product-collection-module__grid-item-gallery", el)
-      .first()
-      .attr("href");
-    if (!url) {
+    const rawUrl =
+      $("a.product-collection-module__grid-item-gallery", el)
+        .first()
+        .attr("href") ||
+      productLink.attr("data-product-url") ||
+      productLink.attr("href");
+    if (!rawUrl) {
       logScrapeWarning(SITE, "Cannot find product URL", {
         caskName,
       });
       continue;
     }
+    const url = new URL(rawUrl, "https://newmake.smwsa.com").toString();
 
     const ageSpec = specList.find(([name]) => name === "Age:");
-    let statedAge = ageSpec ? Number(ageSpec[1].split(" ")[0]) : null;
+    let { statedAge, vintageYear } = parseAge(ageSpec?.[1]);
 
     const caskSpec = specList.find(([name]) => name === "Cask:");
     const maturation = caskSpec?.[1] || null;
+    const abvSpec = specList.find(([name]) => name === "ABV:");
+    const abv = parseAbv(abvSpec?.[1]);
     const caskNumber = itemType.replace(/^Cask No\.\s*/i, "").trim();
 
     const details = parseDetailsFromName(`${itemType} ${caskName}`);
@@ -107,47 +142,53 @@ export async function scrapeBottles(
     }
 
     let name = details.name;
-    let vintageYear;
-
     ({ name, statedAge, vintageYear } = normalizeBottleInput({
       name,
       statedAge,
+      vintageYear,
       isFullName: false,
     }));
 
     const imageUrl =
       $("img.product-collection-module__grid-item-image", el)
         .first()
-        .attr("src") ?? null;
+        .attr("src") ??
+      productLink.attr("data-product-image") ??
+      productLink.find("img").first().attr("src") ??
+      null;
 
-    await cb(
-      {
-        name,
-        vintageYear,
-        category: details.category,
-        statedAge,
-        brand: {
-          name: "The Scotch Malt Whisky Society",
-        },
-        bottler: {
-          name: "The Scotch Malt Whisky Society",
-        },
-        distillers: [{ name: details.distiller }],
-        maturation,
-        caskNumber,
-        singleCask: true,
+    const bottle: z.input<typeof BottleInputSchema> = {
+      name,
+      vintageYear,
+      category: details.category,
+      statedAge,
+      brand: {
+        name: "The Scotch Malt Whisky Society",
       },
-      price
-        ? {
-            name: `SMWS ${details.name}`,
-            price,
-            volume: 750,
-            currency: "usd",
-            url,
-          }
-        : null,
-      imageUrl,
-    );
+      bottler: {
+        name: "The Scotch Malt Whisky Society",
+      },
+      distillers: [{ name: details.distiller }],
+      maturation,
+      caskNumber,
+      singleCask: true,
+    };
+    if (abv !== null) bottle.abv = abv;
+
+    let storePrice: z.input<typeof StorePriceInputSchema> | null = null;
+    if (price !== null) {
+      storePrice = {
+        name: `SMWS ${details.name}`,
+        price,
+        volume: 750,
+        currency: "usd",
+        url,
+      };
+      const externalProductId = productLink.attr("data-product-product-id");
+      if (externalProductId) storePrice.externalProductId = externalProductId;
+    }
+
+    await cb(bottle, storePrice, imageUrl);
     itemCount += 1;
   }
   return itemCount;

--- a/apps/server/src/scraper/legacy/scraper.test.ts
+++ b/apps/server/src/scraper/legacy/scraper.test.ts
@@ -16,6 +16,7 @@ import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import scrapePrices, {
   handleBottle,
+  persistBottleObservation,
   type ScrapePricesCallback,
   type StorePrice,
 } from "./scraper";
@@ -27,6 +28,9 @@ describe("handleBottle", () => {
     statedAge: 12,
     edition: "Batch 3",
     abv: 57.2,
+    releaseYear: 2024,
+    releaseMonth: 10,
+    releaseDay: 2,
     singleCask: true,
     category: "single_malt" as const,
   };
@@ -71,6 +75,9 @@ describe("handleBottle", () => {
       createdByActorId: systemActor.id,
       edition: bottleInput.edition,
       statedAge: bottleInput.statedAge,
+      releaseYear: bottleInput.releaseYear,
+      releaseMonth: bottleInput.releaseMonth,
+      releaseDay: bottleInput.releaseDay,
     });
     const price = await db.query.storePrices.findFirst({
       where: and(
@@ -84,6 +91,9 @@ describe("handleBottle", () => {
       sourceBottleIdentity: expect.objectContaining({
         expression: bottleInput.name,
         edition: bottleInput.edition,
+        release_year: bottleInput.releaseYear,
+        release_month: bottleInput.releaseMonth,
+        release_day: bottleInput.releaseDay,
       }),
     });
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalledWith(
@@ -105,6 +115,31 @@ describe("handleBottle", () => {
         matchingBasis: "source_bottle",
         resolutionSource: "trusted_scraper",
       },
+    });
+  });
+
+  it("saves a Bottle listing under its source site", async ({ fixtures }) => {
+    const site = await fixtures.ExternalSiteOrExisting({ type: "smwsa" });
+
+    await persistBottleObservation(
+      bottleInput,
+      {
+        ...priceInput,
+        currency: "usd",
+        volume: 750,
+      },
+      null,
+      { site: "smwsa" },
+    );
+
+    expect(
+      await db.query.storePrices.findFirst({
+        where: eq(storePrices.externalSiteId, site.id),
+      }),
+    ).toMatchObject({
+      bottleId: expect.any(Number),
+      currency: "usd",
+      volume: 750,
     });
   });
 

--- a/apps/server/src/scraper/legacy/scraper.ts
+++ b/apps/server/src/scraper/legacy/scraper.ts
@@ -142,7 +142,10 @@ export async function handleBottle(
   bottle: z.input<typeof BottleInputSchema>,
   price?: z.input<typeof StorePriceInputSchema> | null,
   imageUrl?: string | null,
-  { dryRun = false }: { dryRun?: boolean } = {},
+  {
+    dryRun = false,
+    site = "smws",
+  }: { dryRun?: boolean; site?: ExternalSiteKey } = {},
 ) {
   if (
     !dryRun &&
@@ -150,14 +153,17 @@ export async function handleBottle(
   ) {
     return;
   }
-  await persistBottleObservation(bottle, price, imageUrl, { dryRun });
+  await persistBottleObservation(bottle, price, imageUrl, { dryRun, site });
 }
 
 export async function persistBottleObservation(
   bottle: z.input<typeof BottleInputSchema>,
   price?: z.input<typeof StorePriceInputSchema> | null,
   imageUrl?: string | null,
-  { dryRun = false }: { dryRun?: boolean } = {},
+  {
+    dryRun = false,
+    site = "smws",
+  }: { dryRun?: boolean; site?: ExternalSiteKey } = {},
 ) {
   if (dryRun) {
     logInfo("Dry run bottle {bottleName}", {
@@ -235,11 +241,11 @@ export async function persistBottleObservation(
       await createStorePriceForBottleAsPeated({
         bottleId: resultBottle.id,
         createdBottle: isNew,
-        site: "smws",
+        site,
         price: sourcePrice,
       });
     } else {
-      await createStorePricesAsPeated({ site: "smws", prices: [sourcePrice] });
+      await createStorePricesAsPeated({ site, prices: [sourcePrice] });
     }
   }
 

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -50,7 +50,7 @@ import {
   defineScrapeTarget,
 } from "./definitions";
 import { loadSingleCaskNationReleases } from "./singleCaskNationReleases";
-import { bottleObservationSink } from "./sinks/bottles";
+import { createBottleObservationSink } from "./sinks/bottles";
 import { externalReviewSink } from "./sinks/externalReviews";
 import { createStorePriceSink } from "./sinks/storePrices";
 
@@ -396,7 +396,7 @@ export const scraperRegistry = createScraperRegistry({
         cursorSchema: z.null(),
         observationSchema: LegacyBottleObservationSchema,
         adapter: createLegacyBottleAdapter(source.type, source.scrape),
-        sink: bottleObservationSink,
+        sink: createBottleObservationSink(source.type),
       }),
     ),
     // TODO(scraper-source-migration): Remove each remaining HTML review

--- a/apps/server/src/scraper/sinks/bottles.ts
+++ b/apps/server/src/scraper/sinks/bottles.ts
@@ -1,13 +1,17 @@
+import type { ExternalSiteKey } from "@peated/server/types";
 import type { LegacyBottleObservation } from "../adapters/legacyBottle";
 import { persistBottleObservation } from "../legacy/scraper";
 import type { ScraperSink } from "../types";
 
-export const bottleObservationSink: ScraperSink<
-  LegacyBottleObservation
-> = async ({ observation }) => {
-  return await persistBottleObservation(
-    observation.value.bottle,
-    observation.value.price,
-    observation.value.imageUrl,
-  );
-};
+export function createBottleObservationSink(
+  site: ExternalSiteKey,
+): ScraperSink<LegacyBottleObservation> {
+  return async ({ observation }) => {
+    return await persistBottleObservation(
+      observation.value.bottle,
+      observation.value.price,
+      observation.value.imageUrl,
+      { site },
+    );
+  };
+}

--- a/docs/architecture/store-price-matching.md
+++ b/docs/architecture/store-price-matching.md
@@ -40,6 +40,10 @@ together. After the source successfully creates or resolves that exact Bottle,
 price ingestion assigns the listing to the returned Bottle ID and records the
 source decision without running the classifier. If Bottle resolution is
 ambiguous or conflicts, the listing stays unresolved and uses the normal queue.
+Only a registered source-specific Bottle sink may use this path. A generic
+configured price source cannot choose a Bottle ID. An SMWS extractor may change
+how it reads JSON or HTML, but it must keep the SMWS Bottle sink as the trusted
+create-and-assign boundary.
 
 A full run:
 
@@ -59,9 +63,9 @@ changes. Deterministic code can reject an unsafe result but cannot promote a
 semantic result that the classifier did not make.
 
 Generic SMWS reference parsing supplies an exact code as an identity anchor and
-still uses the classifier. The SMWS catalog importer instead uses the trusted
-Bottle-source path above because it already created or resolved the Bottle from
-the same structured source record.
+still uses the classifier. The SMWS catalog importers instead use the trusted
+Bottle-source path above because they already created or resolved the Bottle
+from the same structured source record.
 
 ## Proposal And Review
 


### PR DESCRIPTION
SMWSA Bottle collection works with the site’s current product-card markup and now retains ABV, vintage-only dates, stable product IDs, images, and prices. Its listings are saved under the `smwsa` source instead of being mixed into the UK `smws` store. The parser still accepts the prior markup while the source transitions.

The UK JSON and archive paths continue to preserve exact release dates and now retain separate initial and final cask descriptions when SMWS supplies both. Release dates also remain part of the trusted source identity introduced in #1276.

SMWSA stays behind its registered Bottle sink rather than moving to a generic configured price source. That keeps deterministic Society-code resolution and Bottle creation source-scoped; generic price sources still cannot choose a Bottle ID.
