### PR TITLE
fix(scraper): allow SMWS America storefront redirects

### DIFF
--- a/apps/server/src/lib/test/fixtures.ts
+++ b/apps/server/src/lib/test/fixtures.ts
@@ -353,7 +353,7 @@ export const Entity = async (
 ): Promise<dbSchema.Entity> => {
   const name =
     data.name ||
-    `${faker.word.adjective().toLowerCase()} ${choose(distilleryNames)}`;
+    `${faker.word.adjective().toLowerCase()} ${choose(distilleryNames)} ${faker.string.uuid()}`;
 
   return await db.transaction(async (tx) => {
     const createdByActorId =

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -83,6 +83,9 @@ test("registers each built-in scraper source with its target", () => {
     "content-type",
   ]);
   expectHourlyLimit("smws", 80);
+  expect(
+    scraperRegistry.targets.get("smwsa")?.origins.map(({ origin }) => origin),
+  ).toEqual(["https://newmake.smwsa.com", "https://smwsa.com"]);
   expect(EXTERNAL_SITE_DEFINITIONS.bourbonculture.initialRunEvery).toBe(1440);
   expectHourlyLimit("bourbonculture", 10);
   expect(scraperRegistry.targets.get("bruichladdich")).toBeDefined();

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -153,6 +153,8 @@ const legacyBottleSources = [
         origin: "https://newmake.smwsa.com",
         robots: { mode: "enforce" },
       },
+      // SMWS America redirects its original storefront and robots.txt here.
+      { origin: "https://smwsa.com", robots: { mode: "enforce" } },
     ],
     scrape: scrapeSMWSA,
   },

--- a/apps/server/src/scraper/robots.test.ts
+++ b/apps/server/src/scraper/robots.test.ts
@@ -262,6 +262,33 @@ test("does not report a disabled target as unavailable robots", async () => {
   expect(fetchImpl).not.toHaveBeenCalled();
 });
 
+test("reports an undeclared robots redirect instead of retrying it as unavailable", async () => {
+  const { registry, run } = await setupRobotsRuntime();
+  const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+    new Response(null, {
+      status: 301,
+      headers: { location: "https://store.example.com/robots.txt" },
+    }),
+  );
+
+  await expect(
+    ensureRobotsAllowed({
+      runId: run.id,
+      sourceKey: "finedrams",
+      targetKey: "operator",
+      url: new URL("https://example.com/catalog"),
+      registry,
+      fetchImpl,
+      clock: fixedClock(),
+    }),
+  ).rejects.toThrow(
+    "Origin https://store.example.com is not declared for scraper target operator.",
+  );
+  expect(fetchImpl).toHaveBeenCalledTimes(1);
+  const [origin] = await db.select().from(scrapeOrigins);
+  expect(origin?.robotsState).toBeNull();
+});
+
 test("refreshes expired rules and persists parsed rules rather than content", async () => {
   const { registry, run } = await setupRobotsRuntime();
   await db

--- a/apps/server/src/scraper/robots.ts
+++ b/apps/server/src/scraper/robots.ts
@@ -218,18 +218,17 @@ export async function ensureRobotsAllowed({
         const missing = { status: "missing" } as const;
         await writeRobotsCache(url.origin, missing, now);
         state = CachedRobotsRulesSchema.safeParse(missing);
-      } else if (error instanceof ScraperRequestWaitError) {
-        throw error;
       } else if (
-        error instanceof ScraperRequestError &&
-        error.category === "invalid_request"
+        error instanceof ScraperHttpStatusError ||
+        (error instanceof ScraperRequestError &&
+          (error.category === "timeout" || error.category === "transport"))
       ) {
-        throw error;
-      } else {
         throw new ScraperRequestWaitError(
           "robots_unavailable",
           new Date(now.getTime() + ROBOTS_UNAVAILABLE_RETRY_MS),
         );
+      } else {
+        throw error;
       }
     }
   }


### PR DESCRIPTION
SMWS America collection now follows the storefront and robots.txt redirects from `newmake.smwsa.com` to `smwsa.com`. The missing allowed origin previously stopped every run before it saved a record, then exhausted ten retries because the robots check treated the configuration error as temporary.

Declare the new host with robots enforcement and let unexpected robots-check errors reach the normal error handler. HTTP failures, timeouts, and transport failures retain their existing wait behavior. Regression coverage checks the allowed hosts and verifies that an undeclared redirect fails immediately.

Validated with 50 focused scraper tests, server typecheck, lint, and formatting. A live SMWS America collection passed with normal robots checks and request spacing, capturing parsed records in memory without production writes.

Generated Entity fixture names also include a UUID to prevent random uniqueness collisions when tests create several Bottles. The fixture tests and user flavor-list tests pass locally.
